### PR TITLE
[DEADLOCK] Out-of-process, calling back in for a QI.

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -279,7 +279,7 @@ namespace Plugin {
             if (index.Current() == _T("Activate")) {
                 if (index.Next()) {
                     const string callSign(index.Current().Text());
-                    if (callSign == _pluginServer->ControllerName()) {
+                    if (callSign == _service->Callsign()) {
                         result->ErrorCode = Web::STATUS_FORBIDDEN;
                         result->Message = _T("The PluginHost Controller can not be activated.");
                     } else {
@@ -309,7 +309,7 @@ namespace Plugin {
             } else if (index.Current() == _T("Deactivate")) {
                 if (index.Next()) {
                     const string callSign(index.Current().Text());
-                    if (callSign == _pluginServer->ControllerName()) {
+                    if (callSign == _service->Callsign()) {
                         result->ErrorCode = Web::STATUS_FORBIDDEN;
                         result->Message = _T("The PluginHost Controller can not be deactivated.");
                     } else {

--- a/Source/WPEFramework/ControllerJsonRpc.cpp
+++ b/Source/WPEFramework/ControllerJsonRpc.cpp
@@ -84,7 +84,7 @@ namespace Plugin {
 
         ASSERT(_pluginServer != nullptr);
 
-        if (callsign != _pluginServer->ControllerName()) {
+        if (callsign != Callsign()) {
             Core::ProxyType<PluginHost::Server::Service> service;
 
             if (_pluginServer->Services().FromIdentifier(callsign, service) == Core::ERROR_NONE) {
@@ -122,7 +122,7 @@ namespace Plugin {
 
         ASSERT(_pluginServer != nullptr);
 
-        if (callsign != _pluginServer->ControllerName()) {
+        if (callsign != Callsign()) {
             Core::ProxyType<PluginHost::Server::Service> service;
 
             if (_pluginServer->Services().FromIdentifier(callsign, service) == Core::ERROR_NONE) {

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -245,15 +245,13 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
         TRACE_L1("Deactivating %d plugins.", static_cast<uint32_t>(_services.size()));
 
         // First, move them all to deactivated except Controller
-        Core::ProxyType<Service> controller;
+        Core::ProxyType<Service> controller (_server.Controller());
         do {
             index--;
 
             ASSERT(index->second.IsValid());
 
-            if (index->first.c_str() == _server._controller->Callsign()) {
-                controller = index->second;
-            } else {
+            if (index->first.c_str() != controller->Callsign()) {
                 index->second->Deactivate(PluginHost::IShell::SHUTDOWN);
             }
         } while (index != _services.begin());
@@ -295,14 +293,14 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
             result = this;
         } else {
 
-            Lock();
+            _pluginHandling.Lock();
 
             if (_handler != nullptr) {
 
                 result = _handler->QueryInterface(id);
             }
 
-            Unlock();
+            _pluginHandling.Unlock();
         }
 
         return (result);
@@ -553,7 +551,7 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
             serviceCall = true;
 
             if (identifier.length() <= (serviceHeader.length() + 1)) {
-                service = _server._controller;
+                service = _server.Controller();
                 result = Core::ERROR_NONE;
             } else {
                 size_t length;
@@ -568,7 +566,7 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
             serviceCall = false;
 
             if (identifier.length() <= (JSONRPCHeader.length() + 1)) {
-                service = _server._controller;
+                service = _server.Controller();
                 result = Core::ERROR_NONE;
             } else {
                 size_t length;
@@ -741,11 +739,12 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
 
     void Server::Notification(const ForwardMessage& data)
     {
-        if ((_controller.IsValid() == false) || (_controller->ClassType<Plugin::Controller>() == nullptr)) {
+        Plugin::Controller* controller;
+        if ((_controller.IsValid() == false) || ((controller = (_controller->ClassType<Plugin::Controller>())) == nullptr)) {
             DumpCallStack();
         } else {
 
-            _controller->ClassType<Plugin::Controller>()->Notification(data);
+            controller->Notification(data);
 
 #ifdef RESTFULL_API
             string result;
@@ -778,8 +777,11 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
 
         securityProvider->Release();
 
-        _controller->ClassType<Plugin::Controller>()->SetServer(this);
-        _controller->ClassType<Plugin::Controller>()->AddRef();
+        Plugin::Controller* controller = _controller->ClassType<Plugin::Controller>();
+        
+        ASSERT(controller != nullptr);
+        
+        controller->SetServer(this);
 
         _dispatcher.Run();
         Dispatcher().Open(MAX_EXTERNAL_WAITS);

--- a/Source/core/Services.h
+++ b/Source/core/Services.h
@@ -170,7 +170,7 @@ namespace Core {
 
     public:
         template <typename... Args>
-        Sink(Args... args)
+        Sink(Args&&... args)
             : ACTUALSINK(std::forward<Args>(args)...)
             , _referenceCount(0)
         {

--- a/Source/proxystubs/proxystubs.vcxproj
+++ b/Source/proxystubs/proxystubs.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Module.cpp" />
+    <ClCompile Include="ProxyStubs_Plugin.cpp" />
     <ClCompile Include="ProxyStubs_Shell.cpp" />
     <ClCompile Include="ProxyStubs_StateControl.cpp" />
     <ClCompile Include="ProxyStubs_SubSystem.cpp" />
@@ -164,7 +165,7 @@
       <AdditionalLibraryDirectories>$(SolutionDir)..\artifacts\$(Configuration)\</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>python "$(SolutionDir)tools\ProxyStubGenerator\StubGenerator.py" --namespace "WPEFramework::PluginHost" --outdir "$(ProjectDir)." "$(ProjectDir)..\plugins\IShell.h" "$(ProjectDir)..\plugins\IStateControl.h"  "$(ProjectDir)..\plugins\ISubSystem.h"</Command>
+      <Command>python "$(SolutionDir)tools\ProxyStubGenerator\StubGenerator.py" --namespace "WPEFramework::PluginHost" --outdir "$(ProjectDir)." "$(ProjectDir)..\plugins\IShell.h" "$(ProjectDir)..\plugins\IPlugin.h" "$(ProjectDir)..\plugins\IStateControl.h"  "$(ProjectDir)..\plugins\ISubSystem.h"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
This pullrequest resolves:
1) Missing AddRef/Release on the registration of these sinks, which would, after the registration
   call delete the Proxies, and thus crash the system.
2) On the activation report of a plugin, the Service is locked. On the QueryInterface on this service
   the same lock was used. Deadlock. However, this lock was just to protect the Inner Plugin from
   being changed while the query interface on the inner object was being executed. The handling on the
   inner object (shell -- Plugin) is now protected by a dedicated CriticalSection, effectively resolving
   the deadlock