### PR TITLE
For raw packages to follow, the Parse might set the _byteCounter.

### DIFF
--- a/Source/core/Parser.h
+++ b/Source/core/Parser.h
@@ -199,9 +199,9 @@ namespace WPEFramework {
 							int8_t terminated = _terminator.IsTerminated(character);
 
 							if ((terminated & 0x80) == 0x80) {
+								_byteCounter = 0;
 								_parent.Parse(_buffer, ((_state & WAS_QUOTED) == WAS_QUOTED));
 								_parent.EndOfLine();
-								_byteCounter = 0;
 								_state |= SKIP_WHITESPACE;
 								_buffer.clear();
 							}


### PR DESCRIPTION
DIAL fix otherwise the textbodies after the /n/n do not follow anymore