### PR TITLE
[ENHANCEMENTS] Move constructor, removed a check.

### DIFF
--- a/Source/com/IRPCIterator.h
+++ b/Source/com/IRPCIterator.h
@@ -45,12 +45,19 @@ namespace RPC {
     /* @stubgen:skip */
     template<typename INTERFACE>
     class IteratorType : public INTERFACE {
-    private:
+    public:
+        using Container = typename std::list<typename INTERFACE::Element>;
+
         IteratorType() = delete;
         IteratorType(const IteratorType&) = delete;
         IteratorType& operator=(const IteratorType&) = delete;
 
-    public:
+        explicit IteratorType(Container&& container)
+            : _container(std::forward(container))
+            , _index(0)
+        {
+            _iterator = _container.begin();
+        }
         template <typename CONTAINER, typename PREDICATE>
         IteratorType(const CONTAINER& container, PREDICATE predicate)
             : _container()
@@ -185,8 +192,8 @@ namespace RPC {
         END_INTERFACE_MAP
 
     private:
-        typename std::list<typename INTERFACE::Element> _container;
-        mutable typename std::list<typename INTERFACE::Element>::iterator _iterator;
+        Container _container;
+        mutable typename Container::iterator _iterator;
         mutable uint32_t _index;
     };
 }

--- a/Source/core/FileSystem.cpp
+++ b/Source/core/FileSystem.cpp
@@ -193,9 +193,7 @@ namespace Core {
             if (result[length - 1] != '/')
 #endif
             {
-                if (Core::File(location).IsDirectory() == true) {
-                    result += '/';
-                }
+                result += '/';
             }
         }
         return (result);


### PR DESCRIPTION
Move constructor for the Com::Iterator. 
Removed a check on Directory for a directory, since the expectation is that of you Normalize a directory path, the Path does not have to be available (because you are going to create it) you still need the path top be closed with a slash to indicate that you expect it to be a directory.