### PR TITLE
Use NEXUS::NEXUS target instead of hardcoded library

### DIFF
--- a/Source/ocdm/CMakeLists.txt
+++ b/Source/ocdm/CMakeLists.txt
@@ -88,13 +88,8 @@ if (${CDMI_ADAPTER_IMPLEMENTATION} STREQUAL "broadcom-svp")
 
     target_link_libraries(${TARGET}
             PRIVATE
-            -lnexus
+            NEXUS::NEXUS
             -lbrcmsvpmeta
-            )
-
-    target_include_directories( ${TARGET}
-            PRIVATE
-            ${LIBNEXUS_INCLUDE}
             )
 endif()
 


### PR DESCRIPTION
This fixes the error from nexus if the refsw is built with client mode