### PR TITLE
Bluetooth: GATTSocket: Don't set SocketPort send/recv sizes based on maxMTU

### DIFF
--- a/Source/bluetooth/GATTSocket.h
+++ b/Source/bluetooth/GATTSocket.h
@@ -777,7 +777,14 @@ namespace Bluetooth {
 
     public:
         GATTSocket(const Core::NodeId& localNode, const Core::NodeId& remoteNode, const uint16_t maxMTU)
-            : Core::SynchronousChannelType<Core::SocketPort>(SocketPort::SEQUENCED, localNode, remoteNode, maxMTU, maxMTU)
+            : Core::SynchronousChannelType<Core::SocketPort>(SocketPort::SEQUENCED, localNode, remoteNode, static_cast<uint16_t>(~0), static_cast<uint16_t>(~0))
+            , _adminLock()
+            , _sink(*this, maxMTU)
+            , _queue()
+        {
+        }
+        GATTSocket(const Core::NodeId& localNode, const Core::NodeId& remoteNode, const uint16_t maxMTU, const uint16_t sendBufferSize, const uint16_t recvBufferSize)
+            : Core::SynchronousChannelType<Core::SocketPort>(SocketPort::SEQUENCED, localNode, remoteNode, sendBufferSize, recvBufferSize)
             , _adminLock()
             , _sink(*this, maxMTU)
             , _queue()


### PR DESCRIPTION
The GATTSocket constructor is using its 'maxMTU' parameter for setting
the CommandSink's preferred MTU, but also for setting the send/recv
buffer sizes from on the underlying socket managed by SocketPort. These
are different concepts and should not be mixed, because the socket
buffer sizes should be large enough to accommodate for send/recv bursts
of several MTUs and latency on socket polling.

This actually causing incoming packet loss on the GATTSocket, e.g.,
when used from the BluetoohRemoteControl plugin, which is setting the
'maxMTU' to 255 bytes (kernel then imposes a 2240 bytes minimum),
resulting in RCU key events and voice data packets loss.

This way, change the GATTSocket constructor implementation to let
SocketPort (and then the kernel) use the defaults for the socket buffer
sizes, by specifying ~0 for both send and receive buffer sizes.

To still allow configuring the actual socket buffer sizes, introduce a
new GATTSocket constructor with arguments for the socket's send and
receive buffer sizes.

Signed-off-by: Ricardo Silva <ricardo.josilva@parceiros.nos.pt>