### PR TITLE
Crash on non-existing end-points

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -2565,8 +2565,7 @@ namespace PluginHost {
                         AbortUpgrade(Web::STATUS_SERVICE_UNAVAILABLE, _T("Could not find a correct service for this socket."));
                     } else if (Allowed(Path(), Query()) == false) {
                         AbortUpgrade(Web::STATUS_FORBIDDEN, _T("Security prohibites this connection."));
-                    }
-                    if (serviceCall == true) {
+                    } else if (serviceCall == true) {
                         const string& serviceHeader(_parent._config.WebPrefix());
 
                         if (Protocol() == _T("notification")) {


### PR DESCRIPTION
Whenever a socket is opened to a none existing service, THunder would crash on a nullptr access. This was all due to a broken if/else sequence. Fixed.