### PR TITLE
Minor fixes in alignment with changes in JsonGenerator

### DIFF
--- a/Source/interfaces/IBrowser.h
+++ b/Source/interfaces/IBrowser.h
@@ -100,8 +100,8 @@ namespace Exchange {
         // @param fps Current FPS
         virtual uint32_t FPS(uint8_t& fps /* @out */) const = 0;
 
-        virtual uint32_t Headers(string& headers /* @out */) const = 0;
-        virtual uint32_t Headers(const string& headers) = 0;
+        virtual uint32_t Headers(string& header /* @out */) const = 0;
+        virtual uint32_t Headers(const string& header) = 0;
 
         virtual uint32_t UserAgent(string& ua /* @out */) const = 0;
         virtual uint32_t UserAgent(const string& ua) = 0;

--- a/Source/interfaces/IDolby.h
+++ b/Source/interfaces/IDolby.h
@@ -73,6 +73,9 @@ namespace Exchange {
             // @param enable: enable/disable
             virtual uint32_t EnableAtmosOutput(const bool& enable /* @in */) = 0;
 
+            // @property
+            // @brief Dolby Mode
+            // @param mode: dolby mode type
             virtual uint32_t Mode(const Dolby::IOutput::Type& mode) = 0;
             virtual uint32_t Mode(Dolby::IOutput::Type& mode /* @out */) const = 0;
 


### PR DESCRIPTION
1. For methods, argument names need to be different from
method name
2. IDolby interface function mode is a property, not
method