### PR TITLE
[CORE] Store all locking callstacks for critical section

### DIFF
--- a/Source/core/Sync.h
+++ b/Source/core/Sync.h
@@ -89,8 +89,9 @@ namespace Core {
         void TryLock();
 
         static const int _AllocatedStackEntries = 20;
-        int _UsedStackEntries;
-        void* _LockingStack[_AllocatedStackEntries];
+        static const int _AllocatedStacks = 20;
+        int _UsedStackEntries[_AllocatedStacks];
+        void* _LockingStack[_AllocatedStacks][_AllocatedStackEntries];
 
         pthread_t _LockingThread;
         static int StripStackTop(void** stack, int stackEntries, int stripped);


### PR DESCRIPTION
Stores all callstacks used when locking CriticalSection.

If "CRITICAL_SECTION_LOCK_LOG" is enabled, all callstacks when locking a CriticalSection are logged, not just the most recent one. This allows one to investigate unmatched locks/unlocks.