### PR TITLE
Development/windows adaptions

### DIFF
--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -45,8 +45,20 @@ extern "C" {
 #else
         return (InetPton(AF_INET, cp, inp));
 #endif
-}
+    }
 
+    void usleep(CONST uint32_t usec)
+    {
+        HANDLE timer;
+        LARGE_INTEGER ft;
+
+        ft.QuadPart = 0 - (10 * usec); // Convert to 100 nanosecond interval, negative value indicates relative time
+
+        timer = CreateWaitableTimer(NULL, TRUE, NULL);
+        SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+        WaitForSingleObject(timer, INFINITE);
+        CloseHandle(timer);
+    }
 }
 #endif
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -109,8 +109,6 @@
 
 #define AF_NETLINK 16
 
-extern 
-
 inline void SleepS(unsigned int a_Time)
 {
     ::Sleep(a_Time * 1000);

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -109,6 +109,8 @@
 
 #define AF_NETLINK 16
 
+extern 
+
 inline void SleepS(unsigned int a_Time)
 {
     ::Sleep(a_Time * 1000);
@@ -494,7 +496,14 @@ extern "C" {
 
 #ifdef __WINDOWS__
 extern int EXTERNAL inet_aton(const char* cp, struct in_addr* inp);
+extern void EXTERNAL usleep(const uint32_t value);
 #endif
+
+inline void SleepUs(unsigned int a_Time)
+{
+    ::usleep(a_Time);
+}
+
 
 extern void EXTERNAL DumpCallStack(const ThreadId threadId = 0);
 }

--- a/Source/core/ProcessInfo.cpp
+++ b/Source/core/ProcessInfo.cpp
@@ -756,7 +756,13 @@ namespace Core {
 
     bool ProcessTree::ContainsProcess(ThreadId pid) const
     {
+        #ifdef __WINDOWS__
+        #pragma warning(disable : 4312)
+        #endif
         auto comparator = [pid](const ProcessInfo& processInfo){ return ((ThreadId)(processInfo.Id()) == pid); };
+        #ifdef __WINDOWS__
+        #pragma warning(default : 4312)
+        #endif
 
         std::list<ProcessInfo>::const_iterator i = std::find_if(_processes.cbegin(), _processes.cend(), comparator);
         return (i != _processes.cend());
@@ -767,13 +773,25 @@ namespace Core {
         processIds.clear();
 
         for (const ProcessInfo& process : _processes) {
+            #ifdef __WINDOWS__
+            #pragma warning(disable : 4312)
+            #endif
             processIds.push_back((ThreadId)(process.Id()));
+            #ifdef __WINDOWS__
+            #pragma warning(default : 4312)
+            #endif
         }
     }
 
     ThreadId ProcessTree::RootId() const
     {
-       return (ThreadId)(_processes.front().Id());
+        #ifdef __WINDOWS__
+        #pragma warning(disable : 4312)
+        #endif
+        return (ThreadId)(_processes.front().Id());
+        #ifdef __WINDOWS__
+        #pragma warning(default : 4312)
+        #endif
     }
 
     uint64_t ProcessTree::Jiffies() const

--- a/Source/core/Thread.cpp
+++ b/Source/core/Thread.cpp
@@ -122,7 +122,9 @@ namespace Core {
     ::ThreadId Thread::ThreadId()
     {
 #ifdef __WINDOWS__
+        #pragma warning (disable:4312)
         return (reinterpret_cast<::ThreadId>(::GetCurrentThreadId()));
+        #pragma warning (default:4312)
 #else
         return static_cast<::ThreadId>(pthread_self());
 #endif


### PR DESCRIPTION
usleep is not available in Windows, add an implementation in Thunder, if we are building for Windows, so also windows supports the usleep.
Fix some warnings on conversion in windows, so the build gets warning free.