### PR TITLE
SocketPort: Replace memcpy() on overlapping buffer with memmove() on Read()

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1096,7 +1096,7 @@ namespace Core {
 
                 if ((m_ReadBytes != 0) && (handledBytes != 0)) {
                     // Oops not all data was consumed, Lets remove the read data
-                    ::memcpy(m_ReceiveBuffer, &m_ReceiveBuffer[handledBytes], m_ReadBytes);
+                    ::memmove(m_ReceiveBuffer, &m_ReceiveBuffer[handledBytes], m_ReadBytes);
                 }
             }
         }


### PR DESCRIPTION
The SocketPort::Read() method is doing a memcpy() on overlapping memory
regions (destination and source buffers are the same). This is
considered undefined behavior ([1]) and should be replaced with a
memmove() instead, so do that.

[1] https://man7.org/linux/man-pages/man3/memcpy.3.html

Signed-off-by: Ricardo Silva <ricardo.josilva@parceiros.nos.pt>