### PR TITLE
[COMRPC] Allow reverting Administrator announcements

### DIFF
--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -94,6 +94,30 @@ namespace RPC {
             _adminLock.Unlock();
         }
 
+        template <typename ACTUALINTERFACE>
+        void Recall()
+        {
+            _adminLock.Lock();
+
+            std::map<uint32_t, ProxyStub::UnknownStub*>::iterator stub(_stubs.find(ACTUALINTERFACE::ID));
+            if (stub != _stubs.end()) {
+                delete stub->second;
+                _stubs.erase(ACTUALINTERFACE::ID);
+            } else {
+                TRACE_L1("Failed to find a Stub for %d.", ACTUALINTERFACE::ID);
+            }
+
+            std::map<uint32_t, IMetadata*>::iterator proxy(_proxy.find(ACTUALINTERFACE::ID));
+            if (proxy != _proxy.end()) {
+                delete proxy->second;
+                _proxy.erase(ACTUALINTERFACE::ID);
+            } else {
+                TRACE_L1("Failed to find a Proxy for %d.", ACTUALINTERFACE::ID);
+            }
+
+            _adminLock.Unlock();
+        }
+
         Core::ProxyType<InvokeMessage> Message()
         {
             return (_factory.Element());

--- a/Tools/ProxyStubGenerator/StubGenerator.py
+++ b/Tools/ProxyStubGenerator/StubGenerator.py
@@ -1223,6 +1223,17 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
 
         emit.IndentDec()
         emit.Line("}")
+
+        emit.Line("~Instantiation()")
+        emit.Line("{")
+        emit.IndentInc()
+
+        for key, val in announce_list.items():
+            emit.Line("RPC::Administrator::Instance().Recall<%s>();" % (key))
+
+        emit.IndentDec()
+        emit.Line("}")
+
         emit.IndentDec()
         emit.Line("} ProxyStubRegistration;")
         emit.Line()


### PR DESCRIPTION
​
Add a new RPC::Administrator::UnAnnounce() method for reverting what is
done by RPC::Administrator::Announce().
​
Some of the proxy/stubs that are announced to the Administrator may be
gone before the Administrator singleton is deleted, where it is
currently looping through all announced proxy/stubs and deleting the
associated pointers. This happens for all proxy/stubs coming from
'libWPEFrameworkProxyStubs.so'. When an OOP plugin is exiting, this
library is unloaded before the Administrator singleton is destroyed. All
the proxy/plugins allocated by this library are now gone and outside the
process memory space, because the library has been unloaded. This leaves
the Administrator with stale pointers. When it's being destroyed and
trying to delete the stale pointers, it crashes with SIGSEGV.
​
The proxy/stubs generator can be changed to call a method in the
Administrator to revert the announcement when unloading. Provide and
implement such a method, named Recall(). It tries to find
proxy/stubs announced for the given interface and will "unregister" them
from the Administrator, by deleting the associated pointers and then the
entry itself from the maintained proxy/stubs maps.
​
Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>

[StubGen] Add Instantiation destructor implementation to Recall()
​
As the proxy/stubs announce themselves upon loading to the
RPC::Administrator using Announce(), they should symmetrically
recall them when unloading. Otherwise, the Administrator may keep
stale references to announced proxy/stubs that have been unloaded
already.
​
The RPC::Administrator now has an UnAnnounce() method for this purpose,
which should then be called when the proxy/stubs are unloaded, which
happens when Instantiation is destroyed.
​
This way, let the proxy/stubs generator provide a destructor for the
Instantiation class and call RPC::Administrator::UnAnnounce() for both
the proxies and stubs.
​
Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>