### PR TITLE
Fix cleanup of ChannelProxy in CommunicationChannel in JSONRPC::LinkType

### DIFF
--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -277,7 +277,7 @@ namespace JSONRPC {
     
                             typename CallsignMap::iterator index(_callsignMap.begin());
     
-                            while ((index != _callsignMap.end()) && (&(*object) == index->second)) {
+                            while ((index != _callsignMap.end()) && (&(*object) != index->second)) {
                                 index++;
                             }
     


### PR DESCRIPTION
This fixes a crash on re-conncting 

        for (int i=0; i < 10; ++i)
          JSONRPC::LinkType<Core::JSON::IElement> test(string{});
