### PR TITLE
[DOORBELL] Prevent an early binding of the socket.

### DIFF
--- a/Source/core/DoorBell.cpp
+++ b/Source/core/DoorBell.cpp
@@ -90,17 +90,17 @@ namespace Core {
                 _receiveSocket = INVALID_SOCKET;
             }
 #else
-            if (fcntl(_socket, F_SETOWN, getpid()) == -1) {
+            if (fcntl(_receiveSocket, F_SETOWN, getpid()) == -1) {
                 TRACE_L1("Setting Process ID failed. <%d>", errno);
                 ::close(_receiveSocket);
                 _receiveSocket = INVALID_SOCKET;
             }
             else {
-                int flags = fcntl(_socket, F_GETFL, 0) | O_NONBLOCK;
+                int flags = fcntl(_receiveSocket, F_GETFL, 0) | O_NONBLOCK;
 
-                if (fcntl(_socket, F_SETFL, flags) != 0) {
+                if (fcntl(_receiveSocket, F_SETFL, flags) != 0) {
                     TRACE_L1("Error on port socket F_SETFL call. Error %d", errno);
-                    ::closesocket(_receiveSocket);
+                    ::close(_receiveSocket);
                     _receiveSocket = INVALID_SOCKET;
                 }
             }
@@ -114,8 +114,8 @@ namespace Core {
                 else {
 #ifndef __WINDOWS__
                     if ((_doorbell.Type() == NodeId::TYPE_DOMAIN) && (_doorbell.Rights() <= 0777)) {
-                        if ((::chmod(_doorbell.HostName().c_str(), _doorbell.Rights()) != 0) {
-                            ::closesocket(_receiveSocket);
+                        if (::chmod(_doorbell.HostName().c_str(), _doorbell.Rights()) != 0) {
+                            ::close(_receiveSocket);
                             _receiveSocket = INVALID_SOCKET;
                         }
                     }

--- a/Source/core/DoorBell.h
+++ b/Source/core/DoorBell.h
@@ -49,7 +49,7 @@ namespace Core {
             bool Ring()
             {
                 const char message[] = { SIGNAL_DOORBELL };
-                int sendSize = ::sendto(_socket, message, sizeof(message), 0, static_cast<const NodeId&>(_doorbell), _doorbell.Size());
+                int sendSize = ::sendto(_sendSocket, message, sizeof(message), 0, static_cast<const NodeId&>(_doorbell), _doorbell.Size());
                 return (sendSize == sizeof(message));
             }
 
@@ -63,7 +63,7 @@ namespace Core {
                 char buffer[16];
 
                 do {
-                    size = ::recv(_socket, buffer, sizeof(buffer), 0);
+                    size = ::recv(_receiveSocket, buffer, sizeof(buffer), 0);
 
                     if (size != SOCKET_ERROR) {
                         for (int index = 0; index < size; index++) {
@@ -79,8 +79,9 @@ namespace Core {
         private:
             DoorBell& _parent;
             Core::NodeId _doorbell;
-            SOCKET _socket;
-            mutable uint16_t _bound;
+            SOCKET _sendSocket;
+            mutable SOCKET _receiveSocket;
+            mutable uint16_t _registered;
         };
 
     public:


### PR DESCRIPTION
If an UDP socket is used to signal the ringing of the doorbell, the single socket (used before) will automatically bind to a address, not the node id configured, if the Sending is done before the receiving. This is applicable if in the Thudner application (WPEFramework) a TRACE is issued prior to the TraceCOntrol being started. 

This fix splits the Sending and the Receiving so this can no longer be an issue at the cost of an additional socket.