### PR TITLE
[IEXTERNAL] Remove type from Identifier, make it a settable moduleId.

### DIFF
--- a/Source/interfaces/IExternal.h
+++ b/Source/interfaces/IExternal.h
@@ -69,14 +69,6 @@ namespace Exchange {
             virtual void Unregister(ICatalog::INotification* sink) = 0;
         };
 
-        enum identification {
-            ZWAVE    = 0x10000000,
-            GPIO     = 0x20000000,
-            I2C      = 0x30000000,
-            ZIGBEE   = 0x40000000,
-            NRF24L01 = 0x50000000
-        };
-
         //  Basic/specific and dimension together define the Type.
         // 32     13    | 3 |  4  |     12     |
         //  +---------------+------------------+
@@ -86,12 +78,12 @@ namespace Exchange {
         //        should be considerd to be the remainder.
         //        3 bits (0..7)
         //
-        enum basic { /* 4 bits (16)*/
+        enum basic : uint8_t { /* 4 bits (16)*/
             regulator = 0x0,
             measurement = 0x1
         };
 
-        enum specific { /* 12 bits (4096) */
+        enum specific : uint16_t { /* 12 bits (4096) */
             general = 0x000,
             electricity = 0x001,
             water = 0x002,
@@ -109,7 +101,7 @@ namespace Exchange {
             clock = 0x00E
         };
 
-        enum dimension { /* 13 bits (8192) */
+        enum dimension : uint16_t { /* 13 bits (8192) */
             logic = 0x0000, /* values 0 or 1  */
             percentage = 0x0001, /* values 0 - 100 */
             kwh = 0x0002, /* kilo Watt hours  */
@@ -119,7 +111,7 @@ namespace Exchange {
             units = 0x0006, /* unqualified value, just units */
         };
 
-        enum condition {
+        enum condition : uint8_t {
             constructing = 0x0000,
             activated = 0x0001,
             deactivated = 0x0002
@@ -134,6 +126,12 @@ namespace Exchange {
 
         // Identification of this element.
         virtual uint32_t Identifier() const = 0;
+
+        // The module is the top 8 bits of the Identifier. The value of 0 is reserved,
+        // it means that the module is not assigned. Any other number indicates that the 
+        // IExternal is allocated to a module and should not be overwritten with an other
+        // number than 0.
+        virtual void Module(const uint8_t module) = 0;
 
         // Characteristics of this element
         virtual uint32_t Type() const = 0;


### PR DESCRIPTION
When more IExternals will be published the type of the IExternal (what the root source of the
device is) is not so important. The device type is abstracted away. From an IExternal level you
can read and/or write a value on it (int32_t).

By removing the the source type of the IExternal, the top 4 bits become available again, together
with the bits 24-27 we free up a whole byte that can be used the "assign" a module identifier to
the IExternalIdentifier. This way, if a plugin collects all IExternals, it is free to assign a
module identifier (based on the interface offering the IExternal) to the IExternal::Identifier.
This will make the Identifier reported by the IExternal unique over multiple ICatalogs.