### PR TITLE
Extend Systeminfo to have swapmem & cpuloadavg

### DIFF
--- a/Source/core/SystemInfo.cpp
+++ b/Source/core/SystemInfo.cpp
@@ -156,6 +156,12 @@ namespace Core {
         m_totalram = 0;
         m_pageSize = 0;
         m_freeram = 0;
+        m_totalswap=0;
+        m_freeswap=0;
+        m_cpuloadavg[0]=0;
+        m_cpuloadavg[1]=0;
+        m_cpuloadavg[2]=0;
+
         m_prevCpuSystemTicks = 0;
         m_prevCpuUserTicks = 0;
         m_prevCpuIdleTicks = 0;
@@ -167,6 +173,11 @@ namespace Core {
         m_totalram = info.totalram;
         m_pageSize = static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
         m_freeram = info.freeram;
+        m_totalswap = info.totalswap;
+        m_freeswap = info.freeswap;
+        m_cpuloadavg[0]=info.loads[0];
+        m_cpuloadavg[1]=info.loads[1];
+        m_cpuloadavg[2]=info.loads[2];
 #endif
 #endif
 
@@ -365,6 +376,11 @@ namespace Core {
         m_uptime = info.uptime;
         m_freeram = info.freeram;
         m_totalram = info.totalram;
+        m_totalswap = info.totalswap;
+        m_freeswap = info.freeswap;
+        m_cpuloadavg[0] = info.loads[0];
+        m_cpuloadavg[1] = info.loads[1];
+        m_cpuloadavg[2] = info.loads[2];
 #endif
     }
 

--- a/Source/core/SystemInfo.h
+++ b/Source/core/SystemInfo.h
@@ -100,11 +100,29 @@ namespace Core {
             UpdateRealtimeInfo();
             return m_freeram;
         }
+        
+        inline uint64_t GetTotalSwap() 
+        {
+            UpdateRealtimeInfo();
+            return m_totalswap;
+        }
 
+        inline uint64_t GetFreeSwap() 
+        {
+            UpdateRealtimeInfo();
+            return m_freeswap;
+        }        
+ 
         inline uint64_t GetCpuLoad() const
         {
             UpdateCpuStats();
             return m_cpuload;
+        }
+
+        inline uint64_t * GetCpuLoadAvg()
+        {
+            UpdateRealtimeInfo();
+            return m_cpuloadavg;
         }
 
         inline uint64_t GetJiffies() const
@@ -312,7 +330,10 @@ namespace Core {
         uint32_t m_pageSize;
         mutable uint32_t m_uptime;
         mutable uint64_t m_freeram;
+        mutable uint64_t m_totalswap;
+        mutable uint64_t m_freeswap;
         mutable uint64_t m_cpuload;
+        mutable uint64_t m_cpuloadavg[3];
         mutable uint64_t m_jiffies;
         mutable time_t m_lastUpdateCpuStats;
 

--- a/Source/interfaces/json/DeviceInfo.json
+++ b/Source/interfaces/json/DeviceInfo.json
@@ -6,7 +6,40 @@
     "class": "DeviceInfo",
     "description": "DeviceInfo JSON-RPC interface"
   },
+  "definitions": {
+    "cpuloadavgs": {
+      "description": "cpu 1min, 5min,15min load avg",
+      "type": "object",
+      "properties": {
+        "avg1min": {
+          "type": "number",
+          "size": 64,
+          "example": 789132680,
+          "description": "1min cpuload average"
+        },
+        "avg5min": {
+          "type": "number",
+          "size": 64,
+          "example": 789132680,
+          "description": "5min cpuload average"
+        },
+        "avg15min": {
+           "type": "number",
+           "size": 64,
+           "example": 789132680,
+           "description": "15min cpuload average"
+        }
+      },
+      "required": [
+        "avg1min",
+        "avg5min",
+        "avg15min"
+      ]
+  
+    }
+  },
   "properties": {
+
     "systeminfo": {
       "summary": "System general information",
       "readonly": true,
@@ -36,6 +69,18 @@
             "type": "number",
             "size": 64
           },
+          "totalswap": {
+            "description": "Total swap space (in bytes)",
+            "example": 789132680,
+            "type": "number",
+            "size": 64
+          },
+          "freeswap": {
+            "description": "swap space still available (in bytes)",
+            "example": 789132680,
+            "type": "number",
+            "size": 64
+          },
           "devicename": {
             "description": "Host name",
             "example": "buildroot",
@@ -45,6 +90,10 @@
             "description": "Current CPU load (percentage)",
             "example": "2",
             "type": "string"
+          },
+          "cpuloadavg": {
+            "description": "CPU load average",
+            "$ref": "#/definitions/cpuloadavgs"
           },
           "serialnumber": {
             "description": "Device serial number",
@@ -62,8 +111,11 @@
           "uptime",
           "totalram",
           "freeram",
+          "totalswap",
+          "freeswap",
           "devicename",
           "cpuload",
+          "cpuloadavg",
           "serialnumber",
           "time"
         ]


### PR DESCRIPTION
Reason for change: XRE-15801:Refactoring of Process monitoring in XRE netflix plugin with RDK services
To extend thunder and DeviceInfo plugin to have swapmem & cpuloadavg as part of systeminfo property

Risks: Low
Signed-off-by: Anooja Kurian <Anooja_Kurian@comcast.com>