### PR TITLE
Minor change for autogenerating glue code

### DIFF
--- a/Source/interfaces/IPlayerInfo.h
+++ b/Source/interfaces/IPlayerInfo.h
@@ -26,7 +26,7 @@
 namespace WPEFramework {
 namespace Exchange {
 
-    /* json */
+    /* @json */
     struct EXTERNAL IPlayerProperties : virtual public Core::IUnknown {
         enum { ID = ID_PLAYER_PROPERTIES };
 


### PR DESCRIPTION
Fixing a minor mistake that was preventing the JPlayerProperties.h glue code from being generated