### PR TITLE
[JsonGen] Generate docs for plugins with multiple C++ interfaces

### DIFF
--- a/Tools/JsonGenerator/GenerateDocs.sh
+++ b/Tools/JsonGenerator/GenerateDocs.sh
@@ -22,8 +22,8 @@
 #
 # Typical usage:
 #   ./GenerateDocs ../../../ThunderNanoServices/
-#   ./GenerateDocs ../../../WPEFrameworkPlugins/BluetoothControl
-#   ./GenerateDocs ../../../WPEFrameworkPlugins/BluetoothControl/BluetoothControlPlugin.json
+#   ./GenerateDocs ../../../ThunderNanoServices/BluetoothControl
+#   ./GenerateDocs ../../../ThunderNanoServices/BluetoothControl/BluetoothControlPlugin.json
 #
 
 command -v ./JsonGenerator.py >/dev/null 2>&1 || { echo >&2 "JsonGenerator.py is not available. Aborting."; exit 1; }
@@ -40,6 +40,6 @@ fi
 
 echo "Generating Plugin markdown documentation..."
 
-./JsonGenerator.py --docs -i ../../Source/interfaces/json -j ../../Source/interfaces -o doc $files
+./JsonGenerator.py --docs -i ../../Source/interfaces/json -j ../../Source/interfaces -I ../../Source -o doc --verbose $files
 
 echo "Complete."


### PR DESCRIPTION
adds 
- support for creating documentation for plugins with multiple c++ interfaces
- fixes command line bugs with documentation
- backward compatibility with Python 3.4
- add delimiter to json methods originating from c++ interfaces placed inside namespace (i.e. IDolby)

Pierre, regarding the last one, the delimiter is an underscore, so the JSON methds for JDolby will look like 'dolby_atmosmetadata'. If you prefer a different character, please let me know.