### PR TITLE
added playbackStopped method in opencdm interface

### DIFF
--- a/Source/interfaces/IDRM.h
+++ b/Source/interfaces/IDRM.h
@@ -289,6 +289,8 @@ public:
         const uint32_t f_cbClearContentOpaque,
         uint8_t* f_pbClearContentOpaque)
         = 0;
+
+    virtual CDMi_RESULT PlaybackStopped() = 0;
 };
 
 // IMediaKeySession defines the MediaKeySession interface.

--- a/Source/interfaces/IDRM.h
+++ b/Source/interfaces/IDRM.h
@@ -290,7 +290,7 @@ public:
         uint8_t* f_pbClearContentOpaque)
         = 0;
 
-    virtual CDMi_RESULT PlaybackStopped() = 0;
+    virtual CDMi_RESULT ResetOutputProtection() {return CDMi_SUCCESS;}
 };
 
 // IMediaKeySession defines the MediaKeySession interface.

--- a/Source/ocdm/IOCDM.h
+++ b/Source/ocdm/IOCDM.h
@@ -111,7 +111,7 @@ struct ISession : virtual public WPEFramework::Core::IUnknown {
     virtual void Close() = 0;
 
     // Let the CDM know playback has stopped in order to disable output protection
-    virtual void PlaybackStopped() = 0;
+    virtual void ResetOutputProtection() = 0;
 
     // During instantiation a callback is set, here we can decouple.
     virtual void Revoke(OCDM::ISession::ICallback* callback) = 0;

--- a/Source/ocdm/IOCDM.h
+++ b/Source/ocdm/IOCDM.h
@@ -110,6 +110,9 @@ struct ISession : virtual public WPEFramework::Core::IUnknown {
     // We are completely done with the session, it can be closed.
     virtual void Close() = 0;
 
+    // Let the CDM know playback has stopped in order to disable output protection
+    virtual void PlaybackStopped() = 0;
+
     // During instantiation a callback is set, here we can decouple.
     virtual void Revoke(OCDM::ISession::ICallback* callback) = 0;
 };

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -411,16 +411,16 @@ OpenCDMError opencdm_session_remove(struct OpenCDMSession* session)
 }
 
 /**
- * Let CDM know playback stopped
+ * Let CDM know playback stopped and reset output protection
  * \param session \ref OpenCDMSession instance.
  * \return Zero on success, non-zero on error.
  */
-OpenCDMError opencdm_session_playbackstopped(struct OpenCDMSession* session)
+OpenCDMError opencdm_session_resetoutputprotection(struct OpenCDMSession* session)
 {
     OpenCDMError result(ERROR_INVALID_SESSION);
 
     if (session != nullptr) {
-        session->PlaybackStopped();
+        session->ResetOutputProtection();
         result = OpenCDMError::ERROR_NONE;
     }
 

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -411,6 +411,23 @@ OpenCDMError opencdm_session_remove(struct OpenCDMSession* session)
 }
 
 /**
+ * Let CDM know playback stopped
+ * \param session \ref OpenCDMSession instance.
+ * \return Zero on success, non-zero on error.
+ */
+OpenCDMError opencdm_session_playbackstopped(struct OpenCDMSession* session)
+{
+    OpenCDMError result(ERROR_INVALID_SESSION);
+
+    if (session != nullptr) {
+        session->PlaybackStopped();
+        result = OpenCDMError::ERROR_NONE;
+    }
+
+    return (result);
+}
+
+/**
  * Closes a session.
  * \param session \ref OpenCDMSession instance.
  * \return zero on success, non-zero on error.

--- a/Source/ocdm/open_cdm.h
+++ b/Source/ocdm/open_cdm.h
@@ -390,11 +390,11 @@ EXTERNAL OpenCDMError opencdm_session_metadata(const struct OpenCDMSession* sess
     uint16_t* metadataSize);
 
 /**
- * Let CDM know playback stopped
+ * Let CDM know playback stopped and reset output protection
  * \param session \ref OpenCDMSession instance.
  * \return Zero on success, non-zero on error.
  */
-OpenCDMError opencdm_session_playbackstopped(struct OpenCDMSession* session);
+OpenCDMError opencdm_session_resetoutputprotection(struct OpenCDMSession* session);
 
 /**
  * Gets Session ID for a session.

--- a/Source/ocdm/open_cdm.h
+++ b/Source/ocdm/open_cdm.h
@@ -390,6 +390,13 @@ EXTERNAL OpenCDMError opencdm_session_metadata(const struct OpenCDMSession* sess
     uint16_t* metadataSize);
 
 /**
+ * Let CDM know playback stopped
+ * \param session \ref OpenCDMSession instance.
+ * \return Zero on success, non-zero on error.
+ */
+OpenCDMError opencdm_session_playbackstopped(struct OpenCDMSession* session);
+
+/**
  * Gets Session ID for a session.
  * \param session \ref OpenCDMSession instance.
  * \return Session ID, valid as long as \ref session is valid.

--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -579,6 +579,11 @@ public:
 
         _session->Close();
     }
+    inline void PlaybackStopped() {
+        ASSERT (_session != nullptr);
+
+        _session->PlaybackStopped();
+    }
     inline int Remove()
     {
 

--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -579,10 +579,10 @@ public:
 
         _session->Close();
     }
-    inline void PlaybackStopped() {
+    inline void ResetOutputProtection() {
         ASSERT (_session != nullptr);
 
-        _session->PlaybackStopped();
+        _session->ResetOutputProtection();
     }
     inline int Remove()
     {


### PR DESCRIPTION
We need to know when playback has stopped but CDM session is still active. Some apps keep the CDM session alive even when it's no longer active. 

This is useful when we are enforcing HDCP 2.2 requirement for example.

Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>