### PR TITLE
VirtualInput:Do the cleanup of IPCUserInput:services

### DIFF
--- a/Source/plugins/VirtualInput.cpp
+++ b/Source/plugins/VirtualInput.cpp
@@ -738,6 +738,7 @@ namespace PluginHost
     /* virtual */ IPCUserInput::~IPCUserInput()
     {
         ClearKeyMap();
+        _service.Cleanup();
     }
 
     /* virtual */ VirtualInput::Iterator IPCUserInput::Consumers() const


### PR DESCRIPTION
Add this fix to solve the ASSERT during the exit of Thunder
ASSERT [../core/IPCChannel.h:251] (_clients.size() == 0)