### PR TITLE
Use callsign also for the plugin accessor

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -795,7 +795,7 @@ namespace PluginHost {
                 return (_administrator.Configuration().Background());
             }
             string Accessor() const override {
-                return (_administrator.Configuration().URL());
+                return (_administrator.Configuration().URL() + "/" + PluginHost::Service::Configuration().Callsign.Value());
             }
             string ProxyStubPath () const override {
                 return (_administrator.Configuration().ProxyStubPath());


### PR DESCRIPTION
In case of DIALServer, the service->Accessor() is returning http:://IP/Service. Earlier we are providing the callsign also with the plugin accessors. So updated this to provide plugin callsign also to get the proper accessor in plugin context