### PR TITLE
NetworkInfo: Iterate over the rtatp if rtattrlen less than packet length

### DIFF
--- a/Source/core/NetworkInfo.cpp
+++ b/Source/core/NetworkInfo.cpp
@@ -988,7 +988,7 @@ namespace Core {
 
                 uint16_t rtattrlen = length;
 
-                for (; RTA_OK(rtatp, length); rtatp = RTA_NEXT(rtatp, rtattrlen)) {
+                for (; (rtattrlen <= length) && RTA_OK(rtatp, length); rtatp = RTA_NEXT(rtatp, rtattrlen)) {
 
                     /* Here we hit the fist chunk of the message. Time to validate the    *
              * the type. For more info on the different types see man(7) rtnetlink*


### PR DESCRIPTION
In commScope case, I found it is no texting from the update loop, even we complete the traversing of the complete packet. In that case, the rtattrlen was decremented to less than 0, but the rtattrlen is unsigned data type and hence its treating as large value, it is continue the loop.