### PR TITLE
RDK-29971 : Fix JSONRPCSupportsEventStatus

### DIFF
--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -460,7 +460,7 @@ namespace PluginHost {
         virtual void Unsubscribe(Core::JSONRPC::Handler& handler, const uint32_t channelId, const string& eventName, const string& callsign, Core::JSONRPC::Message& response)
         {
             NotifyObservers(eventName, callsign, Status::unregistered);
-            JSONRPC::Subscribe(handler, channelId, eventName, callsign, response);
+            JSONRPC::Unsubscribe(handler, channelId, eventName, callsign, response);
         }
 
     private:


### PR DESCRIPTION
Reason for change: Typo fix.
Test Procedure: For a plugin which derives from
JSONRPCSupportsEventStatus, register then uregister
an event listener.
Risks: Medium
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>