### PR TITLE
Development/module name

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -32,7 +32,23 @@ namespace Plugin {
     // Signing will be done on BackOffice level. The Controller I/F will never be exposed to the outside world.
     static Core::ProxyPoolType<Web::JSONBodyType<PluginHost::MetaData>> jsonBodyMetaDataFactory(1);
     static Core::ProxyPoolType<Web::JSONBodyType<PluginHost::MetaData::Service>> jsonBodyServiceFactory(1);
+    static Core::ProxyPoolType<JSONCallstack> jsonBodyCallstackFactory(1);
     static Core::ProxyPoolType<Web::TextBody> jsonBodyTextFactory(2);
+
+    Core::ProxyType<JSONCallstack> Callstack (const Core::WorkerPool* workerPool, const uint32_t index) {
+        Core::ProxyType<JSONCallstack> response = jsonBodyCallstackFactory.Element();
+        std::list<string> stackList;
+
+        ThreadId threadId = workerPool->Id(index);
+
+        DumpCallStack(threadId, stackList);
+
+        for (const string& entry : stackList) {
+            response->Add() = entry;
+        }
+
+        return (response);
+    }
 
     void Controller::SubSystems(Core::JSON::ArrayType<Core::JSON::EnumType<PluginHost::ISubSystem::subsystem>>::ConstIterator& index)
     {
@@ -254,6 +270,16 @@ namespace Plugin {
             WorkerPoolMetaData(response->Process);
 
             result->Body(Core::proxy_cast<Web::IBody>(response));
+        } else if (index.Current() == _T ("Callstack")) {
+            if (index.Next() == false) {
+                result->ErrorCode = Web::STATUS_BAD_REQUEST;
+                result->Message = _T("Probe functionality not enabled!");
+            }
+            else {
+                Core::NumberType<uint8_t> threadIndex(index.Current());
+                Core::ProxyType<JSONCallstack> response = Callstack (&(_pluginServer->WorkerPool()), threadIndex.Value());
+                result->Body(Core::proxy_cast<Web::IBody>(response));
+            }
         } else if (index.Current() == _T("Discovery")) {
 
             if (_probe == nullptr) {

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -1,4 +1,4 @@
- /*
+/*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
@@ -27,6 +27,10 @@
 
 namespace WPEFramework {
 namespace Plugin {
+
+    using JSONCallstack =  Web::JSONBodyType < Core::JSON::ArrayType < Core::JSON::String > >;
+
+    extern Core::ProxyType<JSONCallstack> Callstack (const Core::WorkerPool* workerPool, const uint32_t index);
 
     class Controller : public PluginHost::IPlugin, public PluginHost::IWeb, public PluginHost::JSONRPC {
     private:
@@ -276,8 +280,8 @@ namespace Plugin {
 
             return (service);
         }
-		void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const
-		{
+	void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const
+	{
             const Core::WorkerPool::Metadata& snapshot = Core::WorkerPool::Instance().Snapshot();
 
             data.PendingRequests = snapshot.Pending;
@@ -289,7 +293,7 @@ namespace Plugin {
                 newElement = snapshot.Slot[teller];
                 data.ThreadPoolRuns.Add(newElement);
             }
-		}
+	}
         void SubSystems();
         void SubSystems(Core::JSON::ArrayType<Core::JSON::EnumType<PluginHost::ISubSystem::subsystem>>::ConstIterator& index);
         Core::ProxyType<Web::Response> GetMethod(Core::TextSegmentIterator& index) const;

--- a/Source/bluetooth/bluetooth.h
+++ b/Source/bluetooth/bluetooth.h
@@ -16,7 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
+
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
 
 #include "IDriver.h"
 #include "HCISocket.h"

--- a/Source/broadcast/broadcast.h
+++ b/Source/broadcast/broadcast.h
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-#ifndef __BROADCAST_H
-#define __BROADCAST_H
+#pragma once
 
-#include "Module.h"
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
 
 #include "Definitions.h"
 #include "Descriptors.h"
@@ -38,5 +39,3 @@
 #ifdef __WINDOWS__
 #pragma comment(lib, "broadcast.lib")
 #endif
-
-#endif // __BROADCAST_H

--- a/Source/com/com.h
+++ b/Source/com/com.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
+
 #include "Administrator.h"
 #include "Communicator.h"
 #include "ConnectorType.h"

--- a/Source/core/core.h
+++ b/Source/core/core.h
@@ -20,6 +20,10 @@
 #ifndef __GENERICS_H
 #define __GENERICS_H
 
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
+
 #include <algorithm>
 #include <iostream>
 #include <list>

--- a/Source/cryptalgo/cryptalgo.h
+++ b/Source/cryptalgo/cryptalgo.h
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
  
-#ifndef __CRYPTALGO_H
-#define __CRYPTALGO_H
+#pragma once
 
-#include "Module.h"
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
 
 #include "AES.h"
 #include "HMAC.h"
@@ -28,12 +29,10 @@
 #include "HashStream.h"
 #include "Random.h"
 
-#if defined(SECURESOCKETS_ENABLED) || defined(__WINDOWS__)
+#if defined(SECURESOCKETS_ENABLED)
 #include "SecureSocketPort.h"
 #endif
 
 #ifdef __WINDOWS__
 #pragma comment(lib, "cryptalgo.lib")
 #endif
-
-#endif // __CRYPTALGO_H

--- a/Source/plugins/plugins.h
+++ b/Source/plugins/plugins.h
@@ -17,8 +17,11 @@
  * limitations under the License.
  */
 
-#ifndef __PLUGIN_FRAMEWORK_SUPPORT_H
-#define __PLUGIN_FRAMEWORK_SUPPORT_H
+#pragma once
+
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
 
 // Since this header is included, the code using it is external to Thunder core.
 // So therefore it should use the correct Tracing functionality and not TRACE_L# (which are just fancy printfs).
@@ -43,5 +46,3 @@
 #ifdef __WINDOWS__
 #pragma comment(lib, "plugins.lib")
 #endif
-
-#endif // __PLUGIN_FRAMEWORK_SUPPORT_H

--- a/Source/tracing/tracing.h
+++ b/Source/tracing/tracing.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
+
 #include "ITraceControl.h"
 #include "ITraceMedia.h"
 #include "Logging.h"

--- a/Source/warningreporting/warningreporting.h
+++ b/Source/warningreporting/warningreporting.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
+
 #include "IWarningReportingMedia.h"
 #include "WarningReportingUnit.h"
 

--- a/Source/websocket/websocket.h
+++ b/Source/websocket/websocket.h
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-#ifndef __WEBSOCKET_H
-#define __WEBSOCKET_H
+#pragma once
 
-#include "Module.h"
+#ifndef MODULE_NAME
+#error "Please define a MODULE_NAME that describes the binary/library you are building."
+#endif
 
 #include "URL.h"
 #include "JSONWebToken.h"
@@ -36,5 +37,3 @@
 #ifdef __WINDOWS__
 #pragma comment(lib, "websocket.lib")
 #endif
-
-#endif // __WEBSOCKET_H


### PR DESCRIPTION
Whenever a module (library or application) includes a Thunder library, this commit will force a compilation error if no MODULE_NAME is defined.
Defining (and declaring) a module name is important as Tracing and Warning Reporting will correctly identify the proper module that is applicable to the Tracing category or the Warning Reporting. If it is not set. The warning or the Traces might be coupled to the wrong modules and debugging will start at the wrong entry point.