### PR TITLE
[CORE] Fixes a few issues found with Unit Tests + valgrind:

### DIFF
--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -34,6 +34,13 @@ namespace RPC {
 
     /* virtual */ Administrator::~Administrator()
     {
+        for (std::pair<uint32_t, IMetadata*> proxy : _proxy) {
+            delete proxy.second;
+        }
+
+        for (std::pair<uint32_t, ProxyStub::UnknownStub*> stub : _stubs) {
+            delete stub.second;
+        }
     }
 
     /* static */ Administrator& Administrator::Instance()

--- a/Source/core/DataElement.cpp
+++ b/Source/core/DataElement.cpp
@@ -103,7 +103,7 @@ namespace Core {
             uint32_t bytesToRead = static_cast<uint32_t>(Size() - offset);
 
             // read as musch as we can from this buffer, move on to the next
-            ::memcpy(buffer, &(Buffer()[offset]), bytesToRead);
+            ::memmove(buffer, &(Buffer()[offset]), bytesToRead);
 
             ASSERT(m_Next != nullptr);
 
@@ -125,7 +125,7 @@ namespace Core {
             uint32_t bytesToWrite = static_cast<uint32_t>(Size() - offset);
 
             // read as musch as we can from this buffer, move on to the next
-            ::memcpy(&(Buffer()[offset]), buffer, bytesToWrite);
+            ::memmove(&(Buffer()[offset]), buffer, bytesToWrite);
 
             ASSERT(m_Next != nullptr);
 
@@ -152,7 +152,7 @@ namespace Core {
                 destinationOffset = 0;
             } else {
                 // The source is the limiting factor, fill the source up..
-                ::memcpy(&(destination->Buffer()[destinationOffset]), &(source->Buffer()[sourceOffset]), static_cast<uint32_t>(source->Size() - sourceOffset));
+                ::memmove(&(destination->Buffer()[destinationOffset]), &(source->Buffer()[sourceOffset]), static_cast<uint32_t>(source->Size() - sourceOffset));
 
                 destinationOffset += (source->Size() - sourceOffset);
                 copiedSize += (source->Size() - sourceOffset);

--- a/Source/core/DataElement.h
+++ b/Source/core/DataElement.h
@@ -343,7 +343,7 @@ namespace Core {
                     copied = true;
                 }
             } else {
-                ::memcpy(&(m_Buffer[offset]), RHS.m_Buffer, static_cast<size_t>(RHS.m_Size));
+                ::memmove(&(m_Buffer[offset]), RHS.m_Buffer, static_cast<size_t>(RHS.m_Size));
 
                 if (m_Size < (offset + RHS.m_Size)) {
                     m_Size = offset + RHS.m_Size;

--- a/Source/core/ProcessInfo.cpp
+++ b/Source/core/ProcessInfo.cpp
@@ -132,9 +132,10 @@ namespace Core {
                 if ('\0' == endptr[0]) {
                     // We have a valid PID, Find, the parent of this process..
                     TCHAR buffer[512];
+                    memset(buffer, 0, sizeof(buffer));
                     int fd;
 
-                    snprintf(buffer, sizeof(buffer), "/proc/%d/stat", pid);
+                    snprintf(buffer, sizeof(buffer) - sizeof(buffer[0]), "/proc/%d/stat", pid);
                     if ((fd = open(buffer, O_RDONLY)) > 0) {
                         if (read(fd, buffer, sizeof(buffer)) > 0) {
                             int ppid = 0;
@@ -315,7 +316,10 @@ namespace Core {
 
         snprintf(buffer, sizeof(buffer), "/proc/%d/statm", _pid);
         if ((fd = open(buffer, O_RDONLY)) > 0) {
-            if (read(fd, buffer, sizeof(buffer)) > 0) {
+            ssize_t readAmount = 0;
+            if ((readAmount = read(fd, buffer, sizeof(buffer))) > 0) {
+                ssize_t nulIndex = std::min(readAmount, static_cast<ssize_t>(sizeof(buffer) - 1));
+                buffer[nulIndex] = '\0';
                 sscanf(buffer, "%d", &VmSize);
                 result = VmSize * PageSize;
             }
@@ -343,7 +347,10 @@ namespace Core {
 
         snprintf(buffer, sizeof(buffer), "/proc/%d/statm", _pid);
         if ((fd = open(buffer, O_RDONLY)) > 0) {
-            if (read(fd, buffer, sizeof(buffer)) > 0) {
+            ssize_t readAmount = 0;
+            if ((readAmount = read(fd, buffer, sizeof(buffer))) > 0) {
+                ssize_t nulIndex = std::min(readAmount, static_cast<ssize_t>(sizeof(buffer) - 1));
+                buffer[nulIndex] = '\0';
                 sscanf(buffer, "%*d %d", &VmRSS);
                 result = VmRSS * PageSize;
             }
@@ -371,7 +378,10 @@ namespace Core {
 
         snprintf(buffer, sizeof(buffer), "/proc/%d/statm", _pid);
         if ((fd = open(buffer, O_RDONLY)) > 0) {
-            if (read(fd, buffer, sizeof(buffer)) > 0) {
+            ssize_t readAmount = 0;
+            if ((readAmount = read(fd, buffer, sizeof(buffer))) > 0) {
+                ssize_t nulIndex = std::min(readAmount, static_cast<ssize_t>(sizeof(buffer) - 1));
+                buffer[nulIndex] = '\0';
                 sscanf(buffer, "%*d %*d %d", &Share);
                 result = Share * PageSize;
             }

--- a/Source/core/SerialPort.cpp
+++ b/Source/core/SerialPort.cpp
@@ -465,8 +465,11 @@ namespace Core {
             ::free(m_SendBuffer);
         }
 
-        uint8_t* allocatedMemory = static_cast<uint8_t*>(::malloc(m_SendBufferSize + m_ReceiveBufferSize));
+        uint8_t* allocatedMemory = static_cast<uint8_t*>(::calloc(m_SendBufferSize + m_ReceiveBufferSize, 1));
         if (m_SendBufferSize != -1) {
+            if (m_SendBuffer != nullptr) {
+                free(m_SendBuffer);
+            }
             m_SendBuffer = allocatedMemory;
         }
         if (m_ReceiveBufferSize != -1) {

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -484,8 +484,11 @@ namespace Core {
         }
 
         if ((receiveBuffer != 0) || (sendBuffer != 0)) {
-            uint8_t* allocatedMemory = static_cast<uint8_t*>(::malloc(sendBuffer + receiveBuffer));
+            uint8_t* allocatedMemory = static_cast<uint8_t*>(::calloc(sendBuffer + receiveBuffer, 1));
             if (sendBuffer != 0) {
+                if (m_SendBuffer != nullptr) {
+                    free(m_SendBuffer);
+                }
                 m_SendBuffer = allocatedMemory;
             }
             if (receiveBuffer != 0) {


### PR DESCRIPTION
- A few memory leaks
- A few memcpys with overlapping buffers (replaced with memmoves)
- Security flaw: send-ing unitialized buffer (might leak sensitive data)
- sscanf on non-NULL terminated strings