### PR TITLE
PluginServer: set accessor with default value in case of accessor not valid case

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -190,6 +190,7 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
             value.sin_port = htons(configuration.Port.Value());
 
             result = value;
+            accessor = result;
 
             TRACE_L1("Invalid config information could not resolve to a proper IP set to: (%s:%d)", result.HostAddress().c_str(), result.PortNumber());
         } else {


### PR DESCRIPTION
If there is no valid network interface ready case the accessor string generated from https://github.com/rdkcentral/Thunder/blob/master/Source/plugins/Service.h#L134 is an invalid string like  http://:65535/Service/${callsign). To avoid this case, it is better to use the 0.0.0.0 address with the port configured in the configuration file. 