### PR TITLE
Core:SetBuffer: Call memcpy only if the length is non-zero

### DIFF
--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -357,8 +357,9 @@ namespace Core {
             }
 
             SetNumber<TYPENAME>(offset, length);
-            ::memcpy(&(_data[offset + sizeof(TYPENAME)]), buffer, length);
-
+            if (buffer) {
+                ::memcpy(&(_data[offset + sizeof(TYPENAME)]), buffer, length);
+            }
             return (requiredLength);
         }
 

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -357,9 +357,12 @@ namespace Core {
             }
 
             SetNumber<TYPENAME>(offset, length);
-            if (buffer) {
+
+            if (length != 0) {
+                ASSERT(buffer != nullptr);
                 ::memcpy(&(_data[offset + sizeof(TYPENAME)]), buffer, length);
             }
+
             return (requiredLength);
         }
 


### PR DESCRIPTION
Even if the length is zero, the memcpy will end up with memory corruption if one of the pointer is nullptr. So better to do the memcpy only if the size is a valid one