### PR TITLE
IPV4AddressIterator operator= maintain RHS state as such

### DIFF
--- a/Source/core/NetworkInfo.h
+++ b/Source/core/NetworkInfo.h
@@ -296,9 +296,9 @@ namespace Core {
 
         inline IPV4AddressIterator& operator=(const IPV4AddressIterator& RHS)
         {
-            _reset = true;
+            _reset = RHS._reset;
             _list = RHS._list;
-            _index = _list.begin();
+            _index = RHS._index;
 
             return (*this);
         }


### PR DESCRIPTION
Due to this issue DIALServer plugin is not activating.
During the iteration time it will be able to find a valid device, but at the recheck time it become invalid [here](https://github.com/rdkcentral/Thunder/blob/267a8e4cb9a6aee1172bfd6d2022c16a5ca0b98a/Source/plugins/Service.cpp#L164) due to this.