### PR TITLE
[BUILD] pragma once does not prevent against copy of this file in oth…

### DIFF
--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -17,7 +17,9 @@
  * limitations under the License.
  */
 
-#pragma once
+#ifndef __ISHELL_H__
+#define __ISHELL_H__
+
 #include "IPlugin.h"
 #include "ISubSystem.h"
 
@@ -320,3 +322,4 @@ namespace Core {
 } // namespace Core
 } // namespace WPEFramework
 
+#endif //__ISHELL_H__


### PR DESCRIPTION
…er locations :-)

Reverting the usage of #pragma once in this file as for some reason the IShell gets copied for the ProxyStubs/JSON generated sources.
However due to this copy, the pragma once is assuming thta these are different files and I get, during the building of the ProxyStubs
a double definition error. Prevented this error by reverting to the preprocessor inclusion paradigm!