### PR TITLE
[SOCKETPORT] Extract from UDP/RAW messages on which interface they wh…

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -315,6 +315,7 @@ namespace Core {
         , m_ReceivedNode()
         , m_SendBuffer(nullptr)
         , m_ReceiveBuffer(nullptr)
+	, m_Interface(~0)
     {
         TRACE_L5("Constructor SocketPort (NodeId&) <%p>", (this));
     }
@@ -336,6 +337,7 @@ namespace Core {
         , m_ReceivedNode()
         , m_SendBuffer(nullptr)
         , m_ReceiveBuffer(nullptr)
+	, m_Interface(~0)
     {
         NodeId::SocketInfo localAddress;
         socklen_t localSize = sizeof(localAddress);

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -109,6 +109,7 @@ namespace Core {
                     {
                         printf("!!!!!! WSARecvMsg is not available !!!!!\n ");
                     }
+		    ::closesocket(sckt);
                 }
             }
 

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -173,6 +173,9 @@ namespace Core {
         {
             return (m_ReceivedNode);
         }
+        inline uint32_t ReceivedInterface() const {
+            return (m_Interface);
+        }
         inline uint16_t SendBufferSize() const
         {
             return (m_SendBufferSize);
@@ -265,6 +268,7 @@ namespace Core {
         uint16_t m_ReadBytes;
         uint16_t m_SendBytes;
         uint16_t m_SendOffset;
+        uint32_t m_Interface;
     };
 
     class EXTERNAL SocketStream : public SocketPort {


### PR DESCRIPTION
…ere received.

To make the locator specific to the IP address on the interface it was received, extract the interface id, with the remote address, on which it was received. This way the Locator can be made to use the IPv4/IPv6 address for that interface to reach it back on.