### PR TITLE
ONEM-18294: assert and abort in Singleton destructor

### DIFF
--- a/Source/core/Singleton.cpp
+++ b/Source/core/Singleton.cpp
@@ -37,7 +37,9 @@ namespace Core {
     /* virtual */ Singleton::SingletonList::~SingletonList()
     {
         // Dispose was not called before main application was ended
-        if (!m_Singletons.empty()) TRACE_L1("%s !!! singleton list is not empty !!!", __FUNCTION__);
+        if (!m_Singletons.empty()) {
+            TRACE_L1("%s !!! singleton list is not empty !!!", __FUNCTION__);
+        }
         Dispose();
     }
 

--- a/Source/core/Singleton.cpp
+++ b/Source/core/Singleton.cpp
@@ -36,8 +36,6 @@ namespace Core {
 
     /* virtual */ Singleton::SingletonList::~SingletonList()
     {
-        // Dispose was not called before main application was ended
-        ASSERT(m_Singletons.empty() == true);
         Dispose();
     }
 

--- a/Source/core/Singleton.cpp
+++ b/Source/core/Singleton.cpp
@@ -37,7 +37,7 @@ namespace Core {
     /* virtual */ Singleton::SingletonList::~SingletonList()
     {
         // Dispose was not called before main application was ended
-        ASSERT(m_Singletons.empty() == true);
+        if (!m_Singletons.empty()) TRACE_L1("%s !!! singleton list is not empty !!!", __FUNCTION__);
         Dispose();
     }
 


### PR DESCRIPTION
Why would like to remove assert ?

For most of the cases it is not a problem. Assert just mandates to invoke
Dispose() by application that is fine for most of the cases, but it is one
known scenario when it is problematic for aaamp-cli:

(1) Run aamp-cli
(2) aamp-cli will start to enumerate gstreamer plugins will start
    gst-plugin-scanner process - gst-plugin-scanner will have his own copy
    of Singleton
(3) It will crash assert->abort the gst-plugin-scanner on exit in the following
    way:

Core was generated by `/usr/libexec/gstreamer-1.0/gst-plugin-scanner -l'.
Program terminated with signal SIGABRT, Aborted.
0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
47    ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S: No such file or directory.
[Current thread is 1 (LWP 4671)]
0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
1  0xb6033af6 in __libc_signal_restore_set (set=0xbee0f6c8) at /usr/src/debug/glibc/2.24-r0/git/sysdeps/unix/sysv/linux/nptl-signals.h:79
2  __GI_raise (sig=sig@entry=6) at /usr/src/debug/glibc/2.24-r0/git/sysdeps/unix/sysv/linux/raise.c:55
3  0xb60347d6 in __GI_abort () at /usr/src/debug/glibc/2.24-r0/git/stdlib/abort.c:89
4  0xb53196f6 in WPEFramework::Core::Singleton::SingletonList::~SingletonList (this=0xb533ceb8 <WPEFramework::Core::Singleton::ListInstance()::g_Singletons>, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+ce0d0e5abd-r0/git/Source/core/Singleton.cpp:40
5  0xb603546a in __run_exit_handlers (status=-1092552732, listp=0x1, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at /usr/src/debug/glibc/2.24-r0/git/stdlib/exit.c:83
6  0xb60354cc in __GI_exit (status=<optimized out>) at /usr/src/debug/glibc/2.24-r0/git/stdlib/exit.c:105
7  0xb602765a in __libc_start_main (main=0x86c1 <_start>, argc=-1092552408, argv=0x0, init=<optimized out>, fini=0x87e5 <__libc_csu_fini>, rtld_fini=0xb6f7b1bd <_dl_fini>, stack_end=0xbee0fa84) at /usr/src/debug/glibc/2.24-r0/git/csu/libc-start.c:323
8  0x000086e0 in _start () at ../sysdeps/arm/start.S:124
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

(4) It is really not obsious how and where in such scenario invoke mandated
    by assert Dispose()