### PR TITLE
[ROUTING] Thunder supports an abstrcat class representation of the cu…

### DIFF
--- a/Source/core/NetworkInfo.cpp
+++ b/Source/core/NetworkInfo.cpp
@@ -1297,7 +1297,7 @@ namespace Core {
                  _table = *((int *)RTA_DATA(rt_attr));
                  break;
             default:
-                 printf ("We also have: %u\n", rt_attr->rta_type);
+                 TRACE_L1("We also have: %u", rt_attr->rta_type);
                  break;
         }
     }

--- a/Source/core/NetworkInfo.cpp
+++ b/Source/core/NetworkInfo.cpp
@@ -1228,6 +1228,154 @@ namespace Core {
         uint32_t _refCount;
     };
 
+    RoutingTable::Route::Route(const uint8_t stream[], const uint16_t length) 
+        : _source()
+        , _destination()
+        , _preferred()
+        , _gateway()
+        , _priority(0)
+        , _interface(0)
+        , _metrics(0)
+        , _table(0)
+        , _mask(0)
+        , _flags(0)
+        , _protocol(0)
+        , _scope(0) {
+        const struct rtmsg* r = reinterpret_cast<const struct rtmsg*>(stream);
+        const struct rtattr* rt_attr = RTM_RTA(r);
+        int rtl = length - sizeof(struct rtmsg);
+
+        _mask = r->rtm_dst_len;
+        _flags = r->rtm_flags;
+        _scope = r->rtm_scope;
+        _protocol = r->rtm_protocol;
+
+        for (; RTA_OK(rt_attr, rtl); rt_attr = RTA_NEXT(rt_attr, rtl))
+            switch (rt_attr->rta_type) {
+            case RTA_DST:
+                 if (r->rtm_family == AF_INET6) {
+                     _destination = Core::NodeId(*reinterpret_cast<const struct in6_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 else {
+                     _destination = Core::NodeId(*reinterpret_cast<const struct in_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 break;
+            case RTA_SRC:
+                 if (r->rtm_family == AF_INET6) {
+                     _source = Core::NodeId(*reinterpret_cast<const struct in6_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 else {
+                     _source = Core::NodeId(*reinterpret_cast<const struct in_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 break;
+            case RTA_GATEWAY:
+                 if (r->rtm_family == AF_INET6) {
+                     _gateway = Core::NodeId(*reinterpret_cast<const struct in6_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 else {
+                     _gateway = Core::NodeId(*reinterpret_cast<const struct in_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 break;
+            case RTA_PREFSRC:
+                 if (r->rtm_family == AF_INET6) {
+                     _preferred = Core::NodeId(*reinterpret_cast<const struct in6_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 else {
+                     _preferred = Core::NodeId(*reinterpret_cast<const struct in_addr*>(RTA_DATA(rt_attr)));
+                 }
+                 break;
+            case RTA_OIF:
+                 _interface = *((int *)RTA_DATA(rt_attr));
+                 break;
+            case RTA_METRICS:
+                 _metrics = *((int *)RTA_DATA(rt_attr));
+                 break;
+            case RTA_PRIORITY:
+                 _priority = *((int *)RTA_DATA(rt_attr));
+                 break;
+            case RTA_TABLE:
+                 _table = *((int *)RTA_DATA(rt_attr));
+                 break;
+            default:
+                 printf ("We also have: %u\n", rt_attr->rta_type);
+                 break;
+        }
+    }
+
+    string RoutingTable::Route::Interface() const {
+        string result;
+        if (_interface != 0) {
+            char buffer[IF_NAMESIZE + 1];
+
+            if_indextoname(_interface, buffer);
+
+            ToString(buffer, result);
+        }
+
+        return (result);
+    }
+
+    RoutingTable::RoutingTable(const bool ipv4) {
+        class IPRouteTable : public Netlink {
+        public:
+            IPRouteTable() = delete;
+            IPRouteTable(const IPRouteTable&) = delete;
+            IPRouteTable& operator=(const IPRouteTable&) = delete;
+
+            IPRouteTable(std::list<Route>& table, const bool ipv4)
+                : _ipv4(ipv4)
+                , _table(table)
+            {
+            }
+            ~IPRouteTable() override = default;
+
+        private:
+            uint16_t Write(uint8_t stream[], const uint16_t length) const override
+            {
+                Flags(NLM_F_REQUEST | NLM_F_DUMP);
+                Type(RTM_GETROUTE);
+
+                struct rtmsg message;
+
+                ::memset(&message, 0, sizeof(message));
+
+                message.rtm_family = (_ipv4 == true ?  AF_INET : AF_INET6);
+                message.rtm_table = RT_TABLE_MAIN;
+
+                uint16_t copyLength = std::min(length, static_cast<uint16_t>(sizeof(struct rtmsg)));
+                memcpy (stream, &message, copyLength);
+                _table.clear();
+
+                return (copyLength);
+            }
+            uint16_t Read(const uint8_t stream[], const uint16_t length) override
+            {
+                if ( (Type() == RTM_GETROUTE) && (length > 0)) {
+                    _table.emplace_back(stream, length);
+
+                } else if (Type() == NLMSG_ERROR) {
+                    const nlmsgerr* error = reinterpret_cast<const nlmsgerr*>(stream);
+
+                    if (error->error != 0) {
+                        TRACE_L1("IPRouteTable: Request failed with code %d", error->error);
+                    } 
+                }
+                else if (Type() != NLMSG_DONE) {
+                    TRACE_L1("IPRouteTable: Read unexpected type: %d", Type());
+                }
+
+                return (length);
+            }
+
+        private:
+            bool _ipv4;
+            std::list<Route>& _table;
+        } collector (_table, ipv4);
+
+        IPNetworks::Instance().Exchange(collector, collector);
+    }
+
+
     Network::Network(const uint32_t index, const struct rtattr* iface, const uint32_t length)
         : _adminLock()
         , _index(index)

--- a/Source/core/NetworkInfo.h
+++ b/Source/core/NetworkInfo.h
@@ -28,6 +28,107 @@
 
 namespace WPEFramework {
 namespace Core {
+    class RoutingTable {
+    public:
+        class Route {
+        public:
+            Route()
+                : _source()
+                , _destination()
+                , _preferred()
+                , _gateway()
+                , _priority(0)
+                , _interface(0)
+                , _metrics(0)
+                , _table(0)
+                , _mask(0)
+                , _flags(0)
+                , _protocol(0)
+                , _scope(0) {
+            }
+            Route(const Route& copy)
+                : _source(copy._source)
+                , _destination(copy._destination)
+                , _preferred(copy._preferred)
+                , _gateway(copy._gateway)
+                , _priority(copy._priority)
+                , _interface(copy._interface)
+                , _metrics(copy._metrics)
+                , _table(copy._table)
+                , _mask(copy._mask)
+                , _flags(copy._flags)
+                , _protocol(copy._protocol)
+                , _scope(copy._scope) {
+            }
+            Route(const uint8_t stream[], const uint16_t length);
+            ~Route() = default;
+
+            Route& operator= (const Route& rhs) {
+                _source = rhs._source;
+                _destination = rhs._destination;
+                _preferred = rhs._preferred;
+                _gateway = rhs._gateway;
+                _priority = rhs._priority;
+                _interface = rhs._interface;
+                _metrics = rhs._metrics;
+                _table = rhs._table;
+                _mask = rhs._mask;
+                _flags = rhs._flags;
+                _protocol = rhs._protocol;
+                _scope = rhs._scope;
+
+                return (*this);
+            }
+ 
+        public:
+            inline const NodeId& Source() const {
+                return (_source);
+            }
+            inline const NodeId& Destination() const {
+                return (_destination);
+            }
+            inline const NodeId& Gateway() const {
+                return (_gateway);
+            }
+            inline const NodeId& Preferred() const {
+                return (_preferred);
+            }
+            inline int Metrics() const {
+                return (_metrics);
+            }
+            inline int Priority() const {
+                return (_priority);
+            }
+            inline string Interface() const;
+
+        private:
+            NodeId _source;
+            NodeId _destination;
+            NodeId _preferred;
+            NodeId _gateway;
+            int _priority;
+            int _interface;
+            int _metrics;
+            int _table;
+            uint8_t _mask;
+            uint8_t _flags;
+            uint8_t _protocol;
+            uint8_t _scope;
+        };
+    public:
+        RoutingTable() = delete;
+        RoutingTable(const RoutingTable&) = delete;
+        RoutingTable& operator= (const RoutingTable&) = delete;
+
+        RoutingTable(const bool ipv4);
+        ~RoutingTable() = default;
+
+    public:
+
+    private:
+        std::list<Route> _table;
+    };
+
 
     class EXTERNAL AdapterObserver {
     public:


### PR DESCRIPTION
…rrent Routing tables.

For the NetworkControl plugin it is usefull to validate the routing tables used by the linux kernel.
This feature adds the possibility to read the Linux Routing tables directly (through netlink) from the
kernel space.