### PR TITLE
Development/secure sockets

### DIFF
--- a/Source/com/Messages.h
+++ b/Source/com/Messages.h
@@ -26,7 +26,7 @@ namespace WPEFramework {
 namespace RPC {
 
     // As COMRPC might run between a 32 bit and 64 bit system, the largest must be accommodated.
-    #if defined(_WIN64) 
+    #if defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8) 
     typedef uint64_t instance_id;
     #else
     typedef uint32_t instance_id;

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -797,6 +797,14 @@ namespace Core {
         }
     }
 
+    /* virtual */ int32_t SocketPort::Read(uint8_t buffer[], const uint16_t length) const {
+        return (::recv(m_Socket, reinterpret_cast<char*>(buffer), length, 0));
+    }
+
+    /* virtual */ int32_t SocketPort::Write(const uint8_t buffer[], const uint16_t length) {
+        return (::send(m_Socket, reinterpret_cast<const char*>(buffer), length, 0));
+    }
+
     void SocketPort::Write()
     {
         bool dataLeftToSend = true;
@@ -823,15 +831,13 @@ namespace Core {
                     ASSERT(m_RemoteNode.IsValid() == true);
 
                     sendSize = ::sendto(m_Socket,
-                        reinterpret_cast<const char*>(&m_SendBuffer[m_SendOffset]),
+                        reinterpret_cast<const char*>(&(m_SendBuffer[m_SendOffset])),
                         m_SendBytes - m_SendOffset, 0,
                         static_cast<const NodeId&>(m_RemoteNode),
                         m_RemoteNode.Size());
 
                 } else {
-                    sendSize = ::send(m_Socket,
-                        reinterpret_cast<const char*>(&m_SendBuffer[m_SendOffset]),
-                        m_SendBytes - m_SendOffset, 0);
+                    sendSize = Write(&(m_SendBuffer[m_SendOffset]), m_SendBytes - m_SendOffset);
                 }
 
                 if (sendSize >= 0) {
@@ -878,9 +884,7 @@ namespace Core {
 
                 m_ReceivedNode = l_Remote;
             } else {
-                l_Size = ::recv(m_Socket,
-                    reinterpret_cast<char*>(&m_ReceiveBuffer[m_ReadBytes]),
-                    m_ReceiveBufferSize - m_ReadBytes, 0);
+                l_Size = Read(&(m_ReceiveBuffer[m_ReadBytes]), m_ReceiveBufferSize - m_ReadBytes);
             }
 
             if (l_Size == 0) {

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -225,6 +225,8 @@ namespace Core {
 
     protected:
         virtual bool Initialize();
+        virtual int32_t Read(uint8_t buffer[], const uint16_t length) const;
+        virtual int32_t Write(const uint8_t buffer[], const uint16_t length);
 
     private:
         virtual IResource::handle Descriptor() const override

--- a/Source/cryptalgo/CMakeLists.txt
+++ b/Source/cryptalgo/CMakeLists.txt
@@ -43,6 +43,25 @@ target_link_libraries(${TARGET}
           CompileSettingsDebug::CompileSettingsDebug
         )
 
+if(SECURE_SOCKET)
+    find_package(OpenSSL REQUIRED)
+
+    if (OPENSSL_FOUND)
+        include_directories(${OPENSSL_INCLUDE_DIR})
+        target_sources(${TARGET}
+            PRIVATE
+                SecureSocketPort.cpp)
+        target_link_libraries(${TARGET}
+            PRIVATE
+                OpenSSL::SSL)
+        target_compile_definitions(${TARGET}
+            PUBLIC
+                SECURESOCKETS_ENABLED=1)
+
+        list(APPEND PUBLIC_HEADERS "SecureSocketPort.h")
+    endif()
+endif()
+
 set_target_properties(${TARGET} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES

--- a/Source/cryptalgo/SecureSocketPort.cpp
+++ b/Source/cryptalgo/SecureSocketPort.cpp
@@ -56,7 +56,9 @@ SecureSocketPort::Handler::~Handler() {
 }
 
 bool SecureSocketPort::Handler::Initialize() {
-    _context = SSL_CTX_new(TLS_method());
+    // _context = SSL_CTX_new(TLS_method());
+    _context = SSL_CTX_new(SSLv23_method());
+    
     _ssl = SSL_new(static_cast<SSL_CTX*>(_context));
     SSL_set_fd(static_cast<SSL*>(_ssl), static_cast<Core::IResource&>(*this).Descriptor());
 

--- a/Source/cryptalgo/SecureSocketPort.cpp
+++ b/Source/cryptalgo/SecureSocketPort.cpp
@@ -1,0 +1,110 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SecureSocketPort.h"
+
+#include <openssl/ssl.h>
+
+namespace {
+
+    class OpenSSL {
+    public:
+        OpenSSL(const OpenSSL&) = delete;
+        OpenSSL& operator= (const OpenSSL&) = delete;
+
+        OpenSSL()
+        {
+            SSL_library_init();
+            OpenSSL_add_all_algorithms();
+            SSL_load_error_strings();
+        }
+        ~OpenSSL()
+        {
+        }
+    };
+
+    static OpenSSL _initialization;
+}
+
+namespace WPEFramework {
+
+namespace Crypto {
+
+SecureSocketPort::Handler::~Handler() {
+    if(_ssl != nullptr) {
+        SSL_free(static_cast<SSL*>(_ssl));
+    }
+    if(_context != nullptr) {
+        SSL_CTX_free(static_cast<SSL_CTX*>(_context));
+    }
+}
+
+bool SecureSocketPort::Handler::Initialize() {
+    _context = SSL_CTX_new(TLS_method());
+    _ssl = SSL_new(static_cast<SSL_CTX*>(_context));
+    SSL_set_fd(static_cast<SSL*>(_ssl), static_cast<Core::IResource&>(*this).Descriptor());
+
+    return (Core::SocketPort::Initialize());
+}
+
+int32_t SecureSocketPort::Handler::Read(uint8_t buffer[], const uint16_t length) const {
+    int32_t result = SSL_read(static_cast<SSL*>(_ssl), buffer, length);
+
+    if (_handShaking != CONNECTED) {
+        const_cast<Handler&>(*this).Update();
+    }
+    return (result);
+}
+
+int32_t SecureSocketPort::Handler::Write(const uint8_t buffer[], const uint16_t length) {
+    return (SSL_write(static_cast<SSL*>(_ssl), buffer, length));
+}
+
+void SecureSocketPort::Handler::Update() {
+    if (IsOpen() == true) {
+        int result;
+
+        if (_handShaking == IDLE) {
+            result = SSL_connect(static_cast<SSL*>(_ssl));
+            if (result == 1) {
+                _handShaking = CONNECTED;
+                _parent.StateChange();
+            }
+            else {
+                result = SSL_get_error(static_cast<SSL*>(_ssl), result);
+                if ((result == SSL_ERROR_WANT_READ) || (result == SSL_ERROR_WANT_WRITE)) {
+                    _handShaking = EXCHANGE;
+                }
+            }
+        }
+        else if (_handShaking == EXCHANGE) {
+            if (SSL_do_handshake(static_cast<SSL*>(_ssl)) == 1) {
+                _handShaking = CONNECTED;
+                _parent.StateChange();
+            }
+        }
+    }
+    else if (_ssl != nullptr) {
+        _handShaking = IDLE;
+        SSL_shutdown(static_cast<SSL*>(_ssl));
+        _parent.StateChange();
+    }
+}
+
+} } // namespace WPEFramework::Crypto

--- a/Source/cryptalgo/SecureSocketPort.h
+++ b/Source/cryptalgo/SecureSocketPort.h
@@ -1,0 +1,153 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace Crypto {
+
+    class SecureSocketPort : public Core::IResource {
+    private:
+        class Handler : public Core::SocketPort {
+        private:
+            enum state : uint8_t {
+                IDLE,
+                EXCHANGE,
+                CONNECTED
+            };
+
+        public:
+            Handler(const Handler&) = delete;
+            Handler& operator=(const Handler&) = delete;
+
+            template <typename... Args>
+            Handler(SecureSocketPort& parent, Args&&... args)
+                : Core::SocketPort(args...) 
+                , _parent(parent)
+                , _context(nullptr)
+                , _ssl(nullptr)
+                , _handShaking(IDLE) {
+            }
+            ~Handler();
+
+        public:
+            bool Initialize() override;
+
+            int32_t Read(uint8_t buffer[], const uint16_t length) const override;
+            int32_t Write(const uint8_t buffer[], const uint16_t length) override;
+
+            // Methods to extract and insert data into the socket buffers
+            uint16_t SendData(uint8_t* dataFrame, const uint16_t maxSendSize) override {
+                return (_parent.SendData(dataFrame, maxSendSize));
+            }
+
+            uint16_t ReceiveData(uint8_t* dataFrame, const uint16_t receivedSize) override {
+                return (_parent.ReceiveData(dataFrame, receivedSize));
+            }
+
+            // Signal a state change, Opened, Closed or Accepted
+            void StateChange() override {
+
+                ASSERT (_context != nullptr);
+                Update();
+            }
+
+        private:
+            void Update();
+ 
+        private:
+            SecureSocketPort& _parent;
+            void* _context;
+            void* _ssl;
+            mutable state _handShaking;
+        };
+
+    public:
+        SecureSocketPort(const SecureSocketPort&);
+        SecureSocketPort& operator=(const SecureSocketPort&);
+
+        template <typename... Args>
+        SecureSocketPort(Args&&... args)
+            : _handler(*this, args...) {
+        }
+        ~SecureSocketPort() override {
+        }
+
+    public:
+        inline bool IsOpen() const
+        {
+            return (_handler.IsOpen());
+        }
+        inline bool IsClosed() const
+        {
+            return (_handler.IsClosed());
+        }
+        inline bool HasError() const
+        {
+            return (_handler.HasError());
+        }
+        inline string LocalId() const
+        {
+            return (_handler.LocalId());
+        }
+        inline string RemoteId() const
+        {
+            return (_handler.RemoteId());
+        }
+
+        inline uint32_t Open(const uint32_t waitTime) {
+            return(_handler.Open(waitTime));
+        }
+        inline uint32_t Close(const uint32_t waitTime) {
+            return(_handler.Close(waitTime));
+        }
+        inline void Trigger() {
+            _handler.Trigger();
+        }
+
+        //
+        // Core::IResource interface
+        // ------------------------------------------------------------------------
+        IResource::handle Descriptor() const override
+        {
+            return (static_cast<const Core::IResource&>(_handler).Descriptor());
+        }
+        uint16_t Events() override
+        {
+            return (static_cast<Core::IResource&>(_handler).Events());
+        }
+        void Handle(const uint16_t events) override
+        {
+            static_cast<Core::IResource&>(_handler).Handle(events);
+        }
+
+        // Methods to extract and insert data into the socket buffers
+        virtual uint16_t SendData(uint8_t* dataFrame, const uint16_t maxSendSize) = 0;
+        virtual uint16_t ReceiveData(uint8_t* dataFrame, const uint16_t receivedSize) = 0;
+
+        // Signal a state change, Opened, Closed or Accepted
+        virtual void StateChange() = 0;
+
+    private:
+        Handler _handler;
+    };
+}
+}

--- a/Source/cryptalgo/cryptalgo.h
+++ b/Source/cryptalgo/cryptalgo.h
@@ -28,6 +28,10 @@
 #include "HashStream.h"
 #include "Random.h"
 
+#ifdef SECURESOCKETS_ENABLED
+#include "SecureSocketPort.h"
+#endif
+
 #ifdef __WINDOWS__
 #pragma comment(lib, "cryptalgo.lib")
 #endif


### PR DESCRIPTION
This adds a SecureSocketPort, based on the OpenSSL interface (abnd implementation). Using this implementation, secure sockets connections can be originating from the Thunder embedded side.
To enable it build using the -DSECURE_SOCKET=ON. The SecureSocketPort class [Crypto] is interface equal to the SocketPort class [Core] and thus, where the SocketPort is used as a template parameters, the SecureSocketPort can be used as well.