### PR TITLE
Development/add interface include path for moved json headers

### DIFF
--- a/Source/interfaces/CMakeLists.txt
+++ b/Source/interfaces/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(${TargetDefinitions}
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
           $<INSTALL_INTERFACE:include/${NAMESPACE}>
+          $<INSTALL_INTERFACE:include/${NAMESPACE}/interfaces>
         )
 
 install(


### PR DESCRIPTION
Since the json headers move, some plugins had trouble locating the Module.h and Ids.h headers form the interfaces directory. 