### PR TITLE
[VirtualInput] Fix locking

### DIFF
--- a/Source/plugins/VirtualInput.cpp
+++ b/Source/plugins/VirtualInput.cpp
@@ -405,7 +405,9 @@ namespace PluginHost
         event.Code = code;
         Send(event);
         if (--_repeatCounter == 0) {
+             _lock.Lock();
             DispatchRegisteredKey(IVirtualInput::KeyData::RELEASED, _pressedCode);
+             _lock.Unlock();
         }
     }
 


### PR DESCRIPTION
Fix a potential locking issue as the RepeatKey method calls DispatchRegisteredKey without taking the required lock 