### PR TITLE
[JSONRPC] Cleanup of the JSONRPC.

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -661,7 +661,7 @@ namespace PluginHost {
 
                 return (result);
             }
-            inline Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t ID, const Core::JSON::IElement& element)
+            inline Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t ID, const Core::ProxyType<Core::JSON::IElement>& element)
             {
                 Core::ProxyType<Core::JSON::IElement> result;
 
@@ -2019,7 +2019,7 @@ namespace PluginHost {
                 }
                 Core::ProxyType<Core::JSON::IElement> Process(const Core::ProxyType<Core::JSON::IElement>& message)
                 {
-                    return (_service->Inbound(_ID, *message));
+                    return (_service->Inbound(_ID, message));
                 }
                 template <typename PACKAGE>
                 void Submit(PACKAGE package)

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -101,6 +101,9 @@ namespace Core {
                     case Core::ERROR_PRIVILIGED_REQUEST:
                         Code = -32604; // Priviliged
                         break;
+                    case Core::ERROR_TIMEDOUT:
+                        Code = -32000; // Server defined, now mapped to Timed out
+                        break;
                     default:
                         Code = static_cast<int32_t>(frameworkError);
                         break;

--- a/Source/plugins/IPlugin.h
+++ b/Source/plugins/IPlugin.h
@@ -158,7 +158,7 @@ namespace PluginHost {
         //! Once the passed object from the previous method is filled (completed), this method allows it to be handled
         //! and to form an answer on the incoming JSON message(if needed).
         //! @}
-        virtual Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t ID, const Core::JSON::IElement& element) = 0;
+        virtual Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t ID, const Core::ProxyType<Core::JSON::IElement>& element) = 0;
     };
 
     struct ITextSocket

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -39,8 +39,6 @@ namespace PluginHost {
         // There should be no need to call these methods from the implementation directly.
         virtual void Activate(IShell* service) = 0;
         virtual void Deactivate() = 0;
-        virtual void Closed(const uint32_t channelId) = 0;
-        virtual uint32_t Observers() const = 0;
     };
 
     class EXTERNAL JSONRPC : public IDispatcher {
@@ -244,13 +242,6 @@ namespace PluginHost {
 
             return (_service->Submit(channel.ChannelId(), Core::ProxyType<Core::JSON::IElement>(message)));
         }
-        uint32_t Observers() const override {
-            uint32_t result = 0;
-            for (const Core::JSONRPC::Handler& element : _handlers) {
-                result += element.Observers();
-            }
-            return(result);
-        }
 
     protected:
         virtual bool Exists(Core::JSONRPC::Handler& handler, const string& parameters)
@@ -405,15 +396,6 @@ namespace PluginHost {
 
             _handlers.front().Close();
             _service = nullptr;
-        }
-        void Closed(const uint32_t id) override
-        {
-            HandlerList::iterator index(_handlers.begin());
-
-            while (index != _handlers.end()) {
-                index->Close(id);
-                index++;
-            }
         }
 
     private:


### PR DESCRIPTION
During the creation of the new WebBridge plugin to connect JavaScript services it
was realised that some of the methods on the interfaces where overkill. Before we
start using this feature massively lets cleanup.