### PR TITLE
[PROCESSNAME] Change the WPEProcess -> Callsign.

### DIFF
--- a/Source/WPEProcess/Process.cpp
+++ b/Source/WPEProcess/Process.cpp
@@ -131,9 +131,10 @@ namespace Process {
     class ConsoleOptions : public Core::Options {
     public:
         ConsoleOptions(int argumentCount, TCHAR* arguments[])
-            : Core::Options(argumentCount, arguments, _T("h:l:c:r:p:s:d:a:m:i:u:g:t:e:x:V:v:P:"))
+            : Core::Options(argumentCount, arguments, _T("h:l:c:C:r:p:s:d:a:m:i:u:g:t:e:x:V:v:P:"))
             , Locator(nullptr)
             , ClassName(nullptr)
+            , Callsign(nullptr)
             , RemoteChannel(nullptr)
             , InterfaceId(Core::IUnknown::ID)
             , Version(~0)
@@ -159,6 +160,7 @@ namespace Process {
     public:
         const TCHAR* Locator;
         const TCHAR* ClassName;
+        const TCHAR* Callsign;
         const TCHAR* RemoteChannel;
         uint32_t InterfaceId;
         uint32_t Version;
@@ -196,6 +198,9 @@ namespace Process {
                 break;
             case 'c':
                 ClassName = argument;
+                break;
+            case 'C':
+                Callsign = argument;
                 break;
             case 'r':
                 RemoteChannel = argument;
@@ -512,6 +517,7 @@ int main(int argc, char** argv)
         printf("Process [-h] \n");
         printf("         -l <locator>\n");
         printf("         -c <classname>\n");
+        printf("         -C <callsign>\n");
         printf("         -r <communication channel>\n");
         printf("         -x <eXchange identifier>\n");
         printf("        [-i <interface ID>]\n");
@@ -541,6 +547,16 @@ int main(int argc, char** argv)
             printf("Argument [%02d]: %s\n", teller, argv[teller]);
         }
     } else {
+        if (options.Callsign != nullptr) {
+            Core::ProcessInfo hostProcess;
+            const TCHAR* callsign = options.Callsign;
+            const TCHAR* lastEntry = ::strrchr(callsign, '.');
+            if (lastEntry != nullptr) {
+                callsign = &(lastEntry[1]);
+            }
+            hostProcess.Name(callsign);
+        }
+
         #ifdef USE_BREAKPAD
         google_breakpad::MinidumpDescriptor descriptor(options.PostMortemPath);
         google_breakpad::ExceptionHandler eh(descriptor, NULL,

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -306,6 +306,7 @@ namespace RPC {
 
             _options.Add(_T("-l")).Add(instance.Locator());
             _options.Add(_T("-c")).Add(instance.ClassName());
+            _options.Add(_T("-C")).Add(instance.Callsign());
             _options.Add(_T("-r")).Add(config.Connector());
             _options.Add(_T("-i")).Add(Core::NumberType<uint32_t>(instance.Interface()).Text());
             _options.Add(_T("-x")).Add(Core::NumberType<uint32_t>(sequenceNumber).Text());

--- a/Source/core/ProcessInfo.cpp
+++ b/Source/core/ProcessInfo.cpp
@@ -29,6 +29,7 @@
 #include <limits.h>
 #include <pwd.h>
 #include <unistd.h>
+#include <sys/prctl.h>
 #endif
 
 #include <fstream>
@@ -525,6 +526,16 @@ namespace Core {
         return (Core::File::FileName(ExecutableName(_handle)));
 #else
         return (Core::File::FileName(ExecutableName(_pid)));
+#endif
+    }
+    void ProcessInfo::Name(const string& name) {
+#ifdef __WINDOWS__
+        if (GetCurrentProcessId() == _pid) {
+        }
+#else
+        if (static_cast<uint32_t>(::getpid()) == _pid) {
+          prctl(PR_SET_NAME, name.c_str(), 0, 0, 0, 0);
+        }
 #endif
     }
     string ProcessInfo::Executable() const

--- a/Source/core/ProcessInfo.h
+++ b/Source/core/ProcessInfo.h
@@ -242,6 +242,7 @@ namespace Core {
         uint64_t Shared() const;
         uint64_t Jiffies() const;
         string Name() const;
+        void Name(const string& name);
         string Executable() const;
         std::list<string> CommandLine() const;
         void MarkOccupiedPages(uint32_t bitSet[], const uint32_t size) const;


### PR DESCRIPTION
Change the WPEPross name to the callsign. Callsigns like org.rdk.webserver will be
abbreviated to the last work after the last dot only (so org.rdk.webserver -> webserver).

Reason for this is that the best supported conversion is only for the short process naem wich is limited to 16 characters.