### PR TITLE
Extend Web::Authorization class to support BASIC header

### DIFF
--- a/Source/websocket/WebRequest.h
+++ b/Source/websocket/WebRequest.h
@@ -157,7 +157,8 @@ namespace Web {
     class EXTERNAL Authorization {
     public:
         enum type {
-            BEARER
+            BEARER,
+            BASIC
         };
 
     public:

--- a/Source/websocket/WebSerializer.cpp
+++ b/Source/websocket/WebSerializer.cpp
@@ -311,6 +311,7 @@ ENUM_CONVERSION_END(Crypto::EnumHashType)
 ENUM_CONVERSION_BEGIN(Web::Authorization::type)
 
     { Web::Authorization::BEARER, _TXT("Bearer") },
+    { Web::Authorization::BASIC, _TXT("Basic") },
 
 ENUM_CONVERSION_END(Web::Authorization::type)
 


### PR DESCRIPTION
Extend Web::Authorization class to support BASIC header.
If username and password is needed for a web request, base64 encoded value of "username:password"
should be generated and passed as BASIC header value for the WebRequest.