### PR TITLE
[COMRPC] Fixes for 3 issues.

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -238,10 +238,14 @@ ENUM_CONVERSION_BEGIN(Core::ProcessInfo::scheduler)
     {
 
         void* result = nullptr;
-        if ((id == Core::IUnknown::ID) || (id == PluginHost::IShell::ID)) {
+        if (id == Core::IUnknown::ID) {
             AddRef();
-            result = this;
-        } else {
+            result = static_cast<IUnknown*>(this);
+        } if (id == PluginHost::IShell::ID) {
+            AddRef();
+            result = static_cast<PluginHost::IShell*>(this);
+        }
+        else {
 
             _pluginHandling.Lock();
 

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -1656,7 +1656,7 @@ namespace PluginHost {
                 sink->AddRef();
                 _notifiers.push_back(sink);
 
-                // Tell this "new" sink all our active/inactive plugins..
+                // Tell this "new" sink all our actived plugins..
                 std::map<const string, Core::ProxyType<Service>>::iterator index(_services.begin());
 
                 // Notifty all plugins that we have sofar..
@@ -1667,7 +1667,7 @@ namespace PluginHost {
 
                     ASSERT(service.IsValid());
 
-                    if (service.IsValid() == true) {
+                    if ( (service.IsValid() == true) && (service->State() == IShell::ACTIVATED) ) {
                         sink->StateChange(&(service.operator*()));
                     }
 

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -167,14 +167,16 @@ namespace ProxyStub {
                 if (outbound == false) {
                     _mode |= CACHING_RELEASE;
                 }
+                else {
+                    // This is an additional call to an interface for which we already have a Proxy issued.
+                    // This is triggerd by the other side, offering us an interface. So once this proxy goes
+                    // out of scope, we also need to "release" the AddRef associated with this on the other
+                    // side..
+                    _remoteReferences++;
+                }
+
                 // This will increment the refcount of this PS, on behalf of the user.
                 result = _parent.QueryInterface(id);
-
-                // This is an additional call to an interface for which we already have a Proxy issued.
-                // This is triggerd by the other side, offering us an interface. So once this proxy goes
-                // out of scope, we also need to "release" the AddRef associated with this on the other
-                // side..
-                _remoteReferences++;
             }
             _adminLock.Unlock();
 


### PR DESCRIPTION
1) In case we Query interface for IShell or IUnknown, do not return the Service address
   but the actual IShell interface or IUnknown interface address.
2) The Registration for Plugin notification interfaces, should only report the Activated
   plugins, not the plugins in differen states. With the Clone functionality, the plugins
   that are available are by definitions dynamic, so do not use this interface to find
   all possible interfaces.
3) Additional references to the same proxy should not be accounted for if the incoming
   interface is not addref'ed on the supplying side (inbound interfaces).