### PR TITLE
Bluetooth: Only set L2CAP_LM option if setting BT_SECURITY option fails

### DIFF
--- a/Source/bluetooth/GATTSocket.cpp
+++ b/Source/bluetooth/GATTSocket.cpp
@@ -326,12 +326,12 @@ bool GATTSocket::Security(const uint8_t level)
 
     if (result == true) {
         struct bt_security btSecurity = { .level = level, 0 };
-        if (::setsockopt(Handle(), SOL_BLUETOOTH, BT_SECURITY, &btSecurity, sizeof(btSecurity))) {
-            TRACE_L1("Failed to set Bluetooth Security level for device [%s], error: %d", RemoteId().c_str(), errno);
-            result = false;
-        } else if (::setsockopt(Handle(), SOL_L2CAP, L2CAP_LM, &lm, sizeof(lm)) < 0) {
-            TRACE_L1("Error setting L2CAP Security for device [%s], error: %d", RemoteId().c_str(), errno);
-            result = false;
+        if (::setsockopt(Handle(), SOL_BLUETOOTH, BT_SECURITY, &btSecurity, sizeof(btSecurity)) != 0) {
+            TRACE_L1("Failed to set Bluetooth Security level for device [%s], error: %d, try L2CAP Security", RemoteId().c_str(), errno);
+            if (::setsockopt(Handle(), SOL_L2CAP, L2CAP_LM, &lm, sizeof(lm)) != 0) {
+                TRACE_L1("Error setting L2CAP Security for device [%s], error: %d", RemoteId().c_str(), errno);
+                result = false;
+            }
         }
     }
 


### PR DESCRIPTION
When setting the GATTSocket Security, the sequence should be first to
try and set the SOL_BLUETOOTH/BT_SECURITY option first and, only if that
fails, try setting the SOL_L2CAP/L2CAP_LM equivalent option. This is
what the reference code (bluez's gattool) is doing.

This way, rework the option setting logic in GATTSocket::Security() to
follow what the reference code does.

Signed-off-by: Ricardo Silva <ricardo.josilva@parceiros.nos.pt>