### PR TITLE
RDKB-27781: fix gcc 4.8.4 compile error when building for xb7

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -433,7 +433,7 @@ namespace Plugin {
 
         if (_resumes.size() > 0) {
             string callsign(plugin->Callsign());
-            std::list<string>::const_iterator index(_resumes.begin());
+            std::list<string>::iterator index(_resumes.begin());
 
             ASSERT(_service != nullptr);
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -763,4 +763,18 @@ namespace Core {
 #define BUILD_REFERENCE engineering_build_for_debug_purpose_only
 #endif
 
+#ifdef __GNUC__
+#if __GNUC__ < 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ < 9 || (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ < 3)))
+//defining atomic_init: see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64658"
+namespace std {
+  template<typename _ITp>
+    inline void
+    atomic_init(atomic<_ITp>* __a, _ITp __i) noexcept
+    {
+       __a->store(__i, memory_order_relaxed);
+    }
+}
+#endif
+#endif
+
 #endif // __PORTABILITY_H

--- a/Source/core/Queue.h
+++ b/Source/core/Queue.h
@@ -94,7 +94,7 @@ namespace Core {
             m_Admin.Lock();
 
             if (m_State != DISABLED) {
-                typename std::list<CONTEXT>::const_iterator
+                typename std::list<CONTEXT>::iterator
                     index
                     = std::find(m_Queue.begin(), m_Queue.end(), a_Entry);
 


### PR DESCRIPTION
Reason for change: While porting thunder to xb7, got compile errors
which needed addressing.  xb7 is currently using gcc 4.8.4.
Got errors passing const iterators to list::erase.
Test Procedure: verify build succeeds.  Ran a few basic tests with messenger on xb7 which worked.
Risks: Low
Signed-off-by: mrollins <mark_rollins@cable.comcast.com>