### PR TITLE
[Core] Make the SynchronousChannel mark the outbound message as sent …

### DIFF
--- a/Source/core/SynchronousChannel.h
+++ b/Source/core/SynchronousChannel.h
@@ -112,7 +112,7 @@ namespace Core {
             {
                 uint16_t result = _message.Serialize(dataFrame, maxSendSize);
 
-                if (result < maxSendSize) {
+                if (result == 0) {
                     _state = (_response == nullptr ? COMPLETE : INBOUND);
                 }
                 return (result);


### PR DESCRIPTION
…only once it's finished being processed completely.

The outbound message is marked as complete too early. The Write() at SocketPort still does one last iteration in its processing loop. If an inbound message is not expected and the sender reloads its outbound message quickly enough (as it is now free to do so), then the loop by accident picks up the new frame data to send to the socket instead of exiting.