### PR TITLE
[CALLSTACK] Callstack dumping functionality fixed.

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -664,7 +664,7 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
     {
         Plugin::Controller* controller;
         if ((_controller.IsValid() == false) || ((controller = (_controller->ClassType<Plugin::Controller>())) == nullptr)) {
-            DumpCallStack();
+            DumpCallStack(0, nullptr);
         } else {
 
             controller->Notification(data);

--- a/Source/WPEProcess/Process.cpp
+++ b/Source/WPEProcess/Process.cpp
@@ -468,7 +468,7 @@ private:
             ProcessFlow::Abort();
 
         } else if (signo == SIGSEGV) {
-            DumpCallStack();
+            DumpCallStack(0, nullptr);
             // now invoke the default segfault handler
             signal(signo, SIG_DFL);
             kill(getpid(), signo);

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -143,7 +143,6 @@ static void CallstackSignalHandler(int signr VARIABLE_IS_NOT_USED, siginfo_t* in
 
 uint32_t GetCallStack(const ThreadId threadId, void* addresses[], const uint32_t bufferSize)
 {
-#ifdef __LINUX__
     uint32_t result = 0;
 
     if ((threadId == 0) || (pthread_self() == threadId)) {
@@ -159,7 +158,7 @@ uint32_t GetCallStack(const ThreadId threadId, void* addresses[], const uint32_t
         callstack.sa_sigaction = CallstackSignalHandler;
         sigaction(SA_SIGINFO, &callstack, &original);
 
-        g_targetThread = (threadId == 0 ? pthread_self() : threadId);
+        g_targetThread = threadId;
         g_threadCallstackBuffer = addresses;
         g_threadCallstackBufferSize = bufferSize;
         g_threadCallstackBufferUsed = 0;
@@ -179,12 +178,6 @@ uint32_t GetCallStack(const ThreadId threadId, void* addresses[], const uint32_t
     }
 
     return result;
-#else
-    DEBUG_VARIABLE(threadId);
-    DEBUG_VARIABLE(addresses);
-    DEBUG_VARIABLE(bufferSize);
-    return 0;
-#endif
 }
 
 #else
@@ -213,17 +206,36 @@ void* memrcpy(void* _Dst, const void* _Src, size_t _MaxCount)
 
 extern "C" {
 
-void DumpCallStack(const ThreadId threadId)
+void DumpCallStack(const ThreadId threadId, FILE* feed)
 {
 #ifdef __DEBUG__
 #ifdef __LINUX__
-    void* addresses[20];
+    void* callstack[32];
+    FILE* output = (feed == nullptr ? stderr : feed);
 
-    int addressCount = GetCallStack(threadId, addresses, (sizeof(addresses) / sizeof(addresses[0])));
+    uint32_t entries = GetCallStack(threadId, callstack, (sizeof(callstack) / sizeof(callstack[0])));
 
-    fprintf(stderr, "=== Stack traceback (most recent call first):\n");
-    backtrace_symbols_fd(addresses, addressCount, fileno(stderr));
-    fflush(stderr);
+    char** symbols = backtrace_symbols(callstack, entries);
+
+    for (uint32_t i = 0; i < entries; i++) {
+        Dl_info info;
+        if (dladdr(callstack[i], &info) && info.dli_sname) {
+            char* demangled = NULL;
+            int status = -1;
+            if (info.dli_sname[0] == '_') {
+                demangled = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
+            }
+            fprintf(output, "%-3d %*p %s + %zd\n", i, int(2 + sizeof(void*) * 2), callstack[i],
+                status == 0 ? demangled : info.dli_sname == 0 ? symbols[i] : info.dli_sname,
+                (char*)callstack[i] - (char*)info.dli_saddr);
+            free(demangled);
+        } else {
+            fprintf(output, "%-3d %*p %s\n",
+            i, int(2 + sizeof(void*) * 2), callstack[i], symbols[i]);
+        }
+    }
+    free(symbols);
+    fflush(output);
 #else
     __debugbreak();
 #endif

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -521,10 +521,10 @@ inline void SleepUs(unsigned int a_Time)
 }
 
 
-extern void EXTERNAL DumpCallStack(const ThreadId threadId = 0);
-}
-
+void EXTERNAL DumpCallStack(const ThreadId threadId, FILE* output);
 uint32_t EXTERNAL GetCallStack(const ThreadId threadId, void* addresses[], const uint32_t bufferSize);
+
+}
 
 #if !defined(__DEBUG)
 #define DEBUG_VARIABLE(X) (void)(X)

--- a/Source/core/Trace.h
+++ b/Source/core/Trace.h
@@ -96,7 +96,7 @@
     do {                                                                                                        \
         if (!(expr)) {                                                                                          \
             ASSERT_LOGGER("===== $$ [%d]: ASSERT [%s:%d] (%s)\n", TRACE_PROCESS_ID, __FILE__, __LINE__, #expr); \
-            DumpCallStack();                                                                                    \
+            DumpCallStack(0, nullptr);                                                                          \
             abort();                                                                                            \
         }                                                                                                       \
     } while(0)
@@ -105,7 +105,7 @@
     do {                                                                                                                                             \
         if (!(expr)) {                                                                                                                               \
             ASSERT_LOGGER("===== $$ [%d]: ASSERT [%s:%d] (%s)\n         " #format "\n", TRACE_PROCESS_ID, __FILE__, __LINE__, #expr, ##__VA_ARGS__); \
-            DumpCallStack();                                                                                                                         \
+            DumpCallStack(0, nullptr);                                                                                                               \
             abort();                                                                                                                                 \
         }                                                                                                                                            \
     } while(0)

--- a/cmake/modules/CompileSettings.cmake
+++ b/cmake/modules/CompileSettings.cmake
@@ -64,18 +64,22 @@ target_compile_options(CompileSettings INTERFACE -std=c++11 -Wno-psabi)
 #
 if("${BUILD_TYPE}" STREQUAL "Debug")
     target_compile_definitions(CompileSettings INTERFACE _THUNDER_DEBUG)
+    target_compile_options(CompileSettings INTERFACE -funwind-tables)
     set(CONFIG_DIR "Debug" CACHE STRING "Build config directory" FORCE)
 
 elseif("${BUILD_TYPE}" STREQUAL "DebugOptimized")
     target_compile_definitions(CompileSettings INTERFACE _THUNDER_DEBUG)
+    target_compile_options(CompileSettings INTERFACE -funwind-tables)
     set(CONFIG_DIR "DebugOptimized" CACHE STRING "Build config directory" FORCE)
 
 elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")
     target_compile_definitions(CompileSettings INTERFACE _THUNDER_NDEBUG)
+    target_compile_options(CompileSettings INTERFACE -funwind-tables)
     set(CONFIG_DIR "ReleaseSymbols" CACHE STRING "Build config directory" FORCE)
 
 elseif("${BUILD_TYPE}" STREQUAL "Release")
     target_compile_definitions(CompileSettings INTERFACE _THUNDER_NDEBUG)
+    target_compile_options(CompileSettings INTERFACE -funwind-tables)
     set(CONFIG_DIR "Release" CACHE STRING "Build config directory" FORCE)
 
 elseif("${BUILD_TYPE}" STREQUAL "Production")


### PR DESCRIPTION
Since the software generation is now with a stricter compiler set:
1) No exception handling
2) Default hidden unless marked as public

The callstack dump on the CLI was broken. Turning of exception handling also
turns of the generation of unwind tables. Currently, even if exception handling
is off, the generation of the unwind-tables is enabled. Only for productions
builds this is also turned off.
During analysing the issue, found that the DumpCallStack and PublishCallstack
had overlapping functionality. Moved it to 1 procedure.