### PR TITLE
[ALIGNMENT] Fix Build on windows, reduce number of warnings.

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1430,6 +1430,7 @@ namespace Core {
             explicit String(const bool quoted = true)
                 : _default()
                 , _scopeCount(quoted ? QuotedSerializeBit : None)
+                , _unaccountedCount(0)
                 , _value()
             {
             }
@@ -1437,6 +1438,7 @@ namespace Core {
             explicit String(const string& Value, const bool quoted = true)
                 : _default()
                 , _scopeCount(quoted ? QuotedSerializeBit : None)
+                , _unaccountedCount(0)
                 , _value()
             {
                 Core::ToString(Value.c_str(), _default);
@@ -1445,6 +1447,7 @@ namespace Core {
             explicit String(const char Value[], const bool quoted = true)
                 : _default()
                 , _scopeCount(quoted ? QuotedSerializeBit : None)
+                , _unaccountedCount(0)
                 , _value()
             {
                 Core::ToString(Value, _default);
@@ -1454,6 +1457,7 @@ namespace Core {
             explicit String(const wchar_t Value[], const bool quoted = true)
                 : _default()
                 , _scopeCount(quoted ? QuotedSerializeBit : None)
+                , _unaccountedCount(0)
                 , _value()
             {
                 Core::ToString(Value, _default);
@@ -1463,6 +1467,7 @@ namespace Core {
             String(const String& copy)
                 : _default(copy._default)
                 , _scopeCount(copy._scopeCount & (QuotedSerializeBit | SetBit))
+                , _unaccountedCount(0)
                 , _value(copy._value)
             {
             }
@@ -2674,13 +2679,17 @@ namespace Core {
 
         public:
             ArrayType()
-                : _data()
+                : _state(0)
+                , _count(0)
+                , _data()
                 , _iterator(_data)
             {
             }
 
             ArrayType(const ArrayType<ELEMENT>& copy)
-                : _data(copy._data)
+                : _state(copy._state)
+                , _count(copy._count)
+                , _data(copy._data)
                 , _iterator(_data)
             {
             }

--- a/Source/core/NodeId.h
+++ b/Source/core/NodeId.h
@@ -38,10 +38,9 @@
 #include <netinet/in.h>
 #include <sys/un.h>
 #include <netpacket/packet.h>
-#endif
-
 #include <net/ethernet.h>
 #include <net/if.h>
+#endif
 
 #ifdef CORE_BLUETOOTH
 #include <../include/bluetooth/bluetooth.h>

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -128,6 +128,7 @@
 #include <array>
 
 #define AF_NETLINK 16
+#define AF_PACKET  17
 
 inline void SleepS(unsigned int a_Time)
 {

--- a/Source/core/WorkerPool.h
+++ b/Source/core/WorkerPool.h
@@ -92,7 +92,7 @@ namespace Core {
         virtual const Metadata& Snapshot() const = 0;
     };
 
-    class WorkerPool : public IWorkerPool {
+    class EXTERNAL WorkerPool : public IWorkerPool {
     private:
         class Timer {
         public:

--- a/Source/cryptalgo/AES.h
+++ b/Source/cryptalgo/AES.h
@@ -26,7 +26,7 @@
 namespace WPEFramework {
 namespace Crypto {
 
-    enum aesType {
+    enum aesType : uint8_t {
         AES_ECB,
         AES_CBC,
         AES_CFB8,
@@ -34,7 +34,7 @@ namespace Crypto {
         AES_OFB
     };
 
-    enum bitLength {
+    enum bitLength : uint16_t {
         BITLENGTH_128 = 128,
         BITLENGTH_192 = 192,
         BITLENGTH_256 = 256

--- a/Source/interfaces/Definitions.vcxproj.filters
+++ b/Source/interfaces/Definitions.vcxproj.filters
@@ -1,12 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="Definitions.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="definitions.h" />
-  </ItemGroup>
-  <ItemGroup>
     <CustomBuild Include="json\DeviceInfo.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
@@ -23,9 +17,6 @@
       <Filter>Contracts</Filter>
     </CustomBuild>
     <CustomBuild Include="json\NetworkControl.json">
-      <Filter>Contracts</Filter>
-    </CustomBuild>
-    <CustomBuild Include="json\OCDM.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
     <CustomBuild Include="json\RemoteControl.json">
@@ -61,7 +52,14 @@
     <CustomBuild Include="json\Browser.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
+    <CustomBuild Include="json\IOConnector.json" />
     <CustomBuild Include="json\DHCPServer.json">
+      <Filter>Contracts</Filter>
+    </CustomBuild>
+    <CustomBuild Include="json\InputSwitch.json">
+      <Filter>Contracts</Filter>
+    </CustomBuild>
+    <CustomBuild Include="json\OCDM.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
     <CustomBuild Include="json\SecurityAgent.json">
@@ -72,9 +70,28 @@
     <Filter Include="Contracts">
       <UniqueIdentifier>{6975244d-cb23-4d09-a334-80cf1e1b4845}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{3c5d92bc-9901-475e-bb35-643cd2f2296b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{c5ebb452-1dd1-4410-9a69-da3188dc9cd5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="json\InputSwitch.json">
+    <ClCompile Include="Definitions.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="definitions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="json\Butler.json">
+      <Filter>Contracts</Filter>
+    </None>
+    <None Include="json\IOControl.json">
       <Filter>Contracts</Filter>
     </None>
   </ItemGroup>

--- a/Source/interfaces/IAVSClient.h
+++ b/Source/interfaces/IAVSClient.h
@@ -33,7 +33,7 @@ namespace Exchange {
             enum { ID = ID_AVSCONTROLLER_NOTIFICATION };
             virtual ~INotification(){}
 
-            enum dialoguestate {
+            enum dialoguestate : uint8_t {
                 IDLE,
                 LISTENING,
                 EXPECTING,

--- a/Source/interfaces/IComposition.h
+++ b/Source/interfaces/IComposition.h
@@ -34,7 +34,7 @@ namespace Exchange {
         static constexpr uint32_t maxZOrder = 255;
         static constexpr uint32_t minZOrder = 0;
 
-        enum ScreenResolution {
+        enum ScreenResolution : uint8_t {
             ScreenResolution_Unknown = 0,
             ScreenResolution_480i = 1,
             ScreenResolution_480p = 2,

--- a/Source/interfaces/IDisplayInfo.h
+++ b/Source/interfaces/IDisplayInfo.h
@@ -38,7 +38,7 @@ namespace Exchange {
 
         virtual ~IConnectionProperties() { }
 
-        enum HDRType {
+        enum HDRType : uint8_t {
             HDR_OFF,
             HDR_10,
             HDR_10PLUS,
@@ -46,7 +46,7 @@ namespace Exchange {
             HDR_TECHNICOLOR
         };
 
-        enum HDCPProtectionType {
+        enum HDCPProtectionType : uint8_t {
             HDCP_Unencrypted,
             HDCP_1X,
             HDCP_2X

--- a/Source/interfaces/IDsgccClient.h
+++ b/Source/interfaces/IDsgccClient.h
@@ -29,7 +29,7 @@ namespace Exchange {
 
         enum { ID = ID_DSGCC_CLIENT };
 
-        enum state {
+        enum state : uint8_t {
             Unknown = 0,
             Ready   = 1,
             Changed = 2,

--- a/Source/interfaces/IExternal.h
+++ b/Source/interfaces/IExternal.h
@@ -131,7 +131,7 @@ namespace Exchange {
         // it means that the module is not assigned. Any other number indicates that the 
         // IExternal is allocated to a module and should not be overwritten with an other
         // number than 0.
-        virtual void Module(const uint8_t module) = 0;
+        virtual uint32_t Module(const uint8_t module) = 0;
 
         // Characteristics of this element
         virtual uint32_t Type() const = 0;

--- a/Source/interfaces/IExternal.h
+++ b/Source/interfaces/IExternal.h
@@ -112,9 +112,9 @@ namespace Exchange {
         };
 
         enum condition : uint8_t {
-            constructing = 0x0000,
-            activated = 0x0001,
-            deactivated = 0x0002
+            constructing = 0x00,
+            activated    = 0x01,
+            deactivated  = 0x02
         };
 
         // Pushing notifications to interested sinks
@@ -147,23 +147,23 @@ namespace Exchange {
         virtual void Evaluate() = 0;
 
         // ------------------------------------------------------------------------
-        // Convenience methods to extract interesting information from the type
+        // Convenience methods to extract interesting information from the Type()
         // ------------------------------------------------------------------------
-        inline basic Basic() const
+        static basic Basic(const uint32_t instanceType)
         {
-            return (static_cast<basic>((Type() >> 12) & 0xF));
+            return (static_cast<basic>((instanceType >> 12) & 0xF));
         }
-        inline dimension Dimension() const
+        static dimension Dimension(const uint32_t instanceType)
         {
-            return (static_cast<dimension>((Type() >> 19) & 0x1FFF));
+            return (static_cast<dimension>((instanceType >> 19) & 0x1FFF));
         }
-        inline specific Specific() const
+        static specific Specific(const uint32_t instanceType)
         {
-            return (static_cast<specific>(Type() & 0xFFF));
+            return (static_cast<specific>(instanceType & 0xFFF));
         }
-        inline uint8_t Decimals() const
+        static uint8_t Decimals(const uint32_t instanceType)
         {
-            return ((Type() >> 16) & 0x07);
+            return ((instanceType >> 16) & 0x07);
         }
     };
 

--- a/Source/interfaces/IExternal.h
+++ b/Source/interfaces/IExternal.h
@@ -165,6 +165,9 @@ namespace Exchange {
         {
             return ((instanceType >> 16) & 0x07);
         }
+        static uint32_t Type(const basic base, const specific spec, const dimension dim, const uint8_t decimals) {
+            return ((dim << 19) | ((decimals & 0x07) << 16) | (base << 12) | spec);
+        }
     };
 
 } } // Namespace Exchange

--- a/Source/interfaces/IExternal.h
+++ b/Source/interfaces/IExternal.h
@@ -145,6 +145,26 @@ namespace Exchange {
 
         // Periodically we might like to be evaluated, call this method at a set time.
         virtual void Evaluate() = 0;
+
+        // ------------------------------------------------------------------------
+        // Convenience methods to extract interesting information from the type
+        // ------------------------------------------------------------------------
+        inline basic Basic() const
+        {
+            return (static_cast<basic>((Type() >> 12) & 0xF));
+        }
+        inline dimension Dimension() const
+        {
+            return (static_cast<dimension>((Type() >> 19) & 0x1FFF));
+        }
+        inline specific Specific() const
+        {
+            return (static_cast<specific>(Type() & 0xFFF));
+        }
+        inline uint8_t Decimals() const
+        {
+            return ((Type() >> 16) & 0x07);
+        }
     };
 
 } } // Namespace Exchange

--- a/Source/interfaces/IExternalBase.h
+++ b/Source/interfaces/IExternalBase.h
@@ -147,6 +147,26 @@ namespace Exchange {
 
     public:
         // ------------------------------------------------------------------------
+        // Convenience methods to extract interesting information from the type
+        // ------------------------------------------------------------------------
+        inline basic Basic() const
+        {
+            return (IExternal::Basic(_type));
+        }
+        inline dimension Dimension() const
+        {
+            return (IExternal::Dimension(_type));
+        }
+        inline specific Specific() const
+        {
+            return (IExternal::Specific(_type));
+        }
+        inline uint8_t Decimals() const
+        {
+            return (IExternal::Decimals(_type));
+        }
+
+        // ------------------------------------------------------------------------
         // Polling interface methods
         // ------------------------------------------------------------------------
         // Define the polling time in Seconds. This value has a maximum of a 24 hour.
@@ -215,6 +235,7 @@ namespace Exchange {
         {
             return (_type);
         }
+
         int32_t Minimum() const override
         {
             int32_t result = 0;

--- a/Source/interfaces/IExternalBase.h
+++ b/Source/interfaces/IExternalBase.h
@@ -140,7 +140,7 @@ namespace Exchange {
         #pragma warning(default : 4355)
         #endif
         inline ExternalBase(const uint32_t id, const basic base, const specific spec, const dimension dim, const uint8_t decimals)
-            : ExternalBase(id, ((dim << 19) | ((decimals & 0x07) << 16) | (base << 12) | spec))
+            : ExternalBase(id, IExternal::Type(base, spec, dim, decimals))
         {
         }
         ~ExternalBase() override = default;

--- a/Source/interfaces/IExternalBase.h
+++ b/Source/interfaces/IExternalBase.h
@@ -224,10 +224,11 @@ namespace Exchange {
         {
             return (_id);
         }
-        void Module(const uint8_t module) override
+        uint32_t Module(const uint8_t module) override
         {
-            ASSERT((module == 0) || ((_id & 0xFF000000) == 0));
+            ASSERT((module == 0) ^ ((_id & 0xFF000000) == 0));
             _id = (_id & 0x00FFFFFF) | (module << 24);
+            return (_id);
         }
 
         // Characteristics of this element

--- a/Source/interfaces/IExternalBase.h
+++ b/Source/interfaces/IExternalBase.h
@@ -147,26 +147,6 @@ namespace Exchange {
 
     public:
         // ------------------------------------------------------------------------
-        // Convenience methods to extract interesting information from the type
-        // ------------------------------------------------------------------------
-        inline basic Basic() const
-        {
-            return (static_cast<basic>((_type >> 12) & 0xF));
-        }
-        inline dimension Dimension() const
-        {
-            return (static_cast<dimension>((_type >> 19) & 0x1FFF));
-        }
-        inline specific Specific() const
-        {
-            return (static_cast<specific>(_type & 0xFFF));
-        }
-        inline uint8_t Decimals() const
-        {
-            return ((_type >> 16) & 0x07);
-        }
-
-        // ------------------------------------------------------------------------
         // Polling interface methods
         // ------------------------------------------------------------------------
         // Define the polling time in Seconds. This value has a maximum of a 24 hour.

--- a/Source/interfaces/IInputSwitch.h
+++ b/Source/interfaces/IInputSwitch.h
@@ -29,7 +29,7 @@ namespace Exchange {
 
         enum { ID = ID_INPUT_SWITCH };
 
-        enum mode {
+        enum mode : uint8_t {
             ENABLED,
             DISABLED,
             SLAVE

--- a/Source/interfaces/IKeyHandler.h
+++ b/Source/interfaces/IKeyHandler.h
@@ -29,7 +29,7 @@ namespace Exchange {
     struct IPointerProducer;
     struct ITouchProducer;
 
-    enum ProducerEvents {
+    enum ProducerEvents : uint8_t {
         PairingStarted = 1,
         PairingSuccess,
         PairingFailed,
@@ -77,7 +77,7 @@ namespace Exchange {
 
         virtual ~ITouchHandler(){};
 
-        enum class touchstate {
+        enum class touchstate : uint8_t {
             TOUCH_MOTION,
             TOUCH_RELEASED,
             TOUCH_PRESSED

--- a/Source/interfaces/IMemory.h
+++ b/Source/interfaces/IMemory.h
@@ -29,7 +29,7 @@ namespace Exchange {
 
     // This interface allows for retrieval of memory usage specific to the implementor
     // of the interface
-    struct IMemory : virtual public Core::IUnknown {
+    struct EXTERNAL IMemory : virtual public Core::IUnknown {
         enum { ID = ID_MEMORY };
         virtual ~IMemory() {}
 

--- a/Source/interfaces/INetflix.h
+++ b/Source/interfaces/INetflix.h
@@ -30,7 +30,7 @@ namespace Exchange {
 
         enum { ID = ID_NETFLIX };
 
-        enum state {
+        enum state : uint16_t {
             PLAYING = 0x0001,
             STOPPED = 0x0002,
             SUSPENDING = 0x0004

--- a/Source/interfaces/IPackager.h
+++ b/Source/interfaces/IPackager.h
@@ -27,7 +27,7 @@ namespace Exchange {
     struct IPackager : virtual public Core::IUnknown {
         enum { ID = ID_PACKAGER };
 
-        enum state {
+        enum state : uint8_t {
             IDLE,
             DOWNLOADING,
             DOWNLOADED,

--- a/Source/interfaces/IPower.h
+++ b/Source/interfaces/IPower.h
@@ -28,7 +28,7 @@ namespace Exchange {
     struct IPower : virtual public Core::IUnknown {
         enum { ID = ID_POWER };
 
-        enum PCState {
+        enum PCState : uint8_t {
             On = 1, // S0.
             ActiveStandby = 2, // S1.
             PassiveStandby = 3, // S2.

--- a/Source/interfaces/IStream.h
+++ b/Source/interfaces/IStream.h
@@ -29,7 +29,7 @@ namespace Exchange {
     struct IStream : virtual public Core::IUnknown {
         enum { ID = ID_STREAM };
 
-        enum class state {
+        enum class state : uint8_t {
             Idle = 0,
             Loading,
             Prepared,
@@ -37,7 +37,7 @@ namespace Exchange {
             Error
         };
 
-        enum class streamtype {
+        enum class streamtype : uint8_t {
             Undefined = 0,
             Cable = 1,
             Handheld = 2,
@@ -50,7 +50,7 @@ namespace Exchange {
             IP = 96
        };
 
-        enum class drmtype {
+        enum class drmtype : uint8_t {
             None = 0,
             ClearKey,
             PlayReady,
@@ -73,7 +73,7 @@ namespace Exchange {
                 virtual IElement* Current() = 0;
             };
 
-            enum class type {
+            enum class type : uint8_t {
                 Unknown = 0,
                 Audio,
                 Video,

--- a/Source/interfaces/ITimeSync.h
+++ b/Source/interfaces/ITimeSync.h
@@ -28,7 +28,7 @@ namespace WPEFramework {
 namespace Exchange {
 
     // This interface gives direct access to a time synchronize / update
-    struct ITimeSync : virtual public Core::IUnknown {
+    struct EXTERNAL ITimeSync : virtual public Core::IUnknown {
         enum { ID = ID_TIMESYNC };
 
         struct INotification : virtual public Core::IUnknown {

--- a/Source/interfaces/Interfaces.vcxproj.filters
+++ b/Source/interfaces/Interfaces.vcxproj.filters
@@ -1,0 +1,196 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="ProxyStubs_AVNClient.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Browser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Composition.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_ContentDecryption.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_DsgccClient.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Guide.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Netflix.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Packager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Performance.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_PlayGiga.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Power.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Provisioning.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_RPCLink.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_RtspClient.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Stream.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_TestController.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_TestUtility.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_WebDriver.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_WebPA.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_WebServer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProxyStubs_Dictionary.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{08108e2f-1ffd-48e0-89d9-23f5409dc0eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{4ee0c8e4-3ba3-4683-8c6f-23463d09d9d7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Interface Files">
+      <UniqueIdentifier>{379b5f39-b7a5-466c-bd91-4f42b78a78bb}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Module.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IBrowser.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ICommand.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IDictionary.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IMemory.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="INetflix.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ISwitchBoard.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IWebServer.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IComposition.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IKeyHandler.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IProvisioning.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ITimeSync.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IVoiceHandler.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IWebDriver.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IRPCLink.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IAVNClient.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IBluetooth.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ICapture.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IContentDecryption.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IDRM.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IDsgccClient.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IExternal.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IGuide.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IIPNetwork.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IPackager.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IPerformance.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IPlayGiga.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IPower.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IRtspClient.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IStreaming.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ISystemCommands.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ITestController.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Ids.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IAVSClient.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IDisplayInfo.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IInputSwitch.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IStream.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="DataModel.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/Source/interfaces/interfaces.vcxproj
+++ b/Source/interfaces/interfaces.vcxproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IAVNClient.h" />
+    <ClInclude Include="IAVSClient.h" />
     <ClInclude Include="IBluetooth.h" />
     <ClInclude Include="IBrowser.h" />
     <ClInclude Include="ICapture.h" />
@@ -56,11 +57,13 @@
     <ClInclude Include="IComposition.h" />
     <ClInclude Include="IContentDecryption.h" />
     <ClInclude Include="IDictionary.h" />
+    <ClInclude Include="IDisplayInfo.h" />
     <ClInclude Include="IDRM.h" />
     <ClInclude Include="Ids.h" />
     <ClInclude Include="IDsgccClient.h" />
     <ClInclude Include="IExternal.h" />
     <ClInclude Include="IGuide.h" />
+    <ClInclude Include="IInputSwitch.h" />
     <ClInclude Include="IIPNetwork.h" />
     <ClInclude Include="IKeyHandler.h" />
     <ClInclude Include="IMemory.h" />
@@ -72,6 +75,7 @@
     <ClInclude Include="IProvisioning.h" />
     <ClInclude Include="IRPCLink.h" />
     <ClInclude Include="IRtspClient.h" />
+    <ClInclude Include="IStream.h" />
     <ClInclude Include="IStreaming.h" />
     <ClInclude Include="ISwitchBoard.h" />
     <ClInclude Include="ISystemCommands.h" />

--- a/Source/ocdm/IOCDM.h
+++ b/Source/ocdm/IOCDM.h
@@ -26,7 +26,7 @@
 
 namespace OCDM {
 
-typedef enum {
+typedef enum : uint32_t {
     OCDM_SUCCESS = 0,
     OCDM_S_FALSE = 1,
     OCDM_KEYSYSTEM_NOT_SUPPORTED = 0x80000002,
@@ -43,7 +43,7 @@ typedef enum {
 // ISession defines the interface towards a DRM context that can decrypt data
 // using a given key.
 struct ISession : virtual public WPEFramework::Core::IUnknown {
-    enum KeyStatus {
+    enum KeyStatus : uint32_t {
         Usable = 0,
         Expired,
         Released,

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -51,7 +51,7 @@ namespace PluginHost {
         }
 
         // State of the IPlugin interface associated with this shell.
-        enum state {
+        enum state : uint8_t {
             DEACTIVATED,
             DEACTIVATION,
             ACTIVATED,
@@ -60,7 +60,7 @@ namespace PluginHost {
             DESTROYED
         };
 
-        enum reason {
+        enum reason : uint8_t {
             REQUESTED,
             AUTOMATIC,
             FAILURE,

--- a/Source/plugins/IStateControl.h
+++ b/Source/plugins/IStateControl.h
@@ -35,12 +35,12 @@ namespace PluginHost {
             ID = RPC::ID_STATECONTROL
         };
 
-        enum command {
+        enum command : uint16_t {
             SUSPEND = 0x0001,
             RESUME = 0x0002
         };
 
-        enum state {
+        enum state : uint16_t {
             UNINITIALIZED = 0x0000,
             SUSPENDED = 0x0001,
             RESUMED = 0x0002,

--- a/Source/plugins/ISubSystem.h
+++ b/Source/plugins/ISubSystem.h
@@ -26,8 +26,7 @@ namespace WPEFramework {
 namespace PluginHost {
 
     // This interface gives direct access to a switchboard
-    struct ISubSystem
-        : virtual public Core::IUnknown {
+    struct EXTERNAL ISubSystem : virtual public Core::IUnknown {
         enum {
             ID = RPC::ID_SUBSYSTEM
         };
@@ -65,7 +64,7 @@ namespace PluginHost {
             NOT_BLUETOOTH // The Bluetooth communication system is NOT available.
         };
 
-        struct INotification
+        struct EXTERNAL INotification
             : virtual public Core::IUnknown {
 
             enum {
@@ -81,7 +80,7 @@ namespace PluginHost {
         };
 
         /* @stubgen:omit */
-        struct ISecurity
+        struct EXTERNAL ISecurity
             : virtual public Core::IUnknown {
 
             enum {
@@ -97,7 +96,7 @@ namespace PluginHost {
         };
 
         /* @stubgen:omit */
-        struct IInternet
+        struct EXTERNAL IInternet
             : virtual public Core::IUnknown {
 
             enum {
@@ -123,7 +122,7 @@ namespace PluginHost {
 
         /* @stubgen:omit */
         // Location information
-        struct ILocation
+        struct EXTERNAL ILocation
             : virtual public Core::IUnknown {
 
             enum {
@@ -142,7 +141,7 @@ namespace PluginHost {
 
         /* @stubgen:omit */
         // Device specific identification.
-        struct IIdentifier
+        struct EXTERNAL IIdentifier
             : virtual public Core::IUnknown {
 
             enum {
@@ -158,7 +157,7 @@ namespace PluginHost {
 
         /* @stubgen:omit */
         // Time synchronisation reporting
-        struct ITime
+        struct EXTERNAL ITime
             : virtual public Core::IUnknown {
 
             enum {
@@ -174,7 +173,7 @@ namespace PluginHost {
 
         /* @stubgen:omit */
         // IProvisioning reporting
-        struct IProvisioning : public RPC::IStringIterator {
+        struct EXTERNAL IProvisioning : public RPC::IStringIterator {
 
             enum {
                 SUBSYSTEM = PROVISIONING
@@ -183,16 +182,14 @@ namespace PluginHost {
 
         /* @stubgen:omit */
         // Decryption reporting
-        struct IDecryption : public RPC::IStringIterator {
+        struct EXTERNAL IDecryption : public RPC::IStringIterator {
 
             enum {
                 SUBSYSTEM = DECRYPTION
             };
         };
 
-        virtual ~ISubSystem()
-        {
-        }
+        virtual ~ISubSystem() = default;
 
         virtual void Register(ISubSystem::INotification* notification) = 0;
         virtual void Unregister(ISubSystem::INotification* notification) = 0;

--- a/Source/plugins/VirtualInput.h
+++ b/Source/plugins/VirtualInput.h
@@ -868,7 +868,7 @@ namespace PluginHost {
         {
             ASSERT(_keyHandler == nullptr);
 #if defined(__WINDOWS__) || defined(__APPLE__)
-            ASSERT(t == VIRTUAL)
+            ASSERT(t == VIRTUAL);
             _keyHandler = new PluginHost::IPCUserInput(Core::NodeId(locator.c_str()), enabled);
             TRACE_L1("Creating a IPC Channel for key communication. %d", 0);
 #else


### PR DESCRIPTION
On windows the ProxyStub generation warnings are more visible and thus for portability
it is good to define the size of the enum (at least in the interfaces (for the PS binary
transfer) to be exact over host boundaries.