### PR TITLE
Portability: Add cmath include

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -210,6 +210,7 @@ typedef std::string string;
 #include <arpa/inet.h>
 #include <assert.h>
 #include <cxxabi.h>
+#include <cmath>
 #include <dirent.h>
 #include <dlfcn.h>
 #include <errno.h>


### PR DESCRIPTION
Fixes compile error: ‘__builtin_isinf_sign’ is not a member of ‘std’ on the VSS SDK builds.