### PR TITLE
XRE-14362: Add HDCP_AUTO & MS12 to InfoPlugin Enums

### DIFF
--- a/Source/interfaces/IDisplayInfo.h
+++ b/Source/interfaces/IDisplayInfo.h
@@ -47,7 +47,8 @@ namespace Exchange {
         enum HDCPProtectionType : uint8_t {
             HDCP_Unencrypted,
             HDCP_1X,
-            HDCP_2X
+            HDCP_2X,
+            HDCP_AUTO
         };
 
         /* @event */

--- a/Source/interfaces/IDolby.h
+++ b/Source/interfaces/IDolby.h
@@ -36,7 +36,8 @@ namespace Exchange {
                 DIGITAL_PCM = 0,
                 DIGITAL_PLUS = 3,
                 DIGITAL_AC3 = 4,
-                AUTO = 5
+                AUTO = 5,
+                MS12 = 6
             };
 
             enum SoundModes : uint8_t {


### PR DESCRIPTION
Reason for change: HDCP _AUTO and
Dolby Multistream 12 enums added to Info Plugins
Test Procedure: use curl commands
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>