### PR TITLE
[THUNDER] Closing down in debug leads to an ASSERT.

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -196,6 +196,10 @@ namespace PluginHost {
 #ifndef __WINDOWS__
                 closelog();
 #endif
+
+                // Do not forget to close the Tracing stuff...
+                Trace::TraceUnit::Instance().Close();
+
                 // Now clear all singeltons we created.
                 Core::Singleton::Dispose();
             }


### PR DESCRIPTION
In the Singleton list, the Traces are not being closed. Close the Trace resources before calling the Singleton::Dispose.