### PR TITLE
[ProcessInfo[ Fallback to old Shared/Resident implementations

### DIFF
--- a/Source/core/ProcessInfo.cpp
+++ b/Source/core/ProcessInfo.cpp
@@ -420,8 +420,21 @@ namespace Core {
             }
         }
 #else
-        _memory.MemoryStats();
-        result = _memory.RSS();
+        int fd;
+        TCHAR buffer[128];
+        int VmRSS = 0;
+
+        snprintf(buffer, sizeof(buffer), "/proc/%d/statm", _pid);
+        if ((fd = open(buffer, O_RDONLY)) > 0) {
+            ssize_t readAmount = 0;
+            if ((readAmount = read(fd, buffer, sizeof(buffer))) > 0) {
+                ssize_t nulIndex = std::min(readAmount, static_cast<ssize_t>(sizeof(buffer) - 1));
+                buffer[nulIndex] = '\0';
+                sscanf(buffer, "%*d %d", &VmRSS);
+                result = VmRSS * PageSize;
+            }
+            close(fd);
+        }
 #endif
 
         return (result);
@@ -438,8 +451,21 @@ namespace Core {
             }
         }
 #else
-        _memory.MemoryStats();
-        result = _memory.Shared();
+        int fd;
+        TCHAR buffer[128];
+        int Share = 0;
+
+        snprintf(buffer, sizeof(buffer), "/proc/%d/statm", _pid);
+        if ((fd = open(buffer, O_RDONLY)) > 0) {
+            ssize_t readAmount = 0;
+            if ((readAmount = read(fd, buffer, sizeof(buffer))) > 0) {
+                ssize_t nulIndex = std::min(readAmount, static_cast<ssize_t>(sizeof(buffer) - 1));
+                buffer[nulIndex] = '\0';
+                sscanf(buffer, "%*d %*d %d", &Share);
+                result = Share * PageSize;
+            }
+            close(fd);
+        }
 #endif
 
         return (result);

--- a/Source/core/ProcessInfo.h
+++ b/Source/core/ProcessInfo.h
@@ -315,9 +315,6 @@ namespace Core {
         }
 #endif
         uint64_t Allocated() const;
-        /**
-         * @brief On Linux, MemoryStats() is called inside those 2 methods, no need to call it beforehand
-         */
         uint64_t Resident() const;
         uint64_t Shared() const;
 


### PR DESCRIPTION
However parsing smaps gives more accurate measurements, it causes the Monitor plugin to use more CPU%. Moreover, to be able to use smaps a kernel config must be enabled (CONFIG_PROC_PAGE_MONITOR). 