### PR TITLE
DELIA-47742 : multiple subscribers

### DIFF
--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -676,6 +676,9 @@ namespace JSONRPC {
 
             if ((result != Core::ERROR_NONE) || (response.IsValid() == false) || (response->Error.IsSet() == true)) {
                 _handler.Unregister(eventName);
+                if ((result == Core::ERROR_NONE) && (response->Error.IsSet() == true)) {
+                    result = response->Error.Code.Value();
+                }
             }
 
             return (result);
@@ -691,6 +694,9 @@ namespace JSONRPC {
 
             if ((result != Core::ERROR_NONE) || (response.IsValid() == false) || (response->Error.IsSet() == true)) {
                 _handler.Unregister(eventName);
+                if ((result == Core::ERROR_NONE) && (response->Error.IsSet() == true)) {
+                    result = response->Error.Code.Value();
+                }
             }
 
             return (result);


### PR DESCRIPTION
Reason for change: if LinkType Subscribe is called more than once
for the same event name, nothing is subscribed.
Test Procedure: testcases provided in ticket
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>