### PR TITLE
[DEPENDENCY CLEANUP] Correct the dependencies for interfaces and modu…

### DIFF
--- a/Source/WPEFramework/Module.h
+++ b/Source/WPEFramework/Module.h
@@ -17,24 +17,18 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_FRAMEWORK_APPLICATION_H
-#define __MODULE_FRAMEWORK_APPLICATION_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Application
 #endif
 
-#include "../core/core.h"
-#include "../cryptalgo/cryptalgo.h"
-#include "../plugins/plugins.h"
-#include "../tracing/tracing.h"
-#include "../websocket/websocket.h"
-
-#undef EXTERNAL
-#define EXTERNAL EXTERNAL_EXPORT
+#include <core/core.h>
+#include <cryptalgo/cryptalgo.h>
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+#include <websocket/websocket.h>
 
 #ifndef TREE_REFERENCE
 #define TREE_REFERENCE engineering_build_for_debug_purpose_only
 #endif
-
-#endif // __MODULE_FRAMEWORK_APPLICATION_H

--- a/Source/WPEFramework/Module.h
+++ b/Source/WPEFramework/Module.h
@@ -32,3 +32,6 @@
 #ifndef TREE_REFERENCE
 #define TREE_REFERENCE engineering_build_for_debug_purpose_only
 #endif
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -51,7 +51,7 @@ namespace Plugin {
 }
 
 namespace PluginHost {
-    class EXTERNAL Server {
+    class Server {
     private:
         Server() = delete;
         Server(const Server&) = delete;
@@ -337,7 +337,7 @@ namespace PluginHost {
         };
 
     private:
-        class EXTERNAL WorkerPoolImplementation : public Core::WorkerPool {
+        class WorkerPoolImplementation : public Core::WorkerPool {
         public:
             WorkerPoolImplementation() = delete;
             WorkerPoolImplementation(const WorkerPoolImplementation&) = delete;
@@ -352,7 +352,7 @@ namespace PluginHost {
             }
         };
 
-        class EXTERNAL FactoriesImplementation : public IFactories {
+        class FactoriesImplementation : public IFactories {
         private:
             FactoriesImplementation(const FactoriesImplementation&) = delete;
             FactoriesImplementation& operator=(const FactoriesImplementation&) = delete;
@@ -398,7 +398,7 @@ namespace PluginHost {
         friend class Plugin::Controller;
 
         // Trace class for internal information of the PluginHost
-        class EXTERNAL Activity {
+        class Activity {
         private:
             // -------------------------------------------------------------------
             // This object should not be copied or assigned. Prevent the copy
@@ -439,7 +439,7 @@ namespace PluginHost {
         private:
             std::string _text;
         };
-        class EXTERNAL WebFlow {
+        class WebFlow {
         private:
             // -------------------------------------------------------------------
             // This object should not be copied or assigned. Prevent the copy
@@ -489,7 +489,7 @@ namespace PluginHost {
         private:
             std::string _text;
         };
-        class EXTERNAL SocketFlow {
+        class SocketFlow {
         private:
             // -------------------------------------------------------------------
             // This object should not be copied or assigned. Prevent the copy
@@ -529,7 +529,7 @@ namespace PluginHost {
         private:
             std::string _text;
         };
-        class EXTERNAL TextFlow {
+        class TextFlow {
         private:
             // -------------------------------------------------------------------
             // This object should not be copied or assigned. Prevent the copy
@@ -564,7 +564,7 @@ namespace PluginHost {
             std::string _text;
         };
 
-        class EXTERNAL Service : public PluginHost::Service {
+        class Service : public PluginHost::Service {
         private:
             Service() = delete;
             Service(const Service&) = delete;
@@ -1193,7 +1193,7 @@ namespace PluginHost {
             static Core::ProxyType<Web::Response> _unavailableHandler;
             static Core::ProxyType<Web::Response> _missingHandler;
         };
-        class EXTERNAL ServiceMap : public PluginHost::IShell::ICOMLink {
+        class ServiceMap : public PluginHost::IShell::ICOMLink {
         public:
             typedef Core::IteratorMapType<std::map<const string, Core::ProxyType<Service>>, Core::ProxyType<Service>, const string&> Iterator;
             typedef std::map<const string, IRemoteInstantiation*> RemoteInstantiators;
@@ -1205,7 +1205,7 @@ namespace PluginHost {
 
             class CommunicatorServer : public RPC::Communicator {
             private:
-                class EXTERNAL RemoteHost : public RPC::Communicator::RemoteConnection {
+                class RemoteHost : public RPC::Communicator::RemoteConnection {
                 private:
                     friend class Core::Service<RemoteHost>;
 
@@ -2081,9 +2081,9 @@ namespace PluginHost {
         // Links. A Channel is identified by an ID, this way, whenever a link dies
         // (is closed) during the service process, the ChannelMap will
         // not find it and just "flush" the presented work.
-        class EXTERNAL Channel : public PluginHost::Channel {
+        class Channel : public PluginHost::Channel {
         private:
-            class EXTERNAL Job : public Core::IDispatch {
+            class Job : public Core::IDispatch {
             public:
                 Job() = delete;
                 Job(const Job&) = delete;
@@ -2157,7 +2157,7 @@ namespace PluginHost {
                 Server* _server;
                 Core::ProxyType<Service> _service;
             };
-            class EXTERNAL WebRequestJob : public Job {
+            class WebRequestJob : public Job {
             public:
                 WebRequestJob() = delete;
                 WebRequestJob(const WebRequestJob&) = delete;
@@ -2259,7 +2259,7 @@ namespace PluginHost {
 
                 static Core::ProxyType<Web::Response> _missingResponse;
             };
-            class EXTERNAL JSONElementJob : public Job {
+            class JSONElementJob : public Job {
             public:
                 JSONElementJob() = delete;
                 JSONElementJob(const JSONElementJob&) = delete;
@@ -2320,7 +2320,7 @@ namespace PluginHost {
                 string _token;
                 bool _jsonrpc;
             };
-            class EXTERNAL TextJob : public Job {
+            class TextJob : public Job {
             public:
                 TextJob() = delete;
                 TextJob(const TextJob&) = delete;
@@ -2780,7 +2780,7 @@ namespace PluginHost {
             // whatever reason, we will report back that the request is unauthorized.
             static Core::ProxyType<Web::Response> _unauthorizedRequest;
         };
-        class EXTERNAL ChannelMap : public Core::SocketServerType<Channel> {
+        class ChannelMap : public Core::SocketServerType<Channel> {
         private:
             typedef Core::SocketServerType<Channel> BaseClass;
 

--- a/Source/WPEFramework/bridge.vcxproj
+++ b/Source/WPEFramework/bridge.vcxproj
@@ -130,7 +130,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;THREADPOOL_COUNT=4;HOSTING_COMPROCESS=comprocess.exe;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -152,7 +152,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;THREADPOOL_COUNT=4;HOSTING_COMPROCESS=comprocess.exe;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -172,7 +172,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;THREADPOOL_COUNT=4;HOSTING_COMPROCESS=comprocess.exe;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -194,7 +194,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;THREADPOOL_COUNT=4;HOSTING_COMPROCESS=comprocess.exe;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Source/WPEProcess/Module.h
+++ b/Source/WPEProcess/Module.h
@@ -17,19 +17,12 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_PROCESS_H
-#define __MODULE_PROCESS_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Process
 #endif
 
-#include "../com/com.h"
-#include "../core/core.h"
-#include "../plugins/plugins.h"
-
-#ifdef EXTERNAL
-#undef EXTERNAL
-#endif
-
-#endif // __MODULE_PROCESS_H
+#include <core/core.h>
+#include <com/com.h>
+#include <plugins/plugins.h>

--- a/Source/WPEProcess/comprocess.vcxproj
+++ b/Source/WPEProcess/comprocess.vcxproj
@@ -110,7 +110,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -129,7 +129,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,7 +146,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -165,7 +165,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Source/bluetooth/Module.h
+++ b/Source/bluetooth/Module.h
@@ -17,15 +17,14 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_BLUETOOTH_H
-#define __MODULE_BLUETOOTH_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Bluetooth 
 #endif
 
-#include "../core/core.h"
-#include "../tracing/tracing.h"
+#include <core/core.h>
+#include <tracing/tracing.h>
 
 #include <../include/bluetooth/bluetooth.h>
 #include <../include/bluetooth/hci.h>
@@ -33,16 +32,8 @@
 #include <../include/bluetooth/mgmt.h>
 #include <../include/bluetooth/l2cap.h>
 
+#if defined(__WINDOWS__) && defined(BLUETOOTH_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef BLUETOOTH_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_BLUETOOTH_H

--- a/Source/broadcast/Module.h
+++ b/Source/broadcast/Module.h
@@ -17,25 +17,16 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_BROADCAST_H
-#define __MODULE_BROADCAST_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Broadcast
 #endif
 
-#include "../core/core.h"
+#include <core/core.h>
 
+#if defined(__WINDOWS__) && defined(BROADCAST_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef __MODULE_BROADCAST__
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_BROADCAST_H

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -20,10 +20,11 @@
 #ifndef __COM_PROCESSLAUNCH_H
 #define __COM_PROCESSLAUNCH_H
 
+#include "Module.h"
+#include "Ids.h"
 #include "Administrator.h"
 #include "ITracing.h"
 #include "IUnknown.h"
-#include "Module.h"
 
 #ifdef PROCESSCONTAINERS_ENABLED
 #include "../processcontainers/ProcessContainer.h"

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -20,9 +20,10 @@
 #ifndef __COM_IUNKNOWN_H
 #define __COM_IUNKNOWN_H
 
+#include "Module.h"
+#include "Ids.h"
 #include "Administrator.h"
 #include "Messages.h"
-#include "Module.h"
 
 namespace WPEFramework {
 

--- a/Source/com/Module.h
+++ b/Source/com/Module.h
@@ -17,27 +17,16 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_COM_H__
-#define __MODULE_COM_H__
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME COM
 #endif
 
-#include "../core/core.h"
-#include "../tracing/tracing.h"
-#include "Ids.h"
+#include <core/core.h>
+#include <tracing/tracing.h>
 
+#if defined(__WINDOWS__) && defined(COM_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef COM_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
-
-#endif // __MODULE_COM_H__

--- a/Source/com/com.vcxproj
+++ b/Source/com/com.vcxproj
@@ -125,7 +125,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;COM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -146,7 +146,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;COM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -165,7 +165,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;COM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -186,7 +186,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;COM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/com/com.vcxproj.filters
+++ b/Source/com/com.vcxproj.filters
@@ -1,74 +1,60 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
     <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+      <UniqueIdentifier>{ff50d913-1df9-499d-837e-31005085670f}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{fb199d9a-32f6-4dc3-830b-7b253f93388c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Administrator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Communicator.cpp">
+    <ClCompile Include="IUnknown.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ITracing.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="IUnknown.cpp">
+    <ClCompile Include="Communicator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Module.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ProxyStubs_Communicator.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ProxyStubs_StringIterator.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ProxyStubs_ValueIterator.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClCompile Include="ProxyStubs_Communicator.cpp" />
+    <ClCompile Include="ProxyStubs_StringIterator.cpp" />
+    <ClCompile Include="ProxyStubs_ValueIterator.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Administrator.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="com.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Communicator.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Ids.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="IStringIterator.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ITracing.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="IUnknown.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="IValueIterator.h">
+    <ClInclude Include="Module.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Messages.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Module.h">
+    <ClInclude Include="Administrator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ITracing.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Communicator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IStringIterator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="com.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Ids.h" />
+    <ClInclude Include="IValueIterator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source/compositorclient/Module.h
+++ b/Source/compositorclient/Module.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_COMPOSITION_CLIENT_H
-#define __MODULE_COMPOSITION_CLIENT_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Composition_Client
@@ -27,7 +26,8 @@
 #include <core/core.h>
 #include <tracing/tracing.h>
 
+#if defined(__WINDOWS__) && defined(COMPOSITORCLIENT_EXPORTS)
 #undef EXTERNAL
 #define EXTERNAL EXTERNAL_EXPORT
+#endif
 
-#endif // __MODULE_COMPOSITION_CLIENT_H

--- a/Source/core/DoorBell.h
+++ b/Source/core/DoorBell.h
@@ -24,7 +24,6 @@
 #include "SocketPort.h"
 #include "Sync.h"
 
-
 namespace WPEFramework {
 namespace Core {
 

--- a/Source/core/Module.h
+++ b/Source/core/Module.h
@@ -17,23 +17,14 @@
  * limitations under the License.
  */
  
-#ifndef __MODULE_CORE_H
-#define __MODULE_CORE_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Core
 #endif
 
+#if defined(__WINDOWS__) && defined(CORE_EXPORTS)
 #undef EXTERNAL
-
-#ifdef _WINDOWS
-#ifdef CORE_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_CORE_H

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -63,7 +63,7 @@
 #define B4000000 4000000
 #endif
 
-#if defined WIN32 || defined _WINDOWS || defined __CYGWIN__
+#if defined(WIN32) || defined(_WINDOWS) || defined (__CYGWIN__)
     #ifdef __GNUC__
         #define EXTERNAL        __attribute__ ((dllimport))
         #define EXTERNAL_EXPORT __attribute__ ((dllexport))
@@ -71,6 +71,12 @@
         #define EXTERNAL        __declspec(dllimport) 
         #define EXTERNAL_EXPORT __declspec(dllexport)
     #endif
+
+    #if defined(CORE_EXPORTS)
+    #undef EXTERNAL
+    #define EXTERNAL EXTERNAL_EXPORT
+    #endif
+
     #define EXTERNAL_HIDDEN
 #else
   #if __GNUC__ >= 4 && !defined(__mips__)
@@ -197,6 +203,7 @@ typedef std::string string;
 #define KEY_RIGHTALT VK_RMENU
 #define KEY_LEFTCTRL VK_LCONTROL
 #define KEY_RIGHTCTRL VK_RCONTROL
+#undef INPUT_MOUSE
 
 // This is an HTTP keyword (VERB) Let's undefine it from windows headers..
 #define _CRT_SECURE_NO_WARNINGS 1
@@ -499,8 +506,6 @@ typedef HANDLE ThreadId;
 
 #define QUOTE(str) #str
 #define EXPAND_AND_QUOTE(str) QUOTE(str)
-
-#include "Module.h"
 
 extern "C" {
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -65,22 +65,21 @@
 
 #if defined WIN32 || defined _WINDOWS || defined __CYGWIN__
     #ifdef __GNUC__
-        #define EXTERNAL_IMPORT __attribute__ ((dllimport))
+        #define EXTERNAL        __attribute__ ((dllimport))
         #define EXTERNAL_EXPORT __attribute__ ((dllexport))
     #else
-        #define EXTERNAL_IMPORT __declspec(dllimport) 
+        #define EXTERNAL        __declspec(dllimport) 
         #define EXTERNAL_EXPORT __declspec(dllexport)
     #endif
     #define EXTERNAL_HIDDEN
 #else
   #if __GNUC__ >= 4 && !defined(__mips__)
-    #define EXTERNAL_IMPORT __attribute__ ((visibility ("hidden")))
-    #define EXTERNAL_EXPORT __attribute__ ((visibility ("default")))
+    #define EXTERNAL_HIDDEN __attribute__ ((visibility ("hidden")))
+    #define EXTERNAL        __attribute__ ((visibility ("default")))
   #else
-    #define EXTERNAL_EXPORT
-    #define EXTERNAL_IMPORT
+    #define EXTERNAL
+    #define EXTERNAL_HIDDEN
   #endif
-  #define EXTERNAL_HIDDEN EXTERNAL_IMPORT
 #endif
 
 #if defined WIN32 || defined _WINDOWS
@@ -350,8 +349,8 @@ int clock_gettime(int, struct timespec*);
 
 #define ALLOCA alloca
 
-extern void EXTERNAL_EXPORT SleepMs(unsigned int a_Time);
-inline void EXTERNAL_EXPORT SleepS(unsigned int a_Time)
+extern void EXTERNAL SleepMs(unsigned int a_Time);
+inline void EXTERNAL SleepS(unsigned int a_Time)
 {
     ::SleepMs(a_Time * 1000);
 }

--- a/Source/core/core.vcxproj
+++ b/Source/core/core.vcxproj
@@ -203,7 +203,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32;_DEBUG;CORE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CORE_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions);</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
@@ -219,7 +219,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;DEBUG;CORE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CORE_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
@@ -237,7 +237,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;IN32;NDEBUG;CORE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CORE_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;IN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
@@ -257,7 +257,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;DEBUG;CORE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CORE_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>

--- a/Source/cryptalgo/Module.h
+++ b/Source/cryptalgo/Module.h
@@ -17,25 +17,16 @@
  * limitations under the License.
  */
  
-#ifndef __MODULE_CRYPTALGO_H
-#define __MODULE_CRYPTALGO_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Crypto
 #endif
 
-#include "../core/core.h"
+#include <core/core.h>
 
+#if defined(__WINDOWS__) && defined(CRYPTALGO_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef CRYPTALGO_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_CRYPTALGO_H

--- a/Source/cryptalgo/cryptalgo.vcxproj
+++ b/Source/cryptalgo/cryptalgo.vcxproj
@@ -122,7 +122,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;CRYPTALGO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,7 +141,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;CRYPTALGO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -158,7 +158,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;CRYPTALGO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -177,7 +177,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;CRYPTALGO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/cryptography/Module.h
+++ b/Source/cryptography/Module.h
@@ -26,7 +26,7 @@
 #include <core/core.h>
 #include <tracing/tracing.h>
 
-#include <climits>
-
+#if defined(__WINDOWS__) && defined(CRYPTOGRAPHY_EXPORTS)
 #undef EXTERNAL
-#define EXTERNAL EXTERNAL_IMPORT
+#define EXTERNAL EXTERNAL_EXPORT
+#endif

--- a/Source/interfaces/Definitions.vcxproj
+++ b/Source/interfaces/Definitions.vcxproj
@@ -190,6 +190,15 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="json\Butler.json">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </CustomBuild>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{577A83B6-66B6-4A98-A3D6-4EBA066A1772}</ProjectGuid>

--- a/Source/interfaces/Definitions.vcxproj.filters
+++ b/Source/interfaces/Definitions.vcxproj.filters
@@ -52,7 +52,6 @@
     <CustomBuild Include="json\Browser.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
-    <CustomBuild Include="json\IOConnector.json" />
     <CustomBuild Include="json\DHCPServer.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
@@ -63,6 +62,9 @@
       <Filter>Contracts</Filter>
     </CustomBuild>
     <CustomBuild Include="json\SecurityAgent.json">
+      <Filter>Contracts</Filter>
+    </CustomBuild>
+    <CustomBuild Include="json\IOConnector.json">
       <Filter>Contracts</Filter>
     </CustomBuild>
   </ItemGroup>
@@ -89,9 +91,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="json\Butler.json">
-      <Filter>Contracts</Filter>
-    </None>
-    <None Include="json\IOControl.json">
       <Filter>Contracts</Filter>
     </None>
   </ItemGroup>

--- a/Source/interfaces/Module.h
+++ b/Source/interfaces/Module.h
@@ -17,21 +17,22 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_INTERFACES_PROXYSTUBS_H
-#define __MODULE_INTERFACES_PROXYSTUBS_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Interfaces
 #endif
 
-#include "../core/core.h"
-#include "../com/com.h"
-#include "../plugins/IPlugin.h"
-#include "../plugins/IShell.h"
-#include "../plugins/ISubSystem.h"
+#include <core/core.h>
+#include <com/com.h>
+#include <plugins/IPlugin.h>
+#include <plugins/IShell.h>
+#include <plugins/IStateControl.h>
+#include <plugins/ISubSystem.h>
 #include "Ids.h"
 
+#if defined(__WINDOWS__) && defined(INTERFACES_EXPORTS)
 #undef EXTERNAL
 #define EXTERNAL EXTERNAL_EXPORT
+#endif
 
-#endif // __MODULE_INTERFACES_PROXYSTUB_H

--- a/Source/interfaces/definitions.h
+++ b/Source/interfaces/definitions.h
@@ -30,17 +30,13 @@
 #include "IVoiceHandler.h"
 #include "IPower.h"
 
+#if defined(__WINDOWS__) 
+#if defined(DEFINITIONS_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef DEFINITIONS_EXPORTS
 #define EXTERNAL EXTERNAL_EXPORT
 #else
-#define EXTERNAL EXTERNAL_IMPORT
 #pragma comment(lib, "definitions.lib")
 #endif
-#else
-#define EXTERNAL EXTERNAL_EXPORT
 #endif
 
 namespace WPEFramework {

--- a/Source/interfaces/interfaces.vcxproj
+++ b/Source/interfaces/interfaces.vcxproj
@@ -181,7 +181,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;INTERFACES_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -213,7 +213,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;INTERFACES_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -243,7 +243,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;INTERFACES_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -275,7 +275,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;INTERFACES_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/interfaces/interfaces.vcxproj
+++ b/Source/interfaces/interfaces.vcxproj
@@ -62,6 +62,7 @@
     <ClInclude Include="Ids.h" />
     <ClInclude Include="IDsgccClient.h" />
     <ClInclude Include="IExternal.h" />
+    <ClInclude Include="IExternalBase.h" />
     <ClInclude Include="IGuide.h" />
     <ClInclude Include="IInputSwitch.h" />
     <ClInclude Include="IIPNetwork.h" />

--- a/Source/ocdm/DataExchange.h
+++ b/Source/ocdm/DataExchange.h
@@ -21,7 +21,7 @@
 #define __DATAEXCHANGE_H
 
 // ---- Include local include files ----
-#include <core/core.h>
+#include "Module.h"
 
 // ---- Referenced classes and types ----
 

--- a/Source/ocdm/IOCDM.h
+++ b/Source/ocdm/IOCDM.h
@@ -21,8 +21,7 @@
 #define __IOPENCDMI_H
 
 #include "Module.h"
-#include <com/com.h>
-#include <core/core.h>
+#include "DataExchange.h"
 
 namespace OCDM {
 

--- a/Source/ocdm/Module.h
+++ b/Source/ocdm/Module.h
@@ -17,26 +17,17 @@
  * limitations under the License.
  */
  
-#ifndef __MODULE_OCDMINTERFACE_H
-#define __MODULE_OCDMINTERFACE_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME OpenCDM
 #endif
 
-#include "../core/core.h"
-#include "../com/com.h"
+#include <core/core.h>
+#include <com/com.h>
 
+#if defined(__WINDOWS__) && defined(OCDM_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef OCDM_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_OCDMINTERFACE_H

--- a/Source/ocdm/ocdm.vcxproj
+++ b/Source/ocdm/ocdm.vcxproj
@@ -116,7 +116,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;OCDM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -140,7 +140,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;OCDM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -162,7 +162,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;OCDM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -186,7 +186,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;OCDM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
+#include "Module.h"
 #include "open_cdm.h"
 #include "DataExchange.h"
 #include "IOCDM.h"
-#include "Module.h"
 #include "open_cdm_impl.h"
 
 MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/Source/ocdm/open_cdm.h
+++ b/Source/ocdm/open_cdm.h
@@ -60,32 +60,35 @@
 #include <stdio.h>
 #include <list>
 
+#ifndef EXTERNAL
 #ifdef _MSVC_LANG
-#undef EXTERNAL
 #ifdef OCDM_EXPORTS
 #define EXTERNAL __declspec(dllexport)
 #else
 #define EXTERNAL __declspec(dllimport)
-#pragma comment(lib, "ocdm.lib")
 #endif
-
-/**
- * Sometimes the compiler would like to be smart, if we do not reference
- * anything here
- * and you enable the rightflags, the linker drops the dependency. Than
- * Proxy/Stubs do
- * not get loaded, so lets make the instantiation of the ProxyStubs explicit !!!
- */
-extern "C" {
-EXTERNAL void ForceLinkingOfOpenCDM();
-}
-
 #else
 #define EXTERNAL __attribute__ ((visibility ("default")))
+#endif
 #endif
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#if defined(_WINDOWS) 
+    #if !defined(OCDM_EXPORTS)
+    #pragma comment(lib, "ocdm.lib")
+    #endif
+
+    /**
+     * Sometimes the compiler would like to be smart, if we do not reference
+     * anything here
+     * and you enable the rightflags, the linker drops the dependency. Than
+     * Proxy/Stubs do
+     * not get loaded, so lets make the instantiation of the ProxyStubs explicit !!!
+     */
+    EXTERNAL void ForceLinkingOfOpenCDM();
 #endif
 
 #define SESSION_ID_LEN 16

--- a/Source/ocdm/open_cdm_ext.cpp
+++ b/Source/ocdm/open_cdm_ext.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
  
+#include "Module.h"
 #include "open_cdm_ext.h"
 
 #include "open_cdm_impl.h"

--- a/Source/plugins/Config.h
+++ b/Source/plugins/Config.h
@@ -30,4 +30,6 @@
 
 #define RUNTIME_STATISTICS 0
 
+#define RESTFULL_API 1
+
 #endif

--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -20,11 +20,11 @@
 #ifndef __WEBBRIDGESUPPORT_CONFIGURATION_H
 #define __WEBBRIDGESUPPORT_CONFIGURATION_H
 
+#include "Module.h"
 #include "Config.h"
 #include "IPlugin.h"
 #include "IShell.h"
 #include "ISubSystem.h"
-#include "Module.h"
 
 namespace WPEFramework {
 namespace Plugin {

--- a/Source/plugins/IPlugin.h
+++ b/Source/plugins/IPlugin.h
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-#include "Module.h"
-
 #ifndef __IPLUGIN_H
 #define __IPLUGIN_H
+
+#include <com/com.h>
 
 namespace WPEFramework {
 
@@ -231,5 +231,8 @@ namespace PluginHost {
 
 } // namespace PluginHost
 } // namespace WPEFramework
+
+// Needed for the ProxyStub generated files
+#include "IShell.h"
 
 #endif // __IPLUGIN_H

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-#include "Module.h"
-
 #ifndef __ISHELL_H
 #define __ISHELL_H
 
 #include "IPlugin.h"
 #include "ISubSystem.h"
+
+#include <com/com.h>
 
 namespace WPEFramework {
 namespace PluginHost {

--- a/Source/plugins/IStateControl.h
+++ b/Source/plugins/IStateControl.h
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-#include "Module.h"
-
 #ifndef __ISTATECONTROL_H
 #define __ISTATECONTROL_H
 
 #include "IShell.h"
+
+#include <com/com.h>
 
 namespace WPEFramework {
 namespace PluginHost {

--- a/Source/plugins/ISubSystem.h
+++ b/Source/plugins/ISubSystem.h
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-#include "Module.h"
-
 #ifndef __ISYSTEMINFO_H
 #define __ISYSTEMINFO_H
+
+#include <com/com.h>
 
 namespace WPEFramework {
 namespace PluginHost {

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
-#include "IShell.h"
-#include "IPlugin.h"
 #include "Module.h"
 #include "System.h"
+#include "IShell.h"
+#include "IPlugin.h"
 
 namespace WPEFramework {
 

--- a/Source/plugins/MetaData.h
+++ b/Source/plugins/MetaData.h
@@ -20,8 +20,8 @@
 #ifndef __WEBBRIDGESUPPORT_METADATA_H
 #define __WEBBRIDGESUPPORT_METADATA_H
 
-#include "Configuration.h"
 #include "Module.h"
+#include "Configuration.h"
 
 namespace WPEFramework {
 namespace PluginHost {

--- a/Source/plugins/Module.h
+++ b/Source/plugins/Module.h
@@ -17,31 +17,20 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_PLUGINS_H
-#define __MODULE_PLUGINS_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Plugins
 #endif
 
-#include "../core/core.h"
-#include "../com/com.h"
-#include "../cryptalgo/cryptalgo.h"
-#include "../tracing/tracing.h"
-#include "../websocket/websocket.h"
+#include <core/core.h>
+#include <com/com.h>
+#include <cryptalgo/cryptalgo.h>
+#include <tracing/tracing.h>
+#include <websocket/websocket.h>
 
-#define RESTFULL_API 1
-
+#if defined(__WINDOWS__) && defined(PLUGINS_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef PLUGINS_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_PLUGINS_H

--- a/Source/plugins/Service.h
+++ b/Source/plugins/Service.h
@@ -20,13 +20,13 @@
 #ifndef __WEBBRIDGESUPPORT_SERVICE__
 #define __WEBBRIDGESUPPORT_SERVICE__
 
+#include "Module.h"
 #include "Channel.h"
 #include "Configuration.h"
-#include "IPlugin.h"
-#include "IShell.h"
 #include "MetaData.h"
 #include "System.h"
-#include "Module.h"
+#include "IPlugin.h"
+#include "IShell.h"
 
 namespace WPEFramework {
 namespace PluginHost {

--- a/Source/plugins/VirtualInput.h
+++ b/Source/plugins/VirtualInput.h
@@ -22,9 +22,8 @@
 #ifndef __VIRTUAL_INPUT__
 #define __VIRTUAL_INPUT__
 
-#include "../virtualinput/IVirtualInput.h"
-
 #include "Module.h"
+#include "../virtualinput/IVirtualInput.h"
 
 namespace WPEFramework {
 namespace PluginHost {

--- a/Source/plugins/plugins.h
+++ b/Source/plugins/plugins.h
@@ -21,7 +21,7 @@
 #define __PLUGIN_FRAMEWORK_SUPPORT_H
 
 #include "Module.h"
-
+#include "Config.h"
 #include "Channel.h"
 #include "Configuration.h"
 #include "IPlugin.h"

--- a/Source/plugins/plugins.vcxproj
+++ b/Source/plugins/plugins.vcxproj
@@ -133,7 +133,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;PLUGINS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -151,7 +151,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;PLUGINS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -167,7 +167,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;PLUGINS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -185,7 +185,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PLUGINS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/plugins/plugins.vcxproj.filters
+++ b/Source/plugins/plugins.vcxproj.filters
@@ -1,30 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="Channel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MetaData.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Module.cpp">
+    <ClCompile Include="Service.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Service.cpp">
+    <ClCompile Include="VirtualInput.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Module.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Shell.cpp">
@@ -36,15 +25,10 @@
     <ClCompile Include="SubSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="VirtualInput.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="System.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="JSONRPC.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="System.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Channel.h">
@@ -56,28 +40,10 @@
     <ClInclude Include="Configuration.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="IPlugin.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="IShell.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="IStateControl.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ISubSystem.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="JSONRPC.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="MetaData.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Module.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="plugins.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Request.h">
@@ -89,12 +55,37 @@
     <ClInclude Include="VirtualInput.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="IRemoteInstantiation.h">
+    <ClInclude Include="IPlugin.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IShell.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IStateControl.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="plugins.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="System.h">
+    <ClInclude Include="ISubSystem.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
+    <ClInclude Include="JSONRPC.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="IRemoteInstantiation.h" />
+    <ClInclude Include="System.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{732d1d78-3748-41b5-bf71-af9724b3d5b7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{7a08230c-cdee-40ba-83c1-3ae9e2a00374}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Interface Files">
+      <UniqueIdentifier>{4ca8a196-74dd-4e20-98ef-051e5a446b67}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/processcontainers/Module.h
+++ b/Source/processcontainers/Module.h
@@ -23,16 +23,10 @@
 #define MODULE_NAME ProcessContainers
 #endif
 
-#include "../core/core.h"
+#include <core/core.h>
 
+#if defined(__WINDOWS__) && defined(CONTAINERS_EXPORTS)
 #undef EXTERNAL
+#define EXTERNAL EXTERNAL_EXPORT
+#endif
 
-#ifdef __WINDOWS__
-#ifdef CONTAINERS_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
-#define EXTERNAL EXTERNAL_EXPORT
-#endif

--- a/Source/protocols/Module.h
+++ b/Source/protocols/Module.h
@@ -17,22 +17,13 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_PROTOCOLS_H__
-#define __MODULE_PROTOCOLS_H__
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Protocols
 #endif
 
-#include "../com/Ids.h"
-#include "../core/core.h"
-#include "../cryptalgo/cryptalgo.h"
-#include "../tracing/tracing.h"
-
-#ifdef __WINDOWS__
-#include "../websocket/windows/include/zlib.h"
-#else
-#include "zlib.h"
-#endif
-
-#endif // __MODULE_PROTOCOLS_H__
+#include <core/core.h>
+#include <cryptalgo/cryptalgo.h>
+#include <tracing/tracing.h>
+#include <zlib.h>

--- a/Source/proxystubs/Module.h
+++ b/Source/proxystubs/Module.h
@@ -17,27 +17,18 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_PROXYSTUBS_H
-#define __MODULE_PROXYSTUBS_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME ProxyStubs
 #endif
 
-#include "../core/core.h"
-#include "../com/com.h"
-#include "../plugins/plugins.h"
+#include <core/core.h>
+#include <com/com.h>
+#include <plugins/plugins.h>
 
+#if defined(__WINDOWS__) && defined(PROXYSTUBS_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef PROXYSTUBS_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_PROXYSTUB_H

--- a/Source/proxystubs/proxystubs.vcxproj
+++ b/Source/proxystubs/proxystubs.vcxproj
@@ -117,7 +117,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;PROXYSTUBS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(ProjectDir)../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -138,7 +138,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;PROXYSTUBS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(ProjectDir)../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -157,7 +157,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;PROXYSTUBS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(ProjectDir)../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -178,7 +178,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;PROXYSTUBS_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(ProjectDir)../plugins;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/securityagent/CMakeLists.txt
+++ b/Source/securityagent/CMakeLists.txt
@@ -20,11 +20,12 @@ set(TARGET securityagent)
 # Construct a library object
 add_library(${TARGET} STATIC
         ipclink.cpp
+        Module.cpp
         )
 
 set(PUBLIC_HEADERS
         securityagent.h
-        SecurityToken.h
+        Module.h
         IPCSecurityToken.h
         )
 

--- a/Source/securityagent/IPCSecurityToken.h
+++ b/Source/securityagent/IPCSecurityToken.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <core/core.h>
+#include "Module.h"
 
 using namespace WPEFramework;
 

--- a/Source/securityagent/Module.cpp
+++ b/Source/securityagent/Module.cpp
@@ -1,4 +1,4 @@
- /*
+/*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
@@ -17,25 +17,7 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "Module.h"
+#include "../core/core.h"
 
-extern "C" {
-
-/*
- * GetToken - function to obtain a token from the SecurityAgent
- *
- * Parameters
- *  maxLength   - holds the maximum uint8_t length of the buffer
- *  inLength    - holds the length of the current that needs to be tokenized.
- *  Id          - Buffer holds the data to tokenize on its way in, and returns in the same buffer the token.
- *
- * Return value
- *  < 0 - failure, absolute value returned is the length required to store the token
- *  > 0 - success, char length of the returned token
- *
- * Post-condition; return value 0 should not occur
- *
- */
-int EXTERNAL GetToken(unsigned short maxLength, unsigned short inLength, unsigned char buffer[]);
-
-}
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/Source/securityagent/Module.h
+++ b/Source/securityagent/Module.h
@@ -1,4 +1,4 @@
- /*
+/*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
@@ -16,12 +16,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #ifndef MODULE_NAME
-#define MODULE_NAME Core
+#define MODULE_NAME SecurityAgent
 #endif
 
-#include "Portability.h"
+#include <core/core.h>
 
+#if defined(__WINDOWS__) && defined(SECURITYAGENT_EXPORTS)
+#undef EXTERNAL
+#define EXTERNAL EXTERNAL_EXPORT
+#endif

--- a/Source/securityagent/ipclink.cpp
+++ b/Source/securityagent/ipclink.cpp
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#include "securityagent.h"
 #include "IPCSecurityToken.h"
+#include "securityagent.h"
 
 using namespace WPEFramework;
 

--- a/Source/securityagent/securityagent.h
+++ b/Source/securityagent/securityagent.h
@@ -19,16 +19,43 @@
 
 #pragma once
 
+#ifndef EXTERNAL
 #ifdef _MSVC_LANG
-#undef EXTERNAL
 #ifdef SECURITYAGENT_EXPORTS
 #define EXTERNAL __declspec(dllexport)
 #else
 #define EXTERNAL __declspec(dllimport)
-#pragma comment(lib, "securityagent.lib")
 #endif
 #else
 #define EXTERNAL __attribute__ ((visibility ("default")))
 #endif
+#endif
 
-#include "SecurityToken.h"
+#if defined(_WINDOWS) && !defined(SECURITYAGENT_EXPORTS)
+#pragma comment(lib, "securityagent.lib")
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/*
+	 * GetToken - function to obtain a token from the SecurityAgent
+	 *
+	 * Parameters
+	 *  maxLength   - holds the maximum uint8_t length of the buffer
+	 *  inLength    - holds the length of the current that needs to be tokenized.
+	 *  Id          - Buffer holds the data to tokenize on its way in, and returns in the same buffer the token.
+	 *
+	 * Return value
+	 *  < 0 - failure, absolute value returned is the length required to store the token
+	 *  > 0 - success, char length of the returned token
+	 *
+	 * Post-condition; return value 0 should not occur
+	 *
+	 */
+	int EXTERNAL GetToken(unsigned short maxLength, unsigned short inLength, unsigned char buffer[]);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/securityagent/securityagent.vcxproj
+++ b/Source/securityagent/securityagent.vcxproj
@@ -103,7 +103,7 @@
       <PreprocessorDefinitions>SECURITYAGENT_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -123,7 +123,7 @@
       <PreprocessorDefinitions>SECURITYAGENT_EXPORTS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,7 +145,7 @@
       <PreprocessorDefinitions>SECURITYAGENT_EXPORTS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -169,7 +169,7 @@
       <PreprocessorDefinitions>SECURITYAGENT_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDOWS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -185,11 +185,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="IPCSecurityToken.h" />
+    <ClInclude Include="Module.h" />
     <ClInclude Include="securityagent.h" />
-    <ClInclude Include="SecurityToken.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ipclink.cpp" />
+    <ClCompile Include="Module.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Source/securityagent/securityagent.vcxproj.filters
+++ b/Source/securityagent/securityagent.vcxproj.filters
@@ -14,15 +14,18 @@
     <ClInclude Include="IPCSecurityToken.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="SecurityToken.h">
+    <ClInclude Include="securityagent.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="securityagent.h">
+    <ClInclude Include="Module.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ipclink.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Module.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Source/tracing/Module.h
+++ b/Source/tracing/Module.h
@@ -17,25 +17,16 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_TRACING_H
-#define __MODULE_TRACING_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME Tracing
 #endif
 
-#include "../core/core.h"
+#include <core/core.h>
 
+#if defined(__WINDOWS__) && defined(TRACING_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef TRACING_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
 
-#endif // __MODULE_TRACING_H

--- a/Source/tracing/tracing.vcxproj
+++ b/Source/tracing/tracing.vcxproj
@@ -121,7 +121,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;TRACING_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -139,7 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;TRACING_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -155,7 +155,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;TRACING_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -173,7 +173,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;TRACING_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/virtualinput/Module.cpp
+++ b/Source/virtualinput/Module.cpp
@@ -18,6 +18,5 @@
  */
 
 #include "Module.h"
-#include "../core/core.h"
 
 MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/Source/virtualinput/Module.h
+++ b/Source/virtualinput/Module.h
@@ -17,27 +17,15 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_VIRTUALINPUT_H
-#define __MODULE_VIRTUALINPUT_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME VirtualInput
 #endif
 
-#include "../core/core.h"
+#include <core/core.h>
 
+#if defined(__WINDOWS__) && defined(VIRTUALINPUT_EXPORTS)
 #undef EXTERNAL
-
-#ifdef _MSVC_LANG
-#undef INPUT_MOUSE
-#ifdef VIRTUALINPUT_EXPORTS
-#define EXTERNAL __declspec(dllexport)
-#else
-#define EXTERNAL __declspec(dllimport)
-#pragma comment(lib, "virtualinput.lib")
+#define EXTERNAL EXTERNAL_EXPORT
 #endif
-#else
-#define EXTERNAL __attribute__ ((visibility ("default")))
-#endif
-
-#endif // __MODULE_VIRTUALINPUT_H

--- a/Source/virtualinput/virtualinput.cpp
+++ b/Source/virtualinput/virtualinput.cpp
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#include "virtualinput.h"
 #include "IVirtualInput.h"
+#include "virtualinput.h"
 
 namespace WPEFramework {
 namespace VirtualInput{

--- a/Source/virtualinput/virtualinput.h
+++ b/Source/virtualinput/virtualinput.h
@@ -21,19 +21,20 @@
 
 #include <stdbool.h>
 
-#undef EXTERNAL
-
+#ifndef EXTERNAL
 #ifdef _MSVC_LANG
 #ifdef VIRTUALINPUT_EXPORTS
 #define EXTERNAL __declspec(dllexport)
 #else
 #define EXTERNAL __declspec(dllimport)
-#pragma comment(lib, "virtualinput.lib")
 #endif
 #else
-#ifndef EXTERNAL
 #define EXTERNAL __attribute__ ((visibility ("default")))
 #endif
+#endif
+
+#if defined(_WINDOWS) && !defined(VIRTUALINPUT_EXPORTS)
+#pragma comment(lib, "virtualinput.lib")
 #endif
 
 #ifdef __cplusplus

--- a/Source/virtualinput/virtualinput.vcxproj
+++ b/Source/virtualinput/virtualinput.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="virtualinput.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="IVirtualInput.h" />
     <ClInclude Include="Module.h" />
     <ClInclude Include="virtualinput.h" />
   </ItemGroup>
@@ -111,7 +112,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;VIRTUALINPUT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -129,7 +130,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;VIRTUALINPUT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,7 +146,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;VIRTUALINPUT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -163,7 +164,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;VIRTUALINPUT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)/..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Source/websocket/Module.h
+++ b/Source/websocket/Module.h
@@ -17,28 +17,17 @@
  * limitations under the License.
  */
 
-#ifndef __MODULE_WEBSOCKET_H
-#define __MODULE_WEBSOCKET_H
+#pragma once
 
 #ifndef MODULE_NAME
 #define MODULE_NAME WebSocket
 #endif
 
-#include "../core/core.h"
-#include "../cryptalgo/cryptalgo.h"
-
+#include <core/core.h>
+#include <cryptalgo/cryptalgo.h>
 #include <zlib.h>
 
+#if defined(__WINDOWS__) && defined(WEBSOCKET_EXPORTS)
 #undef EXTERNAL
-
-#ifdef __WINDOWS__
-#ifdef WEBSOCKET_EXPORTS
-#define EXTERNAL EXTERNAL_EXPORT
-#else
-#define EXTERNAL EXTERNAL_IMPORT
-#endif
-#else
 #define EXTERNAL EXTERNAL_EXPORT
 #endif
-
-#endif // __MODULE_WEBSOCKET_H

--- a/Source/websocket/websocket.vcxproj
+++ b/Source/websocket/websocket.vcxproj
@@ -125,7 +125,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;WEBSOCKET_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -144,7 +144,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;WEBSOCKET_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -161,7 +161,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;WEBSOCKET_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -180,7 +180,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;WEBSOCKET_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..;$(SolutionDir)thirdparty/windows/include;$(SolutionDir)thirdparty/windows/include/zlib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
…les.

Over time some modules/interfaces have inherited incorrect dependencies. For supporting
the default of visibility hidden, changes where made to all Module.h header files. In
this commit we cleanup the usage of the EXTERNAL keyword as well. On linux, the default
for the EXTERNAL macro is "visible". Only on windows we need to toggle this keyword in
case we are building the specific module. Linux requires to change at all, once defined
in Portability.h it is good for all code.

Also some "side-effect" dependencies where dragged in through Interface Header files
like the interface header files in IPlugin. This commit also brings back the dependencies
of these interface header files to com, by only including com here an not the module
header files (which in turn includes WebSockets, CryptAlgo)