### PR TITLE
REFPLTV-735: RDK Services: Controller.1.startdiscovery and Controller…

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -78,7 +78,7 @@ namespace Plugin {
             // "239.255.255.250:1900";
             Core::NodeId node (config.Probe.Node.Value().c_str());
 
-            if (node.IsValid() == true) {
+            if (node.IsValid() == false) {
                 SYSLOG(Logging::Startup, (_T("Probing requested but invalid IP address [%s]"), config.Probe.Node.Value().c_str()));
             }
             else {

--- a/Source/WPEFramework/ControllerJsonRpc.cpp
+++ b/Source/WPEFramework/ControllerJsonRpc.cpp
@@ -154,8 +154,9 @@ namespace Plugin {
     {
         const uint8_t& ttl = params.Ttl.Value();
 
-        ASSERT(_probe != nullptr);
-        _probe->Ping(ttl);
+        if (_probe != nullptr) {
+            _probe->Ping(ttl);
+        }
 
         return Core::ERROR_NONE;
     }
@@ -343,11 +344,14 @@ namespace Plugin {
     uint32_t Controller::get_discoveryresults(Core::JSON::ArrayType<PluginHost::MetaData::Bridge>& response) const
     {
         ASSERT(_probe != nullptr);
-        Probe::Iterator index(_probe->Instances());
 
-        while (index.Next() == true) {
-            PluginHost::MetaData::Bridge element((*index).URL().Text(), (*index).Latency(), (*index).Model(), (*index).IsSecure());
-            response.Add(element);
+        if (_probe != nullptr) {
+            Probe::Iterator index(_probe->Instances());
+
+            while (index.Next() == true) {
+                PluginHost::MetaData::Bridge element((*index).URL().Text(), (*index).Latency(), (*index).Model(), (*index).IsSecure());
+                response.Add(element);
+            }
         }
 
         return Core::ERROR_NONE;


### PR DESCRIPTION
….1.discoveryresults returning Empty reply from server error

Reason for change: Crash observed when Controller.1.startdiscovery and Controller.1.discoveryresults are run.
Test Procedure: Execute Controller.1.startdiscovery and Controller.1.discoveryresults curl command.