### PR TITLE
[CORE] Mark using TRACE_L1 etc from plugins as deprecated 

### DIFF
--- a/Source/core/Trace.h
+++ b/Source/core/Trace.h
@@ -49,11 +49,20 @@ namespace WPEFramework {
 #define TRACE_PROCESS_ID ::getpid()
 #endif
 
-#define TRACE_FORMATTING(fmt, ...)                                                                                                        \
+#define TRACE_FORMATTING_IMPL(fmt, ...)                                                                            \
     do {                                                                                                                                  \
         fprintf(stderr, "\033[1;32m[%s:%d](%s)<%d>" fmt "\n\033[0m", &__FILE__[WPEFramework::Core::FileNameOffset(__FILE__)], __LINE__, __FUNCTION__, TRACE_PROCESS_ID, ##__VA_ARGS__);  \
         fflush(stderr);                                                                                                                   \
     } while (0)
+
+#ifdef CORE_TRACE_NOT_ALLOWED
+#define TRACE_FORMATTING(fmt, ...)                                                                            \
+    _Pragma ("GCC warning \"Using 'TRACE_Lx' outside of Thunder Core is deprecated\"")                                               \
+    TRACE_FORMATTING_IMPL(fmt, ##__VA_ARGS__)
+#else
+#define TRACE_FORMATTING(fmt, ...)                                                                            \
+    TRACE_FORMATTING_IMPL(fmt, ##__VA_ARGS__)
+#endif
 
 #ifdef __WINDOWS__
 #define TRACE_PROCESS_ID ::GetCurrentProcessId()

--- a/Source/plugins/plugins.h
+++ b/Source/plugins/plugins.h
@@ -20,6 +20,10 @@
 #ifndef __PLUGIN_FRAMEWORK_SUPPORT_H
 #define __PLUGIN_FRAMEWORK_SUPPORT_H
 
+// Since this header is included, the code using it is external to Thunder core.
+// So therefore it should use the correct Tracing functionality and not TRACE_L# (which are just fancy printfs).
+#define CORE_TRACE_NOT_ALLOWED
+
 #include "Module.h"
 #include "Config.h"
 #include "Channel.h"


### PR DESCRIPTION
Result from a code review: TRACE_L1 is just a fancy printf and therefore can't be switched on or off. This PR prints a warning when compiling code that should be using correct Tracing/Logging functionalities.