### PR TITLE
CompositorClient:Wayland:Zorder fraction calculation conversion issue updated

### DIFF
--- a/Source/compositorclient/Wayland/Westeros.cpp
+++ b/Source/compositorclient/Wayland/Westeros.cpp
@@ -564,6 +564,8 @@ namespace Wayland {
 
     void Display::SurfaceImplementation::ZOrder(const uint32_t order)
     {
+        // Max layers supported by Westeros have a limitation with 255, hence the ZOrder fraction
+        // difference calculation is limiting with std::numeric_limits<uint8_t>::max()
         ASSERT (order <= std::numeric_limits<uint8_t>::max());
 
         double fractionalOrder = 1.0 - (static_cast<double>(order) / static_cast<double>(std::numeric_limits<uint8_t>::max()));

--- a/Source/compositorclient/Wayland/Westeros.cpp
+++ b/Source/compositorclient/Wayland/Westeros.cpp
@@ -566,7 +566,7 @@ namespace Wayland {
     {
         ASSERT (order <= std::numeric_limits<uint8_t>::max());
 
-        double fractionalOrder = 1.0 - (order / std::numeric_limits<uint8_t>::max());
+        double fractionalOrder = 1.0 - (static_cast<double>(order) / static_cast<double>(std::numeric_limits<uint8_t>::max()));
 
         wl_simple_shell_set_zorder(_display->_simpleShell, _id, wl_fixed_from_double(fractionalOrder));
         wl_display_flush(_display->_display);


### PR DESCRIPTION
Currently the Zorder fraction calculation is not working, its always returning 1.0 since not casting the unit32_t order to double.