### PR TITLE
Bluetooth: Ignore ATT_OP_HANDLE_NOTIFY events in GATTSocket::Command::Deserialize()

### DIFF
--- a/Source/bluetooth/GATTSocket.cpp
+++ b/Source/bluetooth/GATTSocket.cpp
@@ -95,7 +95,7 @@ uint16_t Attribute::Deserialize(const uint16_t size, const uint8_t stream[])
     // See if we need to retrigger..
     if ((stream[0] != _id) && ((stream[0] != ATT_OP_ERROR) && (stream[1] == _id))) {
         TRACE_L1(_T("Unexpected L2CapSocket message. Expected: %d, got %d [%d]"), _id, stream[0], stream[1]);
-    } else {
+    } else if (stream[0] != ATT_OP_HANDLE_NOTIFY) {
         result = length;
 
         // TRACE_L1(_T("L2CapSocket Receive [%d], Type: %02X"), length, stream[0]);


### PR DESCRIPTION
Do not process ATT_OP_HANDLE_NOTIFY incoming messages (events) in
GATTSocket::Command::Deserialize(), as these are events generated by the
device and not associated with any previous command or expected
response, so for these cases, this method must return zero, so these
events can then still be forwarded to the correct consumers.

If there's some pending Command/Response in the GATTSocket and some
unsolicited event (ATT_OP_HANDLE_NOTIFY) arrives at socket in the
meanwhile, GATTSocket::Command::Deserialize() will be called to check if
this incoming data is for the pending Command/Response. Since, by
definition, a ATT_OP_HANDLE_NOTIFY incoming packet os not a response for
any command, then this method should be able to detect that and not
consume the data (i.e., return zero), otherwise the base
SynchronousChannelType::ReceiveData() won't forward this event to where
it is expected, meaning the event gets missed.

There are cases where the ATT_OP_HANDLE_NOTIFY events are being consumed
by GATTSocket::Command::Deserialize(), because they go through the
'else' block and then end up in the 'default' clause from the
'switch/case' inside that 'else', in which case the method returns zero,
meaning it "consumed" the data, then preventing it from reaching the
expected destination.

This is happening with GATTSocket instances created by the
BluetoothRemoteControl, for example in a scenario where the user presses
some key when the BLE RCU is disconnected. A GATTSocket is connected
when this happens and, during the connection process, there are some
commands being sent by the host at the same time that the RCU also sends
key events, which is then causing these key events (ATT_OP_HANDLE_NOTIFY
messages) to reach GATTSocket::Command::Deserialize() and be incorrectly
consumed there, causing these key events to be missed.

This way, make sure the 'else' code is only used if the message is not a
ATT_OP_HANDLE_NOTIFY event.

Signed-off-by: Ricardo Silva <ricardo.josilva@parceiros.nos.pt>