### PR TITLE
Increased RPC communication timeout to 20 secs

### DIFF
--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -36,7 +36,7 @@ namespace RPC {
 #ifdef __DEBUG__
     enum { CommunicationTimeOut = Core::infinite }; // Time in ms. Forever
 #else
-    enum { CommunicationTimeOut = 10000 }; // Time in ms. 10 Seconden
+    enum { CommunicationTimeOut = 20000 }; // Time in ms. 20 Seconden
 #endif
     enum { CommunicationBufferSize = 8120 }; // 8K :-)
 


### PR DESCRIPTION
We have observed that in some cases DRM initialization takes longer than 10 seconds causing OpenCDM update() to fail with a timeout. Increasing the timeout to 20 seconds reduces the frequency of these errors.
Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>