### PR TITLE
DebugOptimzation with set Optimization flag to avoid overriding it from the build environment

### DIFF
--- a/cmake/modules/CompileSettingsDebug.cmake
+++ b/cmake/modules/CompileSettingsDebug.cmake
@@ -30,7 +30,7 @@ include(CMakePackageConfigHelpers)
 #
 if("${BUILD_TYPE}" STREQUAL "DebugOptimized")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR ${CMAKE_COMPILER_IS_GNUCXX} )
-        target_compile_options(CompileSettingsDebug INTERFACE -g)
+        target_compile_options(CompileSettingsDebug INTERFACE -O0 -g)
     endif()
 
 elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")

--- a/cmake/modules/CompileSettingsDebug.cmake
+++ b/cmake/modules/CompileSettingsDebug.cmake
@@ -30,12 +30,12 @@ include(CMakePackageConfigHelpers)
 #
 if("${BUILD_TYPE}" STREQUAL "Debug")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR ${CMAKE_COMPILER_IS_GNUCXX} )
-        target_compile_options(CompileSettingsDebug INTERFACE -O0)
+        target_compile_options(CompileSettingsDebug INTERFACE -O0 -g)
     endif()
 
 elseif("${BUILD_TYPE}" STREQUAL "DebugOptimized")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR ${CMAKE_COMPILER_IS_GNUCXX} )
-        target_compile_options(CompileSettingsDebug INTERFACE -O1 -g)
+        target_compile_options(CompileSettingsDebug INTERFACE -O2 -g)
     endif()
 
 elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")

--- a/cmake/modules/CompileSettingsDebug.cmake
+++ b/cmake/modules/CompileSettingsDebug.cmake
@@ -28,9 +28,14 @@ include(CMakePackageConfigHelpers)
 #
 # Build type specific options
 #
-if("${BUILD_TYPE}" STREQUAL "DebugOptimized")
+if("${BUILD_TYPE}" STREQUAL "Debug")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR ${CMAKE_COMPILER_IS_GNUCXX} )
-        target_compile_options(CompileSettingsDebug INTERFACE -O0 -g)
+        target_compile_options(CompileSettingsDebug INTERFACE -O0)
+    endif()
+
+elseif("${BUILD_TYPE}" STREQUAL "DebugOptimized")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR ${CMAKE_COMPILER_IS_GNUCXX} )
+        target_compile_options(CompileSettingsDebug INTERFACE -O1 -g)
     endif()
 
 elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")


### PR DESCRIPTION
In Yocto, RPI RDK build always used -Os optimisation level, this causing issue for Thunder debug build. 
So added option to set 0 optimisation level debug build to avoid this issues with different build system environment values