### PR TITLE
[METRO-143] ocdm client instance creation

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -511,5 +511,9 @@ namespace RPC {
         // Set event so WaitForCompletion() can continue.
         _announceEvent.SetEvent();
     }
+
+    //We may eliminate the following statement when switched to C++17 compiler
+    constexpr uint32_t RPC::ProcessShutdown::DestructionStackSize;
+
 }
 }

--- a/Source/core/Singleton.h
+++ b/Source/core/Singleton.h
@@ -86,21 +86,10 @@ namespace Core {
         SingletonType<SINGLETON> operator=(const SingletonType<SINGLETON>&) = delete;
 
     protected:
-        SingletonType()
+        template <typename... Args>
+        inline SingletonType(Args&&... args)
             : Singleton(reinterpret_cast<void**>(&g_TypedSingleton))
-            , SINGLETON()
-        {
-        }
-        template <typename ARG1>
-        SingletonType(ARG1 arg1)
-            : Singleton(reinterpret_cast<void**>(&g_TypedSingleton))
-            , SINGLETON(arg1)
-        {
-        }
-        template <typename ARG1, typename ARG2>
-        SingletonType(ARG1 arg1, ARG2 arg2)
-            : Singleton(reinterpret_cast<void**>(&g_TypedSingleton))
-            , SINGLETON(arg1, arg2)
+            , SINGLETON(std::forward<Args>(args)...)
         {
         }
 
@@ -116,7 +105,8 @@ namespace Core {
             return (ClassNameOnly(typeid(SINGLETON).name()).Text());
         }
 
-        static SINGLETON& Instance()
+        template <typename... Args>
+        inline static SINGLETON& Instance(Args&&... args)
         {
             static CriticalSection g_AdminLock;
 
@@ -126,54 +116,10 @@ namespace Core {
 
                 if (g_TypedSingleton == nullptr) {
                     // Create a singleton
-                    g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>());
+                    g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(std::forward<Args>(args)...));
                 }
 
                 g_AdminLock.Unlock();
-            }
-
-            return *(g_TypedSingleton);
-        }
-        template <typename ARG1>
-        static SINGLETON& Instance(ARG1 arg1)
-        {
-            static CriticalSection g_AdminLock;
-
-            // Hmm Double Lock syndrom :-)
-            if (g_TypedSingleton == nullptr) {
-                g_AdminLock.Lock();
-
-                if (g_TypedSingleton == nullptr) {
-                    // Create a singleton
-                    g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(arg1));
-                }
-
-                g_AdminLock.Unlock();
-            } else {
-                // You can not do a retrieval of a singleton with arguments !!!!
-                ASSERT(false);
-            }
-
-            return *(g_TypedSingleton);
-        }
-        template <typename ARG1, typename ARG2>
-        static SINGLETON& Instance(ARG1 arg1, ARG2 arg2)
-        {
-            static CriticalSection g_AdminLock;
-
-            // Hmm Double Lock syndrom :-)
-            if (g_TypedSingleton == nullptr) {
-                g_AdminLock.Lock();
-
-                if (g_TypedSingleton == nullptr) {
-                    // Create a singleton
-                    g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(arg1, arg2));
-                }
-
-                g_AdminLock.Unlock();
-            } else {
-                // You can not do a retrieval of a singleton with arguments !!!!
-                ASSERT(false);
             }
 
             return *(g_TypedSingleton);


### PR DESCRIPTION
 - Reason for change :  Improvement, memory leak fix
     The method:
	static OpenCDMAccessor* Instance()
     is currently casuing a memory leak of this instance.

 - Solution :
	 Suggest to instantiate a OCDMAccessor through lazy creation in order to
         get "properly" destructed on app closure.
	 As an improvement, use variadic template in Singleton implementation.