### PR TITLE
[OCDM] Don't destroy accessor on session release

### DIFF
--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -532,7 +532,6 @@ public:
             DecryptSession(nullptr);
         }
 
-        system->Release();
         TRACE_L1("Destructed the Session Client side: %p", this);
     }
 


### PR DESCRIPTION
Releasing the accessor singleton here causes unnecessary creation/destruction of its object each time drm session is created.