### PR TITLE
SocketPort update on R2

### DIFF
--- a/Source/core/NetworkInfo.cpp
+++ b/Source/core/NetworkInfo.cpp
@@ -1487,6 +1487,11 @@ namespace Core {
         _index = _list.begin();
     }
 
+    AdapterIterator::AdapterIterator(const uint16_t index)
+        : AdapterIterator() {
+        while ( (Next() == true) && (Index() != index) ) { /* Intentionally left empty */ }
+    }
+
     AdapterIterator::AdapterIterator(const string& name) 
         : AdapterIterator() {
         while ( (Next() == true) && (Name() != name) ) { /* Intentionally left empty */ }

--- a/Source/core/NetworkInfo.h
+++ b/Source/core/NetworkInfo.h
@@ -196,6 +196,16 @@ namespace Core {
             : _index(static_cast<uint16_t>(~0))
         {
         }
+        inline AdapterIterator(const uint16_t index)
+            : _index(static_cast<uint16_t>(~0))
+        {
+            while ((Next() == true) && (Index() != index)) /* intentionally left blank */
+                ;
+
+            if (IsValid() == false) {
+                Reset();
+            }
+        }
         inline AdapterIterator(const string& name)
             : _index(static_cast<uint16_t>(~0))
         {
@@ -460,6 +470,7 @@ namespace Core {
     class EXTERNAL AdapterIterator {
     public:
         AdapterIterator();
+        AdapterIterator(const uint16_t index);
         AdapterIterator(const string& name);
         AdapterIterator(const AdapterIterator& copy);
         ~AdapterIterator() = default;
@@ -488,6 +499,10 @@ namespace Core {
         }
         inline uint16_t Count() const {
             return (_list.size());
+        }
+        inline uint16_t Index() const {
+            ASSERT (IsValid());
+            return ((*_index)->Id());
         }
 
         inline string Name() const {

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -316,6 +316,7 @@ namespace Core {
         , m_ReceivedNode()
         , m_SendBuffer(nullptr)
         , m_ReceiveBuffer(nullptr)
+	, m_Interface(~0)
     {
         TRACE_L5("Constructor SocketPort (NodeId&) <%p>", (this));
     }
@@ -337,6 +338,7 @@ namespace Core {
         , m_ReceivedNode()
         , m_SendBuffer(nullptr)
         , m_ReceiveBuffer(nullptr)
+	, m_Interface(~0)
     {
         NodeId::SocketInfo localAddress;
         socklen_t localSize = sizeof(localAddress);

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -50,6 +50,7 @@
 #ifdef __WINDOWS__
 #include <Winsock2.h>
 #include <ws2tcpip.h>
+#include <Mswsock.h>
 #define __ERRORRESULT__ ::WSAGetLastError()
 #define __ERROR_WOULDBLOCK__ WSAEWOULDBLOCK
 #define __ERROR_AGAIN__ WSAEALREADY
@@ -79,6 +80,7 @@ namespace Core {
         public:
             WinSocketInitializer()
             {
+                _lpWSARecvMsg = nullptr;
                 WORD requestedVersion;
                 WSADATA winsockInfo;
                 int retCode;
@@ -101,7 +103,13 @@ namespace Core {
                     WSACleanup();
                     exit(1);
                 } else {
-                    printf("Winsock 2.2 DLL success\n");
+                    SOCKET sckt = ::socket(AF_INET, SOCK_DGRAM, 0);
+                    GUID guid = WSAID_WSARECVMSG;
+                    DWORD dwBytesReturned = 0;
+                    if (WSAIoctl(sckt, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &_lpWSARecvMsg, sizeof(_lpWSARecvMsg), &dwBytesReturned, NULL, NULL) != 0)
+                    {
+                        printf("!!!!!! WSARecvMsg is not available !!!!!\n ");
+                    }
                 }
             }
 
@@ -115,11 +123,123 @@ namespace Core {
             {
                 return (true);
             }
+
+            LPFN_WSARECVMSG _lpWSARecvMsg;
         };
 
         static WinSocketInitializer g_SocketInitializer;
 
+        
+
     } // Nameless namespace
+
+    static uint32_t ReceiveFrom(SOCKET handle, char* buffer, int bufferSize, struct sockaddr* remote, socklen_t* remoteLength, uint32_t& interfaceId) {
+
+        DWORD dwBytesRecv = 0;
+        char controlBuffer[256];
+
+        WSABUF msgbuf;
+        msgbuf.len = bufferSize;
+        msgbuf.buf = buffer;
+
+        WSAMSG msg;
+        memset(&msg, 0, sizeof(msg));
+        msg.name = (struct sockaddr*)remote;
+        msg.namelen = *remoteLength;
+        msg.lpBuffers = &msgbuf;
+        msg.dwBufferCount = 1;
+        msg.Control.len = sizeof(controlBuffer);
+        msg.Control.buf = controlBuffer;
+
+        if (g_SocketInitializer._lpWSARecvMsg(handle, &msg, &dwBytesRecv, NULL, NULL) != 0)
+        {
+            dwBytesRecv = -1;
+        }
+        else
+        {
+            WSACMSGHDR* msghdr = WSA_CMSG_FIRSTHDR(&msg);
+            while (msghdr)
+            {
+                switch (msghdr->cmsg_type)
+                {
+                case IP_PKTINFO: // also IPV6_PKTINF
+                {
+                    // must call setsockopt(sckt, IPPROTO_IP, IP_PKTINFO, TRUE) beforehand to receive this for IPv4
+                    // must call setsockopt(sckt, IPPROTO_IPV6, IPV6_PKTINFO, TRUE) beforehand to receive this for IPv6
+
+                    switch (remote->sa_family)
+                    {
+                    case AF_INET:
+                    {
+                        struct in_pktinfo* pktinfo = (struct in_pktinfo*)WSA_CMSG_DATA(msghdr);
+                        // use pktinfo as needed...
+                        interfaceId = pktinfo->ipi_ifindex;
+                        break;
+                    }
+
+                    case AF_INET6:
+                    {
+                        struct in6_pktinfo* pktinfo = (struct in6_pktinfo*)WSA_CMSG_DATA(msghdr);
+                        // use pktinfo as needed...
+                        interfaceId = pktinfo->ipi6_ifindex;
+                        break;
+                    }
+                    }
+
+                    break;
+                }
+
+                // other packet options as needed...
+                }
+
+                msghdr = WSA_CMSG_NXTHDR(&msg, msghdr);
+            }
+        }
+
+        return (dwBytesRecv);
+    }
+
+#else
+
+    static uint32_t ReceiveFrom(SOCKET handle, char* buffer, int bufferSize, struct sockaddr* remote, socklen_t* remoteLength, uint32_t& interfaceId) {
+        uint32_t result;
+
+        // the control data is dumped here
+        char cmbuf[256];
+
+        struct iovec msgbuf = {
+            .iov_base = buffer,
+            .iov_len = static_cast<size_t>(bufferSize),
+        };
+
+        // if you want access to the data you need to init the msg_iovec fields
+        struct msghdr mh = {
+            .msg_name = remote,
+            .msg_namelen = *remoteLength,
+            .msg_iov = &msgbuf,
+            .msg_iovlen = 1,
+            .msg_control = cmbuf,
+            .msg_controllen = sizeof(cmbuf),
+        };
+        result = recvmsg(handle, &mh, 0);
+        for ( // iterate through all the control headers
+            struct cmsghdr* cmsg = CMSG_FIRSTHDR(&mh);
+            cmsg != NULL;
+            cmsg = CMSG_NXTHDR(&mh, cmsg))
+        {
+            if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO) && (remote->sa_family == AF_INET))
+            {
+                const struct in_pktinfo* info = reinterpret_cast<const struct in_pktinfo*>CMSG_DATA(cmsg);
+                interfaceId = info->ipi_ifindex;
+            }
+            else if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO) && (remote->sa_family == AF_INET6))
+            {
+                const struct in6_pktinfo* info = reinterpret_cast<const struct in6_pktinfo*>CMSG_DATA(cmsg);
+                interfaceId = info->ipi6_ifindex;
+            }
+        }
+        return (result);
+    }
 
 #endif
 
@@ -566,7 +686,23 @@ namespace Core {
                 l_Result = INVALID_SOCKET;
             }
         }
+        else 
 #endif
+        if ((localNode.IsAnyInterface() == true) && (SocketMode() != SOCK_STREAM)) {
+
+            int optval = 1;
+
+            if (localNode.Type() == NodeId::TYPE_IPV4) {
+                if (::setsockopt(l_Result, IPPROTO_IP, IP_PKTINFO, (const char*)&optval, sizeof(optval)) != 0) {
+                    TRACE_L1("Error getting additional info on received packages. Error %d", __ERRORRESULT__);
+                }
+            }
+            else if (localNode.Type() == NodeId::TYPE_IPV6) {
+                if (::setsockopt(l_Result, IPPROTO_IPV6, IPV6_PKTINFO, (const char*)&optval, sizeof(optval)) != 0) {
+                    TRACE_L1("Error getting additional info on received packages. Error %d", __ERRORRESULT__);
+                }
+            }
+        }
 
         if (l_Result != INVALID_SOCKET) {
             // Do we need to find something to bind to or is it pre-destined
@@ -881,10 +1017,10 @@ namespace Core {
                 NodeId::SocketInfo l_Remote;
                 socklen_t l_Address = sizeof(l_Remote);
 
-                l_Size = ::recvfrom(m_Socket,
+                l_Size = ReceiveFrom(m_Socket,
                     reinterpret_cast<char*>(&m_ReceiveBuffer[m_ReadBytes]),
-                    m_ReceiveBufferSize - m_ReadBytes, 0, (struct sockaddr*)&l_Remote,
-                    &l_Address);
+                    m_ReceiveBufferSize - m_ReadBytes, (struct sockaddr*)&l_Remote,
+                    &l_Address, m_Interface);
 
                 m_ReceivedNode = l_Remote;
             } else {

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -110,6 +110,7 @@ namespace Core {
                     {
                         printf("!!!!!! WSARecvMsg is not available !!!!!\n ");
                     }
+		    ::closesocket(sckt);
                 }
             }
 

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -173,6 +173,9 @@ namespace Core {
         {
             return (m_ReceivedNode);
         }
+        inline uint32_t ReceivedInterface() const {
+            return (m_Interface);
+        }
         inline uint16_t SendBufferSize() const
         {
             return (m_SendBufferSize);
@@ -265,6 +268,7 @@ namespace Core {
         uint16_t m_ReadBytes;
         uint16_t m_SendBytes;
         uint16_t m_SendOffset;
+        uint32_t m_Interface;
     };
 
     class EXTERNAL SocketStream : public SocketPort {


### PR DESCRIPTION
Moving changes related to extracting interface number from socket messages' ancillary data to R2. Cherry-picked from master.