### PR TITLE
64 bit fix for downcasting issues in Communicator

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -430,7 +430,7 @@ namespace RPC {
         ASSERT(BaseClass::IsOpen() == false);
         _announceEvent.ResetEvent();
 
-        instance_id impl = reinterpret_cast<instance_id>(implementation);
+        instance_id impl = TO_INSTANCE_ID(implementation);
 
         _announceMessage->Parameters().Set(Core::ProcessInfo().Id(), interfaceId, impl, exchangeId);
 

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1125,7 +1125,7 @@ namespace RPC {
                     string jsonDefaultCategories(Trace::TraceUnit::Instance().Defaults());
                     void* result = _parent.Announce(proxyChannel, message->Parameters());
 
-                    message->Response().Set(reinterpret_cast<instance_id>(result), proxyChannel->Extension().Id(), _parent.ProxyStubPath(), jsonDefaultCategories);
+                    message->Response().Set(TO_INSTANCE_ID(result), proxyChannel->Extension().Id(), _parent.ProxyStubPath(), jsonDefaultCategories);
 
                     // We are done, report completion
                     channel.ReportResponse(data);
@@ -1342,7 +1342,7 @@ namespace RPC {
                 const uint32_t interfaceId(message->Parameters().InterfaceId());
                 const uint32_t versionId(message->Parameters().VersionId());
 
-                instance_id implementation = reinterpret_cast<instance_id>(_parent.Aquire(className, interfaceId, versionId));
+                instance_id implementation = TO_INSTANCE_ID(_parent.Aquire(className, interfaceId, versionId));
                 message->Response().Implementation(implementation);
 
                 channel.ReportResponse(data);
@@ -1451,7 +1451,7 @@ namespace RPC {
 
             if (BaseClass::IsOpen() == true) {
 
-                _announceMessage->Parameters().Set(Core::ProcessInfo().Id(), INTERFACE::ID, reinterpret_cast<instance_id>(offer), Data::Init::OFFER);
+                _announceMessage->Parameters().Set(Core::ProcessInfo().Id(), INTERFACE::ID, TO_INSTANCE_ID(offer), Data::Init::OFFER);
 
                 BaseClass::Invoke(_announceMessage, waitTime);
 
@@ -1475,7 +1475,7 @@ namespace RPC {
 
             if (BaseClass::IsOpen() == true) {
 
-                _announceMessage->Parameters().Set(Core::ProcessInfo().Id(), INTERFACE::ID, reinterpret_cast<instance_id>(offer), Data::Init::REVOKE);
+                _announceMessage->Parameters().Set(Core::ProcessInfo().Id(), INTERFACE::ID, TO_INSTANCE_ID(offer), Data::Init::REVOKE);
 
                 BaseClass::Invoke(_announceMessage, waitTime);
 

--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -70,7 +70,7 @@ namespace ProxyStub {
                 uint32_t newInterfaceId(reader.Number<uint32_t>());
 
                 void* newInterface = implementation->QueryInterface(newInterfaceId);
-                response.Number<RPC::instance_id>(reinterpret_cast<RPC::instance_id>(newInterface));
+                response.Number<RPC::instance_id>(TO_INSTANCE_ID(newInterface));
 
                 if (newInterface != nullptr) {
                     RPC::Administrator::Instance().RegisterInterface(channel, newInterface, newInterfaceId);

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -24,6 +24,8 @@
 #include "Messages.h"
 #include "Module.h"
 
+#define TO_INSTANCE_ID(x) ((WPEFramework::RPC::instance_id)*(WPEFramework::RPC::instance_id*)(x))
+
 namespace WPEFramework {
 
 namespace RPC {

--- a/Tools/ProxyStubGenerator/StubGenerator.py
+++ b/Tools/ProxyStubGenerator/StubGenerator.py
@@ -853,7 +853,7 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                     (m.name, retval.str_typename))
                         else:
                             if retval.proxy:
-                                emit.Line("writer.%s(reinterpret_cast<RPC::instance_id>(%s));" % (retval.RpcType(), retval.name))
+                                emit.Line("writer.%s((WPEFramework::RPC::instance_id)*(WPEFramework::RPC::instance_id*)(%s));" % (retval.RpcType(), retval.name))
                             else:
                                 emit.Line("writer.%s(%s);" % (retval.RpcType(), retval.name))
                             if retval.is_interface and not retval.type.IsConst():
@@ -884,7 +884,7 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                             elif p.is_nonconstref:
                                 if not p.is_length:
                                     if p.is_interface:
-                                        emit.Line("writer.%s(reinterpret_cast<RPC::instance_id>(%s));" % (p.RpcType(), p.name))
+                                        emit.Line("writer.%s((WPEFramework::RPC::instance_id)*(WPEFramework::RPC::instance_id*)(%s));" % (p.RpcType(), p.name))
                                     else:
                                         emit.Line("writer.%s(%s);" % (p.RpcType(), p.name))
                                 if p.is_interface and not p.type.IsConst():
@@ -1052,7 +1052,7 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                       or p.is_maxlength) and (p.is_input or
                                                               (not p.is_nonconstref and not p.is_nonconstptr) or p.obj):
                                     if p.proxy:
-                                        emit.Line("writer.%s(reinterpret_cast<RPC::instance_id>(param%i));" % (p.RpcType(), c))
+                                        emit.Line("writer.%s((WPEFramework::RPC::instance_id)*(WPEFramework::RPC::instance_id*)(param%i));" % (p.RpcType(), c))
                                     else:
                                         emit.Line("writer.%s(param%i);" % (p.RpcType(), c))
                         emit.Line()


### PR DESCRIPTION
reinterpret_cast<unsigned int> from void* fails when data types have different lengths (e.g. on x86_64)