### PR TITLE
Westeros: fix to avoid crash due to refCount is not adjusted properly

### DIFF
--- a/Source/compositorclient/Wayland/Westeros.cpp
+++ b/Source/compositorclient/Wayland/Westeros.cpp
@@ -1013,6 +1013,7 @@ namespace Wayland {
 
         // Wait till we are fully registered.
         _waylandSurfaces.insert(std::pair<struct wl_surface*, SurfaceImplementation*>(surface->_surface, surface));
+        surface->AddRef();
 
         result = surface;
 


### PR DESCRIPTION
In westeros, we are releasing the graphics surface from the client application after its use as well as from the cleanup of _waylandSurfaces. So it has to adjusted properly