### PR TITLE
[COMRPCREFACTOR] As a left over from the COMRPC refactor it was obser…

### DIFF
--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -71,7 +71,10 @@ namespace ProxyStub {
                 void* newInterface = implementation->QueryInterface(newInterfaceId);
                 response.Number<void*>(newInterface);
 
-                RPC::Administrator::Instance().RegisterInterface(channel, newInterface, newInterfaceId);
+                if (newInterface != nullptr) {
+                    RPC::Administrator::Instance().RegisterInterface(channel, newInterface, newInterfaceId);
+                }
+
                 break;
             }
             default: {


### PR DESCRIPTION
…ved that

                 some customers had a crash on nullptr access in case the
                 Query interface returned nullptr (Interface not suppored) not
                 an error, but in case of the cleanup, this caused a nullptr
                 access. This fix prevents nullptrs to be inserted.