### PR TITLE
[XRE-16308] Change how processcontainers imports DobbyProxy

### DIFF
--- a/Source/processcontainers/CMakeLists.txt
+++ b/Source/processcontainers/CMakeLists.txt
@@ -130,17 +130,6 @@ elseif (PROCESSCONTAINERS_DOBBY)
 
                 ${SYSTEMD_LIBRARIES}
                 )
-
-        target_include_directories( ${TARGET}
-                PRIVATE
-                # Dobby includes
-                $<TARGET_PROPERTY:DobbyClientLib,INTERFACE_INCLUDE_DIRECTORIES>
-                $<TARGET_PROPERTY:IpcService,INTERFACE_INCLUDE_DIRECTORIES>
-                $<TARGET_PROPERTY:AppInfraCommon,INTERFACE_INCLUDE_DIRECTORIES>
-                $<TARGET_PROPERTY:AppInfraLogging,INTERFACE_INCLUDE_DIRECTORIES>
-                ${DOBBY_INCLUDE_DIRS}
-                ${JSONCPP_INCLUDE_DIRS}
-        )
 endif()
 
 install(
@@ -157,5 +146,5 @@ InstallCMakeConfig(
         TARGETS ${TARGET})
 
 InstallPackageConfig(
-        TARGETS ${TARGET} 
+        TARGETS ${TARGET}
         DESCRIPTION "Enable ease of development for Process Container support." )

--- a/Source/processcontainers/CMakeLists.txt
+++ b/Source/processcontainers/CMakeLists.txt
@@ -130,6 +130,11 @@ elseif (PROCESSCONTAINERS_DOBBY)
 
                 ${SYSTEMD_LIBRARIES}
                 )
+
+        target_include_directories( ${TARGET}
+                PRIVATE
+                ${JSONCPP_INCLUDE_DIRS}
+        )
 endif()
 
 install(

--- a/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
+++ b/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
@@ -19,8 +19,8 @@
 
 #include "DobbyImplementation.h"
 #include <thread>
-#include "IpcFactory.h"
-#include "DobbyProxy.h"
+#include <Dobby/IpcService/IpcFactory.h>
+#include <Dobby/DobbyProxy.h>
 #include <fstream>
 
 namespace WPEFramework {

--- a/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
+++ b/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
@@ -26,8 +26,8 @@
 #include "processcontainers/common/Lockable.h"
 #include "processcontainers/common/NetworkInfoUnimplemented.h"
 
-#include <Dobby/IDobbyProxy.h>
-#include "DobbyProtocol.h"
+#include <Dobby/Public/Dobby/IDobbyProxy.h>
+#include <Dobby/DobbyProtocol.h>
 
 namespace WPEFramework {
 namespace ProcessContainers {


### PR DESCRIPTION
With Dobby PR#41 (see rdkcentral/Dobby#41)
DobbyProxy no longer needs to be imported via cmake targets.