### PR TITLE
Compositor: JSON error firstresourcenotfound changed to unavailable

### DIFF
--- a/Source/interfaces/json/Compositor.json
+++ b/Source/interfaces/json/Compositor.json
@@ -101,7 +101,7 @@
       "errors": [
         {
           "description": "Client not found",
-          "$ref": "#/common/errors/firstresourcenotfound"
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
@@ -124,7 +124,7 @@
       "errors": [
         {
           "description": "Client not found",
-          "$ref": "#/common/errors/firstresourcenotfound"
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
@@ -145,7 +145,7 @@
       "errors": [
         {
           "description": "Client not found",
-          "$ref": "#/common/errors/firstresourcenotfound"
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     }
@@ -173,7 +173,7 @@
       "errors": [
         {
           "description": "Client not found",
-          "$ref": "#/common/errors/firstresourcenotfound"
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
@@ -205,7 +205,7 @@
       "errors": [
         {
           "description": "Client(s) not found",
-          "$ref": "#/common/errors/firstresourcenotfound"
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
@@ -231,7 +231,7 @@
       "errors": [
         {
           "description": "Client not found",
-          "$ref": "#/common/errors/firstresourcenotfound"
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     }


### PR DESCRIPTION
Currently the JSON error value used in Compositor when the client not found case is ERROR_FIRST_RESOURCE_NOT_FOUND. Changed to use ERROR_UNAVAILABLE instead that when the client is not found.