### PR TITLE
[ONEM-20141][cmake] breakpad compilation problem

### DIFF
--- a/Source/WPEProcess/CMakeLists.txt
+++ b/Source/WPEProcess/CMakeLists.txt
@@ -66,7 +66,7 @@ else()
 endif ()
 
 if(BREAKPAD_FOUND)
-    add_definitions(-DUSE_BREAKPAD=1)
+    add_definitions(-DUSE_BREAKPAD=1 -D__STDC_FORMAT_MACROS)
     target_link_libraries(${TARGET} PUBLIC ${BREAKPAD_LIBRARIES} pthread)
     target_include_directories(${TARGET} PUBLIC ${BREAKPAD_INCLUDE_DIRS})
 endif(BREAKPAD_FOUND)


### PR DESCRIPTION
Following error fix:
In file included from ...apollo-debug/usr/include/breakpad/google_breakpad/common/minidump_format.h:66:0,
                 from ...apollo-debug/usr/include/breakpad/client/linux/dump_writer_common/mapping_info.h:37,
                 from ...apollo-debug/usr/include/breakpad/client/linux/minidump_writer/linux_dumper.h:50,
                 from ...apollo-debug/usr/include/breakpad/client/linux/minidump_writer/minidump_writer.h:41,
                 from ...apollo-debug/usr/include/breakpad/client/linux/handler/exception_handler.h:42,
                 from ...git/Source/WPEProcess/Process.cpp:7:
apollo-debug/usr/include/breakpad/google_breakpad/common/breakpad_types.h:45:2: error: #error "inttypes.h has already been included before this header file, but "
 #error "inttypes.h has already been included before this header file, but "
  ^~~~~
apollo-debug/usr/include/breakpad/google_breakpad/common/breakpad_types.h:46:2: error: #error "without __STDC_FORMAT_MACROS defined."
 #error "without __STDC_FORMAT_MACROS defined."

refer to:
https://www.gnu.org/software/gnulib/manual/html_node/inttypes_002eh.html

It happened with 'arm-rdk-linux-gnueabi-g++ (GCC) 6.4.0' compiler.