### PR TITLE
[TRACING] Change the coloring scheme for low-level tracing.

### DIFF
--- a/Source/core/SystemInfo.cpp
+++ b/Source/core/SystemInfo.cpp
@@ -73,7 +73,7 @@ namespace Core {
 
                 if (KeyLength < (DeviceIdLength + SystemPrefixLength)) {
                     TRACE_L1("Losing uniqueness because the id is truncated from %d to the first %d chars of your given id!",
-                        DeviceIdLength, (KeyLength - SystemPrefixLength))
+                        DeviceIdLength, (KeyLength - SystemPrefixLength));
                     ::memcpy(&buffer[SystemPrefixLength], DeviceId, KeyLength - SystemPrefixLength);
                 } else {
                     if (KeyLength > (DeviceIdLength + SystemPrefixLength)) {

--- a/Source/core/Trace.h
+++ b/Source/core/Trace.h
@@ -27,6 +27,34 @@
 #include <syslog.h>
 #endif
 
+namespace WPEFramework {
+    namespace Core {
+        template <typename T, size_t S>
+        inline constexpr size_t FileNameOffset(const T(&str)[S], size_t i = S - 1)
+        {
+            return (str[i] == '/' || str[i] == '\\') ? i + 1 : (i > 0 ? FileNameOffset(str, i - 1) : 0);
+        }
+
+        template <typename T>
+        inline constexpr size_t FileNameOffset(T(&str)[1])
+        {
+            return 0;
+        }
+    }
+}
+
+#ifdef __WINDOWS__
+#define TRACE_PROCESS_ID ::GetCurrentProcessId()
+#else
+#define TRACE_PROCESS_ID ::getpid()
+#endif
+
+#define TRACE_FORMATTING(fmt, ...)                                                                                                        \
+    do {                                                                                                                                  \
+        fprintf(stderr, "\033[1;32m[%s:%d](%s)<%d>" fmt "\n\033[0m", &__FILE__[WPEFramework::Core::FileNameOffset(__FILE__)], __LINE__, __FUNCTION__, TRACE_PROCESS_ID, ##__VA_ARGS__);  \
+        fflush(stderr);                                                                                                                   \
+    } while (0)
+
 #ifdef __WINDOWS__
 #define TRACE_PROCESS_ID ::GetCurrentProcessId()
 #define ASSERT_LOGGER(message, ...) fprintf(stderr, message, ##__VA_ARGS__)
@@ -44,41 +72,31 @@
 #endif
 
 #if _TRACE_LEVEL > 4
-#define TRACE_L5(x, ...)                                                         \
-    fprintf(stderr, "----- L5 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__); \
-    fflush(stderr);
+#define TRACE_L5(x, ...) TRACE_FORMATTING("<5>: " x, ##__VA_ARGS__)
 #else
 #define TRACE_L5(x, ...)
 #endif
 
 #if _TRACE_LEVEL > 3
-#define TRACE_L4(x, ...)                                                         \
-    fprintf(stderr, "----  L4 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__); \
-    fflush(stderr);
+#define TRACE_L4(x, ...) TRACE_FORMATTING("<4>: " x, ##__VA_ARGS__)
 #else
 #define TRACE_L4(x, ...)
 #endif
 
 #if _TRACE_LEVEL > 2
-#define TRACE_L3(x, ...)                                                         \
-    fprintf(stderr, "---   L3 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__); \
-    fflush(stderr);
+#define TRACE_L3(x, ...) TRACE_FORMATTING("<3>: " x, ##__VA_ARGS__)
 #else
 #define TRACE_L3(x, ...)
 #endif
 
 #if _TRACE_LEVEL > 1
-#define TRACE_L2(x, ...)                                                         \
-    fprintf(stderr, "--    L2 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__); \
-    fflush(stderr);
+#define TRACE_L2(x, ...) TRACE_FORMATTING("<2>: " x, ##__VA_ARGS__)
 #else
 #define TRACE_L2(x, ...)
 #endif
 
 #if _TRACE_LEVEL > 0
-#define TRACE_L1(x, ...)                                                         \
-    fprintf(stderr, "-     L1 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__); \
-    fflush(stderr);
+#define TRACE_L1(x, ...) TRACE_FORMATTING("<1>: " x, ##__VA_ARGS__)
 #else
 #define TRACE_L1(x, ...)
 #endif


### PR DESCRIPTION
Whenever the dependency on the Tracing module (libtracing.so) can not be made, or is not allowed, we have the possibility of the "low-level" tracing, which is compile time and is only enabled (by default) in debug.

This tracing is made more verbose (filename, stripped and function) and we gave it a different color (green) so it is more visible between other tracing.
