### PR TITLE
[IInputPin] Subscribing to the TimedInput can only be done globally.

### DIFF
--- a/Source/interfaces/IInputPin.h
+++ b/Source/interfaces/IInputPin.h
@@ -40,8 +40,8 @@ namespace Exchange {
         virtual void Register(IInputPin::INotification* sink) = 0;
         virtual void Unregister(IInputPin::INotification* sink) = 0;
 
-        virtual uint32_t AddMarker(const IInputPin::INotification* sink, const uint32_t marker) = 0;
-        virtual uint32_t RemoveMarker(const IInputPin::INotification* sink, const uint32_t marker) = 0;
+        virtual void AddMarker(const uint32_t marker) = 0;
+        virtual void RemoveMarker(const uint32_t marker) = 0;
     };
 }
 }


### PR DESCRIPTION
This is to simplify the IExternal -> IInputPin possibilities. There is no use case where the creator of a pin, is only interested in 1 marker. The pin owner is interested in which time frame the input pin was released (upon being pressed :-) )