### PR TITLE
[WPEFRAMEWORK] Make sure HTTP requests can be made a-synchronous

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -539,6 +539,7 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
         , _parent(static_cast<ChannelMap&>(*parent).Parent())
         , _security(_parent.Officer())
         , _service()
+        , _requestClose(false)
     {
         TRACE(Activity, (_T("Construct a link with ID: [%d] to [%s]"), Id(), remoteId.QualifiedName().c_str()));
     }

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -2026,6 +2026,9 @@ namespace PluginHost {
                 {
                     _server->Dispatcher().Submit(_ID, package);
                 }
+                void RequestClose() {
+                    _server->Dispatcher().RequestClose(_ID);
+                }
 
             private:
                 uint32_t _ID;
@@ -2077,15 +2080,20 @@ namespace PluginHost {
                     Core::ProxyType<Web::Response> response;
 
                     if (_jsonrpc == true) {
-                        response = IFactories::Instance().Response();
                         Core::ProxyType<Core::JSONRPC::Message> message(_request->Body<Core::JSONRPC::Message>());
 
                         if (message->IsSet()) {
                             Core::ProxyType<Core::JSONRPC::Message> body = Job::Process(_token, message);
 
+                            // If we have no response body, it looks like an async-call...
                             if (body.IsValid() == false) {
-                                response->ErrorCode = Web::STATUS_BAD_REQUEST;
-                            } else {
+                                // It's a a-synchronous call, seems we should just queue this request, it will be answered later on..
+                                if (_request->Connection.Value() == Web::Request::CONNECTION_CLOSE) {
+                                    Job::RequestClose();
+                                }
+                            }
+                            else {
+                                response = IFactories::Instance().Response();
                                 response->Body(body);
                                 if (body->Error.IsSet() == false) {
                                     response->ErrorCode = Web::STATUS_OK;
@@ -2096,11 +2104,15 @@ namespace PluginHost {
                                 }
                             }
                         } else {
+                            response = IFactories::Instance().Response();
                             response->ErrorCode = Web::STATUS_ACCEPTED;
                             response->Message = _T("Failed to parse JSONRPC message");
                         }
                     } else {
                         response = Job::Process(_request);
+                        if (response.IsValid() == false) {
+                            response = _missingResponse;
+                        }
                     }
 
                     if (response.IsValid() == true) {
@@ -2112,13 +2124,10 @@ namespace PluginHost {
                             response->CacheControl = _T("no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0");
 
                         Job::Submit(response);
-                    } else {
-                        // Fire and forget, We are done !!!
-                        Job::Submit(_missingResponse);
-                    }
 
-                    if (_request->Connection.Value() == Web::Request::CONNECTION_CLOSE) {
-                        Job::Close();
+                        if (_request->Connection.Value() == Web::Request::CONNECTION_CLOSE) {
+                            Job::Close();
+                        }
                     }
 
                     // We are done, clear all info
@@ -2283,6 +2292,36 @@ namespace PluginHost {
                 }
 
                 PluginHost::Channel::Unlock();
+            }
+            inline void Submit(const string& text)
+            {
+                PluginHost::Channel::Submit(text);
+            }
+            inline void Submit(const Core::ProxyType<Web::Response>& entry)
+            {
+                PluginHost::Channel::Submit(entry);
+            }
+            void Submit(const Core::ProxyType<Core::JSON::IElement>& entry) 
+            {
+                if (State() == Channel::ChannelState::WEB) {
+                    Core::ProxyType<Web::Response> response = IFactories::Instance().Response();
+
+                    if (response->AccessControlOrigin.IsSet() == false)
+                        response->AccessControlOrigin = _T("*");
+
+                    if (response->CacheControl.IsSet() == false)
+                        response->CacheControl = _T("no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0");
+
+                    response->Body(entry);
+
+                    PluginHost::Channel::Submit(response);
+                }
+                else {
+                    PluginHost::Channel::Submit(entry);
+                }
+            }
+            inline void RequestClose() {
+                _requestClose = true;
             }
 
         private:
@@ -2463,6 +2502,9 @@ namespace PluginHost {
             }
             virtual void Send(const Core::ProxyType<Web::Response>& response)
             {
+                if (_requestClose == true) {
+                    PluginHost::Channel::Close(0);
+                }
                 TRACE(WebFlow, (response));
             }
 
@@ -2645,6 +2687,7 @@ namespace PluginHost {
             Server& _parent;
             PluginHost::ISecurity* _security;
             Core::ProxyType<Service> _service;
+            bool _requestClose;
 
             // Factories for creating jobs that can be placed on the PluginHost Worker pool.
             static Core::ProxyPoolType<WebRequestJob> _webJobs;
@@ -2760,6 +2803,13 @@ namespace PluginHost {
             inline uint32_t ActiveClients() const
             {
                 return (Core::SocketServerType<Channel>::Count());
+            }
+            inline void RequestClose(const uint32_t id) {
+                Core::ProxyType<Channel> client(BaseClass::Client(id));
+
+                if (client.IsValid() == true) {
+                    client->RequestClose();
+                }
             }
             void GetMetaData(Core::JSON::ArrayType<MetaData::Channel>& metaData) const;
 

--- a/Source/core/SocketServer.h
+++ b/Source/core/SocketServer.h
@@ -208,6 +208,23 @@ namespace Core {
             {
                 SocketListner::LocalNode(localNode);
             }
+            inline Core::ProxyType<HANDLECLIENT> Client(const uint32_t ID)
+            {
+                Core::ProxyType<HANDLECLIENT> result;
+
+                _lock.Lock();
+
+                typename ClientMap::iterator index = _clients.find(ID);
+
+                if (index != _clients.end()) {
+                    // Oke connection still exists, send the message..
+                    result = index->second;
+                }
+
+                _lock.Unlock();
+
+                return (result);
+            }
             inline void Suspend(const uint32_t ID)
             {
                 _lock.Lock();
@@ -347,6 +364,10 @@ namespace Core {
         inline void Cleanup()
         {
             _handler.Cleanup();
+        }
+        inline Core::ProxyType<CLIENT> Client(const uint32_t ID)
+        {
+            return (_handler.Client(ID));
         }
         inline void Suspend(const uint32_t ID)
         {


### PR DESCRIPTION
The WebBridge plugin delegates incoming requests to the Javascript plugin running in a JavaScriptInterpreter. This can potentially take some time so the system decouples the request from the response to the Javascript plugin. In case an HTTP request with a JSONRPC message is received, it was expecting a response on the invoke. Due to the decoupled WebBridge feature a JSONRPC request now nolonger return a response by default.

This patch assumes that if there is no JSONRPC message response on the invoke that it is an a-synchronous call and response will follow later. As  part of the initial request, is the request to "close" the TCP connection on completeion of this request, this information is forwarded and stored now as part of the channelInformation. If finally the JSONRPC response is received (and wrapped into an always HTTP response 200 OK message), the channel is closed (if requested) after the JSONRPC response has been send.