### PR TITLE
ONEM-18296: Usage of created by systemd sockets instead of creating them

### DIFF
--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -228,6 +228,15 @@ if(ExecInfo_FOUND)
             )
 endif()
 
+find_package(Systemd)
+if (SYSTEMD_FOUND)
+    target_link_libraries( ${TARGET}
+        PRIVATE
+        Systemd::Systemd
+    )
+    SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DSYSTEMD_FOUND")
+endif()
+
 # ===========================================================================================
 # Install ARTIFACTS:
 # ===========================================================================================

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -44,6 +44,9 @@
 #include <signal.h>
 #include <sys/ioctl.h>
 #include <sys/signalfd.h>
+#ifdef SYSTEMD_FOUND
+#include <systemd/sd-daemon.h>
+#endif
 #endif
 
 #ifdef __WINDOWS__
@@ -320,7 +323,8 @@ namespace Core {
         , m_ReceivedNode()
         , m_SendBuffer(nullptr)
         , m_ReceiveBuffer(nullptr)
-	, m_Interface(~0)
+        , m_Interface(~0)
+        , m_SystemdSocket(false)
     {
         TRACE_L5("Constructor SocketPort (NodeId&) <%p>", (this));
     }
@@ -342,7 +346,8 @@ namespace Core {
         , m_ReceivedNode()
         , m_SendBuffer(nullptr)
         , m_ReceiveBuffer(nullptr)
-	, m_Interface(~0)
+        , m_Interface(~0)
+        , m_SystemdSocket(false)
     {
         NodeId::SocketInfo localAddress;
         socklen_t localSize = sizeof(localAddress);
@@ -636,12 +641,40 @@ namespace Core {
         SOCKET l_Result = INVALID_SOCKET;
 
 #ifndef __WINDOWS__
+        int foundUnixSocketFd = -1;
         // Check if domain path already exists, if so remove.
         if ((localNode.Type() == NodeId::TYPE_DOMAIN) && (m_SocketType == SocketPort::LISTEN)) {
-            if (access(localNode.HostName().c_str(), F_OK) != -1) {
-                TRACE_L1("Found out domain path already exists, deleting: %s", localNode.HostName().c_str());
-                remove(localNode.HostName().c_str());
+            if (access(localNode.HostName().c_str(), R_OK | W_OK) != -1) {
+#ifdef SYSTEMD_FOUND
+                int fd, n;
+                n = sd_listen_fds(0);
+                TRACE_L1("Found %d systemd created listening sockets", n);
+                if (n > 0) {
+                    for (fd = SD_LISTEN_FDS_START; fd < SD_LISTEN_FDS_START + n; fd++) {
+                        if (sd_is_socket_unix(fd, SOCK_STREAM, 1, localNode.HostName().c_str(), 0)) {
+                            TRACE_L1("Use systemd created socket for: %s fd=%d", localNode.HostName().c_str(), fd);
+                            foundUnixSocketFd = fd;
+                            m_SystemdSocket = true;
+                            break;
+                        }
+                    }
+                }
+#endif
+                if (foundUnixSocketFd == -1) {
+                    TRACE_L1("Found out domain path already exists, deleting: %s", localNode.HostName().c_str());
+                    remove(localNode.HostName().c_str());
+                }
             }
+        }
+        if (foundUnixSocketFd != -1) {
+            if (SetNonBlocking(foundUnixSocketFd) == false) {
+                TRACE_L1("Error on setting non blocking");
+            } else {
+                l_Result = foundUnixSocketFd;
+                BufferAlignment(l_Result);
+            }
+            TRACE_L1("Return valid unix socket for %s fd=%d", localNode.HostName().c_str(), l_Result);
+            return l_Result;
         }
 #endif
 
@@ -1098,7 +1131,9 @@ namespace Core {
             DestroySocket(m_Socket);
             ResourceMonitor::Instance().Unregister(*this);
             // Remove socket descriptor for UNIX domain datagram socket.
-            if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) && ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM))) {
+            if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) && 
+                ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM)) &&
+                !m_SystemdSocket) {
                 TRACE_L1("CLOSED: Remove socket descriptor %s", m_LocalNode.HostName().c_str());
 #ifdef __WINDOWS__
                 _unlink(m_LocalNode.HostName().c_str());

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -269,6 +269,7 @@ namespace Core {
         uint16_t m_SendBytes;
         uint16_t m_SendOffset;
         uint32_t m_Interface;
+        bool m_SystemdSocket;
     };
 
     class EXTERNAL SocketStream : public SocketPort {

--- a/cmake/modules/FindSystemd.cmake
+++ b/cmake/modules/FindSystemd.cmake
@@ -1,0 +1,41 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_SYSTEMD libsystemd)
+
+if(${PC_SYSTEMD_FOUND})
+    find_library(SYSTEMD_LIBRARY systemd
+        HINTS ${PC_SYSTEMD_LIBDIR} ${PC_SYSTEMD_LIBRARY_DIRS} REQUIRED
+        )
+    find_path(SYSTEMD_INCLUDE systemd/sd-daemon.h
+        PATHS ${PC_SYSTEMD_INCLUDE_DIRS}
+        )
+
+    set(SYSTEMD_FOUND ${PC_SYSTEMD_FOUND})
+    if(NOT TARGET Systemd::Systemd)
+        add_library(Systemd::Systemd UNKNOWN IMPORTED)
+
+        set_target_properties(Systemd::Systemd
+            PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${SYSTEMD_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${SYSTEMD_INCLUDE}"
+            INTERFACE_LINK_LIBRARIES "${PC_SYSTEMD_LIBRARIES}"
+        )
+    endif()
+endif()


### PR DESCRIPTION
Existence of socket is checked and if the socket was created by systemd, systemd
file descriptor is used.
Additional behaviour implemented for such sockets: avoid unlinking.

Feature conditionally enabled depending on systemd library existence on target
platform.