### PR TITLE
RDK-29971: Thunder Messenger Restrictions

### DIFF
--- a/Source/plugins/JSONRPC.cpp
+++ b/Source/plugins/JSONRPC.cpp
@@ -35,7 +35,7 @@ namespace PluginHost {
         _handlers.emplace_back([&](const uint32_t id, const string& designator, const string& data) { Notify(id, designator, data); }, versions);
     }
 
-    JSONRPC::JSONRPC(const std::vector<uint8_t> versions)
+    JSONRPC::JSONRPC(const std::vector<uint8_t>& versions)
         : _adminLock()
         , _handlers()
         , _service(nullptr)
@@ -57,7 +57,7 @@ namespace PluginHost {
         _handlers.emplace_back([&](const uint32_t id, const string& designator, const string& data) { Notify(id, designator, data); }, versions);
     }
 
-    JSONRPC::JSONRPC(const std::vector<uint8_t> versions, const TokenCheckFunction& validation)
+    JSONRPC::JSONRPC(const std::vector<uint8_t>& versions, const TokenCheckFunction& validation)
         : _adminLock()
         , _handlers()
         , _service(nullptr)

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -412,6 +412,9 @@ namespace PluginHost {
         JSONRPCSupportsEventStatus& operator=(const JSONRPCSupportsEventStatus&) = delete;
 
         JSONRPCSupportsEventStatus() = default;
+        JSONRPCSupportsEventStatus(const TokenCheckFunction& validation) : JSONRPC(validation) {}
+        JSONRPCSupportsEventStatus(const std::vector<uint8_t> versions) : JSONRPC(versions) {}
+        JSONRPCSupportsEventStatus(const std::vector<uint8_t> versions, const TokenCheckFunction& validation) : JSONRPC(versions, validation) {}
         virtual ~JSONRPCSupportsEventStatus() = default;
 
         enum class Status { registered,

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -85,8 +85,8 @@ namespace PluginHost {
         JSONRPC& operator=(const JSONRPC&) = delete;
         JSONRPC();
         JSONRPC(const TokenCheckFunction& validation);
-        JSONRPC(const std::vector<uint8_t> versions);
-        JSONRPC(const std::vector<uint8_t> versions, const TokenCheckFunction& validation);
+        JSONRPC(const std::vector<uint8_t>& versions);
+        JSONRPC(const std::vector<uint8_t>& versions, const TokenCheckFunction& validation);
         ~JSONRPC() override;
 
     public:
@@ -413,8 +413,8 @@ namespace PluginHost {
 
         JSONRPCSupportsEventStatus() = default;
         JSONRPCSupportsEventStatus(const TokenCheckFunction& validation) : JSONRPC(validation) {}
-        JSONRPCSupportsEventStatus(const std::vector<uint8_t> versions) : JSONRPC(versions) {}
-        JSONRPCSupportsEventStatus(const std::vector<uint8_t> versions, const TokenCheckFunction& validation) : JSONRPC(versions, validation) {}
+        JSONRPCSupportsEventStatus(const std::vector<uint8_t>& versions) : JSONRPC(versions) {}
+        JSONRPCSupportsEventStatus(const std::vector<uint8_t>& versions, const TokenCheckFunction& validation) : JSONRPC(versions, validation) {}
         virtual ~JSONRPCSupportsEventStatus() = default;
 
         enum class Status { registered,


### PR DESCRIPTION
Reason for change: Allow non default
constructors of JSONRPC.
Test Procedure: It builds
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>