### PR TITLE
added HWError and OutputRestrictedHDCP22key status types

### DIFF
--- a/Source/ocdm/IOCDM.h
+++ b/Source/ocdm/IOCDM.h
@@ -48,9 +48,11 @@ struct ISession : virtual public WPEFramework::Core::IUnknown {
         Expired,
         Released,
         OutputRestricted,
+        OutputRestrictedHDCP22,
         OutputDownscaled,
         StatusPending,
-        InternalError
+        InternalError,
+        HWError
     };
 
     // ICallback defines the callback interface to receive

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -83,6 +83,14 @@ KeyStatus CDMState(const OCDM::ISession::KeyStatus state)
         return KeyStatus::Released;
     case OCDM::ISession::Expired:
         return KeyStatus::Expired;
+    case OCDM::ISession::OutputRestricted:
+        return KeyStatus::OutputRestricted;
+    case OCDM::ISession::OutputRestrictedHDCP22:
+        return KeyStatus::OutputRestrictedHDCP22;
+    case OCDM::ISession::OutputDownscaled:
+        return KeyStatus::OutputDownscaled;
+    case OCDM::ISession::HWError:
+        return KeyStatus::HWError;
     default:
         assert(false);
     }

--- a/Source/ocdm/open_cdm.h
+++ b/Source/ocdm/open_cdm.h
@@ -81,9 +81,11 @@ typedef enum {
     Expired,
     Released,
     OutputRestricted,
+    OutputRestrictedHDCP22,
     OutputDownscaled,
     StatusPending,
-    InternalError
+    InternalError,
+    HWError
 } KeyStatus;
 
 #ifdef _MSVC_LANG


### PR DESCRIPTION
Added HWError and OutputRestrictedHDCP22 key statuses to handle certain error cases from OCDM.

Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>