### PR TITLE
[WPEFramework] Fix access permission for /tmp/keyhandler

### DIFF
--- a/Source/WPEFramework/Config.h
+++ b/Source/WPEFramework/Config.h
@@ -219,7 +219,7 @@ namespace PluginHost {
                     : Locator("127.0.0.1:9631")
                     , Type(InputHandler::VIRTUAL)
 #else
-                    : Locator("/tmp/keyhandler|0760")
+                    : Locator("/tmp/keyhandler|0766")
                     , Type(InputHandler::VIRTUAL)
 #endif
                     , OutputEnabled(true)


### PR DESCRIPTION
Some of the process (like Amazon plugin) can run with a different
user and group than the Framework main process. In this
case, the processes that are using /tmp/keyhandler can't access
that file, thus loosing possibility to obtain key presess.
This commit fix this, with adding R/W file permission for
the 'other' group.