### PR TITLE
ONEM-20048: Reverse sequence on closed connection

### DIFF
--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -886,6 +886,8 @@ namespace RPC {
 
                     std::list<RPC::IRemoteConnection::INotification*>::iterator observer(_observers.begin());
 
+                    _parent.Closed(destructed);
+
                     while (observer != _observers.end()) {
                         (*observer)->Deactivated(index->second);
                         observer++;
@@ -898,8 +900,6 @@ namespace RPC {
                     index->second->Release();
                     _connections.erase(index);
                     _adminLock.Unlock();
-
-                    _parent.Closed(destructed);
 
                     connection->Release();
                 }


### PR DESCRIPTION
Reverse sequence in WPEFramework::RPC::Communicator::RemoteConnectionMap::Closed:
1) _parent.Closed(destructed); - it will invoke WPEFramework::RPC::Administrator::DeleteChannel and do the cleanup in _channelReferenceMap
2) Then notify all observers about closed connection - some of the plugins are registrered on that
3) Plugins on that notification start the job in separate thread: Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
4) ... and always later Plugin.Deinitialize on plugin is invoked 

If points 1) and 2) is swapped we have race on WPEFramework::RPC::Administrator::DeleteChannel and Plugin.Deinitialize

It is enough to grant that point (1) is before (4) and it is always this way now.

Example problematic callstacks (FireboltMediaPlayer):
[Switching to Thread 7433.7553]

Thread 6 "WPEFramework" hit Breakpoint 1, WPEFramework::Core::Sink<WPEFramework::Plugin::FireboltMediaPlayer::MediaStreamProxy::MediaStreamSink>::~Sink (this=0x24d1a4, __in_chrg=<optimized out>, 
    __vtt_parm=<optimized out>) at /usr/include/WPEFramework/core/Services.h:184
184    in /usr/include/WPEFramework/core/Services.h
(gdb) bt
#0  WPEFramework::Core::Sink<WPEFramework::Plugin::FireboltMediaPlayer::MediaStreamProxy::MediaStreamSink>::~Sink (this=0x24d1a4, __in_chrg=<optimized out>, __vtt_parm=<optimized out>)
    at /usr/include/WPEFramework/core/Services.h:184
#1  0xb251be92 in WPEFramework::Plugin::FireboltMediaPlayer::MediaStreamProxy::~MediaStreamProxy (this=0x24d180, __in_chrg=<optimized out>)
    at /usr/src/debug/rdkservice-fireboltmediaplayer/3.0+gitAUTOINC+7cbed4f3c1-r1/git/FireboltMediaPlayer/FireboltMediaPlayer.cpp:32
#2  0xb251bee0 in WPEFramework::Plugin::FireboltMediaPlayer::MediaStreamProxy::~MediaStreamProxy (this=0x24d180, __in_chrg=<optimized out>)
    at /usr/src/debug/rdkservice-fireboltmediaplayer/3.0+gitAUTOINC+7cbed4f3c1-r1/git/FireboltMediaPlayer/FireboltMediaPlayer.cpp:45
#3  0xb251c812 in WPEFramework::Plugin::FireboltMediaPlayer::Deinitialize (this=0x23cfb0, service=0x1df4f4)
    at /usr/src/debug/rdkservice-fireboltmediaplayer/3.0+gitAUTOINC+7cbed4f3c1-r1/git/FireboltMediaPlayer/FireboltMediaPlayer.cpp:118
#4  0x0013b49a in WPEFramework::PluginHost::Server::Service::Deactivate (this=0x1df4f0, why=WPEFramework::PluginHost::IShell::FAILURE)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/WPEFramework/PluginServer.cpp:460
#5  0xb6f0027a in WPEFramework::PluginHost::IShell::Job::Dispatch (this=0x23d650) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/plugins/IShell.h:112
#6  0x00139b56 in WPEFramework::PluginHost::Server::WorkerPoolImplementation::Dispatcher::Dispatch (this=0x1d8cac, job=0x23d650)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/WPEFramework/PluginServer.cpp:182
#7  0x00140248 in WPEFramework::Core::ThreadPool::Minion::Process (this=0x1e9a00) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/ThreadPool.h:191
#8  0x001404e2 in WPEFramework::Core::ThreadPool::Executor::Worker (this=0x1e9910) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/ThreadPool.h:261
#9  0xb6d01370 in WPEFramework::Core::Thread::StartThread (cClassPointer=0x1e9910) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/Thread.cpp:172

====>>> this=0x24d1a4

Thread 3 "WPEFramework" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 7433.7549]
0xb6ded59a in WPEFramework::RPC::Administrator::DeleteChannel (this=0xb6e5cc34 <WPEFramework::RPC::Administrator::Instance()::systemAdministrator>, channel=..., pendingProxies=...)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/build/Source/protocols/com/Administrator.cpp:313
313    /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/build/Source/protocols/com/Administrator.cpp: No such file or directory.
(gdb) bt
#0  0xb6ded59a in WPEFramework::RPC::Administrator::DeleteChannel (this=0xb6e5cc34 <WPEFramework::RPC::Administrator::Instance()::systemAdministrator>, channel=..., pendingProxies=...)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/build/Source/protocols/com/Administrator.cpp:313
#1  0xb6e011f6 in WPEFramework::RPC::Communicator::Closed (this=0x1d8f58, channel=...) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/build/Source/protocols/com/Communicator.h:1274
#2  0xb6dff888 in WPEFramework::RPC::Communicator::RemoteConnectionMap::Closed (this=0x1d8f5c, id=3)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/build/Source/protocols/com/Communicator.h:866
#3  0xb6e0086a in WPEFramework::RPC::Communicator::ChannelLink::StateChange (this=0x230228) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/build/Source/protocols/com/Communicator.h:1060
#4  0xb6e1d46e in WPEFramework::Core::IPCChannelType<WPEFramework::Core::SocketPort, WPEFramework::RPC::Communicator::ChannelLink>::__StateChange<WPEFramework::Core::SocketPort, WPEFramework::RPC::Communicator::ChannelLink> (this=0x22ff78) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/IPCConnector.h:1054
#5  0xb6e1cfa2 in WPEFramework::Core::IPCChannelType<WPEFramework::Core::SocketPort, WPEFramework::RPC::Communicator::ChannelLink>::StateChange (this=0x22ff78)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/IPCConnector.h:1042
#6  0xb6e1ce82 in WPEFramework::Core::IPCChannelClientType<WPEFramework::RPC::Communicator::ChannelLink, false, false>::StateChange (this=0x22ff78)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/IPCChannel.h:138
#7  0xb6e1d0d8 in WPEFramework::Core::IPCChannelType<WPEFramework::Core::SocketPort, WPEFramework::RPC::Communicator::ChannelLink>::IPCLink::StateChange (this=0x22ffe0)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/IPCConnector.h:879
#8  0xb6f2c2d4 in WPEFramework::Core::LinkType<WPEFramework::Core::SocketPort, WPEFramework::Core::IMessage, WPEFramework::Core::IMessage, WPEFramework::Core::IPCChannel::IPCFactory&>::HandlerType<WPEFramework::Core::LinkType<WPEFramework::Core::SocketPort, WPEFramework::Core::IMessage, WPEFramework::Core::IMessage, WPEFramework::Core::IPCChannel::IPCFactory&>, WPEFramework::Core::SocketPort>::StateChange (
    this=0x230040) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/Link.h:216
#9  0xb6cfc816 in WPEFramework::Core::SocketPort::Closed (this=0x230040) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/SocketPort.cpp:1119
#10 0xb6cfbe56 in WPEFramework::Core::SocketPort::Handle (this=0x230040, flagsSet=17) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/SocketPort.cpp:961
#11 0xb6ccab9a in WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>::Worker (this=0x1d6a48)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/ResourceMonitor.h:422
#12 0xb6cca2aa in WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>::MonitorWorker::Worker (this=0x1d6bf8)
    at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/ResourceMonitor.h:82
#13 0xb6d01370 in WPEFramework::Core::Thread::StartThread (cClassPointer=0x1d6bf8) at /usr/src/debug/wpeframework/rdkv-2019q4+gitAUTOINC+cc494fb280-r0/git/Source/core/Thread.cpp:172
#14 0xb6a97616 in start_thread (arg=0x0) at /usr/src/debug/glibc/2.24-r0/git/nptl/pthread_create.c:458
#15 0xb6b37f12 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:86 from ./rootfs/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

(gdb) p loop->Unknown()
$1 = (WPEFramework::Core::IUnknown *) 0x24d1a4




