### PR TITLE
ONEM-21088 - fix for abort() via websocket JSONRPC

### DIFF
--- a/Source/WPEFramework/ControllerJsonRpc.cpp
+++ b/Source/WPEFramework/ControllerJsonRpc.cpp
@@ -435,8 +435,6 @@ namespace Plugin {
     //  - ERROR_NONE: Success
     uint32_t Controller::get_discoveryresults(Core::JSON::ArrayType<PluginHost::MetaData::Bridge>& response) const
     {
-        ASSERT(_probe != nullptr);
-
         if (_probe != nullptr) {
             Probe::Iterator index(_probe->Instances());
 


### PR DESCRIPTION
websocket calls to JSONRPC are not checked against _probe nullptr. 
That check is present in http based requests only. 
I would like to remove this assert and keep existing check introduced on master. 