### PR TITLE
Development/generate file out of source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ uninstall.cmake
 /cppcheck_report.txt
 /cppcheck_log.txt
 clion-environment/
-Source/Config.json
 /clion-environment/WPEFrameworkPlugins/RemoteControl/RemoteControl.json
 /clion-environment/WPEFrameworkPlugins/Commander/Commander.json
 /clion-environment/WPEFrameworkPlugins/DeviceInfo/DeviceInfo.json
@@ -29,7 +28,6 @@ Source/Config.json
 workspace/
 /.vs
 /artifacts/Debug
-/Source/protocols
 *.user
 /artifacts/Release
 *.pyc

--- a/Source/com/CMakeLists.txt
+++ b/Source/com/CMakeLists.txt
@@ -17,19 +17,19 @@
 
 set(TARGET ${NAMESPACE}COM)
 
-ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/Communicator.h)
-ProxyStubGenerator(NAMESPACE "WPEFramework::Trace" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/ITracing.h)
-ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IStringIterator.h)
-ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IValueIterator.h)
+ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/Communicator.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+ProxyStubGenerator(NAMESPACE "WPEFramework::Trace" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/ITracing.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IStringIterator.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IValueIterator.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
 
 add_library(${TARGET} SHARED
         Administrator.cpp
         Communicator.cpp
-        ProxyStubs_Communicator.cpp
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_Communicator.cpp"
         ITracing.cpp
-        ProxyStubs_Tracing.cpp
-        ProxyStubs_StringIterator.cpp
-        ProxyStubs_ValueIterator.cpp
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_Tracing.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_StringIterator.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_ValueIterator.cpp"
         IUnknown.cpp
         Module.cpp
         )
@@ -56,6 +56,8 @@ target_link_libraries(${TARGET}
         PRIVATE
           CompileSettingsDebug::CompileSettingsDebug
         )
+
+target_include_directories(${TARGET} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if(PROCESSCONTAINERS)
     target_link_libraries(${TARGET}

--- a/Source/interfaces/CMakeLists.txt
+++ b/Source/interfaces/CMakeLists.txt
@@ -20,21 +20,23 @@ set(TargetDefinitions ${NAMESPACE}Definitions)
 string(TOLOWER ${NAMESPACE} NAMESPACE_LIB)
 
 file(GLOB PUBLIC_HEADERS I*.h)
-file(GLOB JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/json/*.json)
+file(GLOB JSON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/json/*.json")
 
 list(APPEND PUBLIC_HEADERS Module.h)
 list(APPEND PUBLIC_HEADERS definitions.h)
 
-ProxyStubGenerator(INPUT ${CMAKE_CURRENT_SOURCE_DIR})
-JsonGenerator(CODE INPUT ${JSON_FILE})
-JsonGenerator(CODE INPUT ${CMAKE_CURRENT_SOURCE_DIR}/I*.h OUTPUT json)
+ProxyStubGenerator(INPUT "${CMAKE_CURRENT_SOURCE_DIR}" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+JsonGenerator(CODE INPUT ${JSON_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/json")
+JsonGenerator(CODE INPUT "${CMAKE_CURRENT_SOURCE_DIR}/I*.h" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/json")
 
-file(GLOB PROXY_STUB_SOURCES ProxyStubs*.cpp)
+file(GLOB PROXY_STUB_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs*.cpp")
 add_library(${TargetMarshalling} SHARED ${PROXY_STUB_SOURCES})
 
-file(GLOB JSON_DATA_HEADERS json/JsonData*.h)
-file(GLOB JSON_ENUM_SOURCES json/JsonEnum*.cpp)
-file(GLOB JSON_LINK_HEADERS json/J*.h)
+target_include_directories(${TargetMarshalling} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+file(GLOB JSON_DATA_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/generated/json/JsonData*.h")
+file(GLOB JSON_ENUM_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/generated/json/JsonEnum*.cpp")
+file(GLOB JSON_LINK_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/generated/json/J*.h")
 
 add_library(${TargetDefinitions} SHARED
         Module.cpp

--- a/Source/ocdm/CMakeLists.txt
+++ b/Source/ocdm/CMakeLists.txt
@@ -19,12 +19,12 @@ set(TARGET ocdm)
 
 option(CDMI_ADAPTER_IMPLEMENTATION "Defines which implementation is used." "None")
 
-ProxyStubGenerator(NAMESPACE "OCDM" INPUT ${CMAKE_CURRENT_SOURCE_DIR})
+ProxyStubGenerator(NAMESPACE "OCDM" INPUT "${CMAKE_CURRENT_SOURCE_DIR}" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
 
 add_library(${TARGET} SHARED
         open_cdm.cpp
         open_cdm_ext.cpp
-        ProxyStubs_OCDM.cpp
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_OCDM.cpp"
         )
 
 set(PUBLIC_HEADERS

--- a/Source/protocols/CMakeLists.txt
+++ b/Source/protocols/CMakeLists.txt
@@ -19,10 +19,10 @@ set(TARGET ${NAMESPACE}Protocols)
 
 find_package(ZLIB REQUIRED)
 
-ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../com/Communicator.h)
-ProxyStubGenerator(NAMESPACE "WPEFramework::Trace" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../com/ITracing.h)
-ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../com/IStringIterator.h)
-ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../com/IValueIterator.h)
+ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/../com/Communicator.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+ProxyStubGenerator(NAMESPACE "WPEFramework::Trace" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/../com/ITracing.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/../com/IStringIterator.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
+ProxyStubGenerator(NAMESPACE "WPEFramework::RPC" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/../com/IValueIterator.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
 
 # Take care the sources are listed !!! TWICE !!! in this setup. raised a JIRA ticket to solve this for now, also scroll down and list the 
 # new source file again. This is in case CMAKE forgets :-)
@@ -37,11 +37,7 @@ set(SOURCES_COM
         com/Messages.h
         com/Administrator.cpp
         com/Communicator.cpp
-        com/ProxyStubs_Communicator.cpp
         com/ITracing.cpp
-        com/ProxyStubs_Tracing.cpp
-        com/ProxyStubs_StringIterator.cpp
-        com/ProxyStubs_ValueIterator.cpp
         com/IValueIterator.h
         com/IUnknown.cpp
         com/IStringIterator.h
@@ -67,35 +63,41 @@ set(SOURCES_WEBSOCKETS
         websocket/WebTransform.h
         )
 
-foreach(file IN LISTS SOURCES_COM SOURCES_WEBSOCKETS)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/../${file}" ${CMAKE_CURRENT_SOURCE_DIR} COPYONLY)
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/com")
+foreach(file IN LISTS SOURCES_COM)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/../${file}" ${CMAKE_CURRENT_BINARY_DIR}/com COPYONLY)
+endforeach()
+
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/websocket")
+foreach(file IN LISTS SOURCES_WEBSOCKETS)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/../${file}" ${CMAKE_CURRENT_BINARY_DIR}/websocket COPYONLY)
 endforeach()
 
 set(COM_INCLUDES
-        Administrator.h
-        com.h
-        Communicator.h
-        Ids.h
-        ITracing.h
-        IUnknown.h
-        Messages.h
-        IRPCIterator.h
-        IStringIterator.h
-        IValueIterator.h
+        "${CMAKE_CURRENT_BINARY_DIR}/com/Administrator.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/com.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/Communicator.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/Ids.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/ITracing.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/IUnknown.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/Messages.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/IRPCIterator.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/IStringIterator.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/IValueIterator.h"
         )
 
 set(PROTOCOLS_INCLUDES
-        URL.h
-        JSONWebToken.h
-        JSONRPCLink.h
-        WebLink.h
-        WebRequest.h
-        WebResponse.h
-        WebSerializer.h
-        websocket.h
-        WebSocketLink.h
-        WebTransfer.h
-        WebTransform.h
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/URL.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/JSONWebToken.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/JSONRPCLink.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebLink.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebRequest.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebResponse.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebSerializer.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/websocket.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebSocketLink.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebTransfer.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebTransform.h"
         )
 
 set(PUBLIC_HEADERS
@@ -107,20 +109,27 @@ set(PUBLIC_HEADERS
 # Construct a library object
 add_library(${TARGET} SHARED
         Module.cpp
-        URL.cpp
-        JSONWebToken.cpp
-        ITracing.cpp
-        ProxyStubs_Tracing.cpp
-        IUnknown.cpp
-        WebSerializer.cpp
-        WebSocketLink.cpp
-        JSONRPCLink.cpp
-        Administrator.cpp
-        Communicator.cpp
-        ProxyStubs_Communicator.cpp
-        ProxyStubs_StringIterator.cpp
-        ProxyStubs_ValueIterator.cpp
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/URL.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/JSONWebToken.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/ITracing.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_Tracing.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/IUnknown.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebSerializer.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/WebSocketLink.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/websocket/JSONRPCLink.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/Administrator.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/com/Communicator.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_Communicator.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_StringIterator.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_ValueIterator.cpp"
         )
+
+target_include_directories(${TARGET} 
+        PRIVATE 
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/com>
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/websocket>
+)
 
 target_link_libraries(${TARGET}
         PRIVATE

--- a/Source/proxystubs/CMakeLists.txt
+++ b/Source/proxystubs/CMakeLists.txt
@@ -25,17 +25,28 @@ set(PLUGIN_INCLUDES
         plugins/ISubSystem.h
         )
 
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
 foreach(file IN LISTS PLUGIN_INCLUDES)
-        ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/../${file}" OUTDIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/../${file}" ${CMAKE_CURRENT_BINARY_DIR}/include COPYONLY)
+endforeach()
+
+foreach(file IN LISTS PLUGIN_INCLUDES)
+        ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_BINARY_DIR}/include" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs")
 endforeach()
 
 add_library(${TARGET} SHARED
-        ProxyStubs_Shell.cpp
-        ProxyStubs_Plugin.cpp
-        ProxyStubs_StateControl.cpp
-        ProxyStubs_SubSystem.cpp
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_Shell.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_Plugin.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_StateControl.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/proxystubs/ProxyStubs_SubSystem.cpp"
         Module.cpp
         )
+
+target_include_directories(${TARGET}
+         PRIVATE 
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+)
 
 if (PROTOCOLS)
     target_link_libraries(${TARGET}

--- a/Tools/JsonGenerator/JsonGenerator.py
+++ b/Tools/JsonGenerator/JsonGenerator.py
@@ -1162,7 +1162,7 @@ def EmitEnumRegs(root, emit, header_file):
         emit.Line("ENUM_CONVERSION_END(%s);" % fullname)
 
     # Enumeration conversion code
-    emit.Line("#include \"../definitions.h\"")
+    emit.Line("#include <interfaces/definitions.h>")
     emit.Line("#include <core/Enumerate.h>")
     emit.Line("#include \"%s_%s.h\"" % (DATA_NAMESPACE, header_file))
     emit.Line()

--- a/Tools/ProxyStubGenerator/StubGenerator.py
+++ b/Tools/ProxyStubGenerator/StubGenerator.py
@@ -229,9 +229,9 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         emit.Line("//")
         emit.Line()
 
-        if os.path.isfile(os.path.join(os.path.dirname(output_file), interface_header_name)):
+        if os.path.isfile(os.path.join(os.path.dirname(source_file), interface_header_name)):
             emit.Line('#include "%s"' % interface_header_name)
-        if os.path.isfile(os.path.join(os.path.dirname(output_file), "Module.h")):
+        if os.path.isfile(os.path.join(os.path.dirname(source_file), "Module.h")):
             emit.Line('#include "Module.h"')
         emit.Line()
 

--- a/Tools/cmake/FindProxyStubGenerator.cmake.in
+++ b/Tools/cmake/FindProxyStubGenerator.cmake.in
@@ -81,6 +81,7 @@ function(ProxyStubGenerator)
     endif()
 
     if (Argument_OUTDIR)
+        file(MAKE_DIRECTORY "${Argument_OUTDIR}")
         list(APPEND _execute_command  "--outdir" "${Argument_OUTDIR}")
     endif()
 


### PR DESCRIPTION
During native development I saw that the generators where polluting the original sources even when I executed an out-of-tree build. With this change all the sources that are generated and those who where copied to a a different location configure time are now put in to the cmake binary directory. This leaves the original file structure untouched.