### PR TITLE
Development/unavailable

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -373,6 +373,29 @@ namespace Plugin {
                         }
                     }
                 }
+            } else if (index.Current() == _T("Unavailable")) {
+                if (index.Next()) {
+                    const string callSign(index.Current().Text());
+                    if (callSign == _service->Callsign()) {
+                        result->ErrorCode = Web::STATUS_FORBIDDEN;
+                        result->Message = _T("The PluginHost Controller can not set Unavailable.");
+                    } else {
+                        Core::ProxyType<PluginHost::Server::Service> pluginInfo(FromIdentifier(callSign));
+
+                        if (pluginInfo.IsValid()) {
+                            if (pluginInfo->State() == PluginHost::IShell::DEACTIVATED) {
+                                // Mark the plugin as unavailable.
+                                if (pluginInfo->Unavailable(PluginHost::IShell::REQUESTED) != Core::ERROR_NONE) {
+                                    result->ErrorCode = Web::STATUS_NOT_MODIFIED;
+                                    result->Message = _T("Marking the plugin as Unavailble failed.");
+                                }
+                            }
+                        } else {
+                            result->ErrorCode = Web::STATUS_NOT_FOUND;
+                            result->Message = _T("There is no callsign: ") + callSign;
+                        }
+                    }
+                }
             } else if (index.Current() == _T("Configuration")) {
                 if ((index.Next() == true) && (request.HasBody() == true)) {
 

--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -512,6 +512,10 @@ namespace Plugin {
         event_statechange(callsign, PluginHost::IShell::DEACTIVATED, plugin->Reason());
     }
 
+    void Controller::Unavailable(const string& callsign, PluginHost::IShell* plugin)
+    {
+        event_statechange(callsign, PluginHost::IShell::UNAVAILABLE, plugin->Reason());
+    }
 
     void Controller::SubSystems()
     {

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -28,6 +28,8 @@
 namespace WPEFramework {
 namespace Plugin {
 
+    using JSONCallstack =  Web::JSONBodyType < Core::JSON::ArrayType < Core::JSON::String > >;
+
     class Controller : public PluginHost::IPlugin, public PluginHost::IWeb, public PluginHost::JSONRPC {
     private:
         class Sink : public PluginHost::IPlugin::INotification,
@@ -86,13 +88,21 @@ namespace Plugin {
             }
 
         private:
-            virtual void Updated() override
+            void Updated() override
             {
                 _decoupled->Schedule();
             }
-            virtual void StateChange(PluginHost::IShell* plugin) override
+            void Activated(const string& callsign, PluginHost::IShell* plugin) override
             {
-                _parent.StateChange(plugin);
+                _parent.Activated(callsign, plugin);
+            }
+            void Deactivated(const string& callsign, PluginHost::IShell* plugin) override
+            {
+                _parent.Deactivated(callsign, plugin);
+            }
+            void Unavailable(const string& callsign, PluginHost::IShell* plugin) override
+            {
+                _parent.Unavailable(callsign, plugin);
             }
 
             BEGIN_INTERFACE_MAP(Sink)
@@ -291,7 +301,9 @@ namespace Plugin {
         Core::ProxyType<Web::Response> GetMethod(Core::TextSegmentIterator& index) const;
         Core::ProxyType<Web::Response> PutMethod(Core::TextSegmentIterator& index, const Web::Request& request);
         Core::ProxyType<Web::Response> DeleteMethod(Core::TextSegmentIterator& index, const Web::Request& request);
-        void StateChange(PluginHost::IShell* plugin);
+        void Activated(const string& callsign, PluginHost::IShell* plugin);
+        void Deactivated(const string& callsign, PluginHost::IShell* plugin);
+        void Unavailable(const string& callsign, PluginHost::IShell* plugin);
 
         void RegisterAll();
         void UnregisterAll();

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -307,6 +307,8 @@ namespace Plugin {
 
         void RegisterAll();
         void UnregisterAll();
+        uint32_t endpoint_suspend(const JsonData::Controller::ActivateParamsInfo& params);
+        uint32_t endpoint_resume(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_activate(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_clone(const JsonData::Controller::CloneParamsInfo& params, Core::JSON::String& response);
         uint32_t endpoint_deactivate(const JsonData::Controller::ActivateParamsInfo& params);
@@ -315,6 +317,7 @@ namespace Plugin {
         uint32_t endpoint_storeconfig();
         uint32_t endpoint_delete(const JsonData::Controller::DeleteParamsData& params);
         uint32_t endpoint_harakiri();
+        uint32_t get_callstack(const string& index, Core::JSON::ArrayType<Core::JSON::String>& response) const;
         uint32_t get_status(const string& index, Core::JSON::ArrayType<PluginHost::MetaData::Service>& response) const;
         uint32_t get_links(Core::JSON::ArrayType<PluginHost::MetaData::Channel>& response) const;
         uint32_t get_processinfo(PluginHost::MetaData::Server& response) const;

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -1,4 +1,4 @@
-/*
+ /*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
@@ -27,8 +27,6 @@
 
 namespace WPEFramework {
 namespace Plugin {
-
-    using JSONCallstack =  Web::JSONBodyType < Core::JSON::ArrayType < Core::JSON::String > >;
 
     class Controller : public PluginHost::IPlugin, public PluginHost::IWeb, public PluginHost::JSONRPC {
     private:
@@ -88,21 +86,13 @@ namespace Plugin {
             }
 
         private:
-            void Updated() override
+            virtual void Updated() override
             {
                 _decoupled->Schedule();
             }
-            void Unavailable(const string& callsign, PluginHost::IShell* plugin) override
+            virtual void StateChange(PluginHost::IShell* plugin) override
             {
-
-            }
-            void Activated(const string& callsign, PluginHost::IShell* plugin) override
-            {
-                _parent.Activated(callsign, plugin);
-            }
-            void Deactivated(const string& callsign, PluginHost::IShell* plugin) override
-            {
-                _parent.Deactivated(callsign, plugin);
+                _parent.StateChange(plugin);
             }
 
             BEGIN_INTERFACE_MAP(Sink)
@@ -282,8 +272,8 @@ namespace Plugin {
 
             return (service);
         }
-	void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const
-	{
+		void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const
+		{
             const Core::WorkerPool::Metadata& snapshot = Core::WorkerPool::Instance().Snapshot();
 
             data.PendingRequests = snapshot.Pending;
@@ -295,27 +285,24 @@ namespace Plugin {
                 newElement = snapshot.Slot[teller];
                 data.ThreadPoolRuns.Add(newElement);
             }
-	}
+		}
         void SubSystems();
         void SubSystems(Core::JSON::ArrayType<Core::JSON::EnumType<PluginHost::ISubSystem::subsystem>>::ConstIterator& index);
         Core::ProxyType<Web::Response> GetMethod(Core::TextSegmentIterator& index) const;
         Core::ProxyType<Web::Response> PutMethod(Core::TextSegmentIterator& index, const Web::Request& request);
         Core::ProxyType<Web::Response> DeleteMethod(Core::TextSegmentIterator& index, const Web::Request& request);
-        void Activated(const string& callsign, PluginHost::IShell* plugin);
-        void Deactivated(const string& callsign, PluginHost::IShell* plugin);
+        void StateChange(PluginHost::IShell* plugin);
 
         void RegisterAll();
         void UnregisterAll();
-        uint32_t endpoint_suspend(const JsonData::Controller::ActivateParamsInfo& params);
-        uint32_t endpoint_resume(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_activate(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_clone(const JsonData::Controller::CloneParamsInfo& params, Core::JSON::String& response);
         uint32_t endpoint_deactivate(const JsonData::Controller::ActivateParamsInfo& params);
+        uint32_t endpoint_unavailable(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_startdiscovery(const JsonData::Controller::StartdiscoveryParamsData& params);
         uint32_t endpoint_storeconfig();
         uint32_t endpoint_delete(const JsonData::Controller::DeleteParamsData& params);
         uint32_t endpoint_harakiri();
-        uint32_t get_callstack(const string& index, Core::JSON::ArrayType<Core::JSON::String>& response) const;
         uint32_t get_status(const string& index, Core::JSON::ArrayType<PluginHost::MetaData::Service>& response) const;
         uint32_t get_links(Core::JSON::ArrayType<PluginHost::MetaData::Channel>& response) const;
         uint32_t get_processinfo(PluginHost::MetaData::Server& response) const;

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -92,6 +92,10 @@ namespace Plugin {
             {
                 _decoupled->Schedule();
             }
+            void Unavailable(const string& callsign, PluginHost::IShell* plugin) override
+            {
+
+            }
             void Activated(const string& callsign, PluginHost::IShell* plugin) override
             {
                 _parent.Activated(callsign, plugin);

--- a/Source/WPEFramework/ControllerJsonRpc.cpp
+++ b/Source/WPEFramework/ControllerJsonRpc.cpp
@@ -35,8 +35,7 @@ namespace Plugin {
     {
         Register<ActivateParamsInfo,void>(_T("activate"), &Controller::endpoint_activate, this);
         Register<ActivateParamsInfo,void>(_T("deactivate"), &Controller::endpoint_deactivate, this);
-        Register<ActivateParamsInfo,void>(_T("suspend"), &Controller::endpoint_suspend, this);
-        Register<ActivateParamsInfo,void>(_T("resume"), &Controller::endpoint_resume, this);
+        Register<ActivateParamsInfo,void>(_T("unavailable"), &Controller::endpoint_unavailable, this);
         Register<StartdiscoveryParamsData,void>(_T("startdiscovery"), &Controller::endpoint_startdiscovery, this);
         Register<void,void>(_T("storeconfig"), &Controller::endpoint_storeconfig, this);
         Register<DeleteParamsData,void>(_T("delete"), &Controller::endpoint_delete, this);
@@ -49,18 +48,15 @@ namespace Plugin {
         Property<Core::JSON::String>(_T("environment"), &Controller::get_environment, nullptr, this);
         Property<Core::JSON::String>(_T("configuration"), &Controller::get_configuration, &Controller::set_configuration, this);
         Register<CloneParamsInfo,Core::JSON::String>(_T("clone"), &Controller::endpoint_clone, this);
-        Property<Core::JSON::ArrayType<Core::JSON::String>>(_T("callstack"), &Controller::get_callstack, nullptr, this);
     }
 
     void Controller::UnregisterAll()
     {
-        Unregister(_T("callstack"));
         Unregister(_T("harakiri"));
         Unregister(_T("delete"));
         Unregister(_T("storeconfig"));
         Unregister(_T("startdiscovery"));
-        Unregister(_T("suspend"));
-        Unregister(_T("resume"));
+        Unregister(_T("unavailable"));
         Unregister(_T("deactivate"));
         Unregister(_T("activate"));
         Unregister(_T("configuration"));
@@ -153,54 +149,14 @@ namespace Plugin {
         return result;
     }
 
-    // Method: activate - Resume a plugin
+    // Method: unavailable- Mark the plugin as unavailable
     // Return codes:
     //  - ERROR_NONE: Success
-    //  - ERROR_PENDING_CONDITIONS: The plugin will be activated once its activation preconditions are met
-    //  - ERROR_INPROGRESS: The plugin is currently being activated
-    //  - ERROR_UNKNOWN_KEY: The plugin does not exist
-    //  - ERROR_OPENING_FAILED: Failed to activate the plugin
-    //  - ERROR_ILLEGAL_STATE: Current state of the plugin does not allow activation
-    //  - ERROR_PRIVILEGED_REQUEST: Activation of the plugin is not allowed (e.g. Controller)
-    uint32_t Controller::endpoint_resume(const ActivateParamsInfo& params)
-    {
-        uint32_t result = Core::ERROR_OPENING_FAILED;
-        const string& callsign = params.Callsign.Value();
-
-        ASSERT(_pluginServer != nullptr);
-
-        if (callsign != Callsign()) {
-            Core::ProxyType<PluginHost::Server::Service> service;
-
-            if (_pluginServer->Services().FromIdentifier(callsign, service) == Core::ERROR_NONE) {
-                ASSERT(service.IsValid());
-                result = service->Resume(PluginHost::IShell::REQUESTED);
-
-                // Normalise return code
-                if ((result != Core::ERROR_NONE) && (result != Core::ERROR_ILLEGAL_STATE) && (result !=  Core::ERROR_INPROGRESS) && (result != Core::ERROR_PENDING_CONDITIONS)) {
-                    result = Core::ERROR_OPENING_FAILED;
-                }
-            }
-            else {
-                result = Core::ERROR_UNKNOWN_KEY;
-            }
-        }
-        else {
-            result = Core::ERROR_PRIVILIGED_REQUEST;
-        }
-
-        return result;
-    }
-
-    // Method: suspend - Suspends a plugin
-    // Return codes:
-    //  - ERROR_NONE: Success
-    //  - ERROR_INPROGRESS: The plugin is currently being deactivated
     //  - ERROR_UNKNOWN_KEY: The plugin does not exist
     //  - ERROR_ILLEGAL_STATE: Current state of the plugin does not allow deactivation
     //  - ERROR_CLOSING_FAILED: Failed to activate the plugin
     //  - ERROR_PRIVILEGED_REQUEST: Deactivation of the plugin is not allowed (e.g. Controller)
-    uint32_t Controller::endpoint_suspend(const ActivateParamsInfo& params)
+    uint32_t Controller::endpoint_unavailable(const ActivateParamsInfo& params)
     {
         uint32_t result = Core::ERROR_OPENING_FAILED;
         const string& callsign = params.Callsign.Value();
@@ -212,7 +168,7 @@ namespace Plugin {
 
             if (_pluginServer->Services().FromIdentifier(callsign, service) == Core::ERROR_NONE) {
                 ASSERT(service.IsValid());
-                result = service->Suspend(PluginHost::IShell::REQUESTED);
+                result = service->Unavailable(PluginHost::IShell::REQUESTED);
 
                 // Normalise return code
                 if ((result != Core::ERROR_NONE) && (result != Core::ERROR_ILLEGAL_STATE) && (result !=  Core::ERROR_INPROGRESS)) {
@@ -519,32 +475,6 @@ namespace Plugin {
         params.Reason = reason;
 
         Notify(_T("statechange"), params);
-    }
-
-    // Property: callstack - Information the callstack associated with the given index 0 - <Max number of threads in the threadpool>
-    // Return codes:
-    //  - ERROR_NONE: Success
-    //  - ERROR_UNKNOWN_KEY: The index (uint8_t) is not supplied
-    uint32_t Controller::get_callstack(const string& index, Core::JSON::ArrayType<Core::JSON::String>& response) const
-    {
-        uint32_t result = Core::ERROR_UNKNOWN_KEY;
-
-        if (index.empty() == true) {
-            uint8_t indexValue = Core::NumberType<uint8_t>(Core::TextFragment(index)).Value();
-
-            result = Core::ERROR_NONE;
-            std::list<string> stackList;
-
-            ThreadId threadId = _pluginServer->WorkerPool().Id(indexValue);
-
-            DumpCallStack(threadId, stackList);
-
-            for (const string& entry : stackList) {
-                response.Add() = entry;
-            }
-        }
-
-        return result;
     }
 
     // Note: event_all and event_subsytemchange are handled internally within the Controller

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -515,8 +515,6 @@ namespace PluginHost
 
             State(why == CONDITIONS? PRECONDITION : DEACTIVATED);
 
-            _administrator.Deactivated(callSign, this);
-
 #if THUNDER_RESTFULL_API
             _administrator.Notification(_T("{\"callsign\":\"") + callSign + _T("\",\"state\":\"deactivated\",\"reason\":\"") + textReason.Data() + _T("\"}"));
 #endif

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -358,7 +358,6 @@ namespace PluginHost
             } else {
 
                 State(ACTIVATION);
-                _administrator.StateChange(this);
 
                 Unlock();
 
@@ -374,7 +373,6 @@ namespace PluginHost
                     Lock();
                     ReleaseInterfaces();
                     State(DEACTIVATED);
-                    _administrator.StateChange(this);
                 } else {
                     const Core::EnumerateType<PluginHost::IShell::reason> textReason(why);
                     const string webUI(PluginHost::Service::Configuration().WebUI.Value());
@@ -392,7 +390,7 @@ namespace PluginHost
                     SYSLOG(Logging::Startup, (_T("Activated plugin [%s]:[%s]"), className.c_str(), callSign.c_str()));
                     Lock();
                     State(ACTIVATED);
-                    _administrator.StateChange(this);
+                    _administrator.Activated(callSign, this);
 
 #if THUNDER_RESTFULL_API
                     _administrator.Notification(_T("{\"callsign\":\"") + callSign + _T("\",\"state\":\"deactivated\",\"reason\":\"") + textReason.Data() + _T("\"}"));
@@ -441,7 +439,7 @@ namespace PluginHost
                 ASSERT(_handler != nullptr);
 
                 State(DEACTIVATION);
-                _administrator.StateChange(this);
+                _administrator.Deactivated(callSign, this);
 
                 Unlock();
 
@@ -478,7 +476,7 @@ namespace PluginHost
 
             State(why == CONDITIONS? PRECONDITION : DEACTIVATED);
 
-            _administrator.StateChange(this);
+            _administrator.Deactivated(callSign, this);
 
 #if THUNDER_RESTFULL_API
             _administrator.Notification(_T("{\"callsign\":\"") + callSign + _T("\",\"state\":\"deactivated\",\"reason\":\"") + textReason.Data() + _T("\"}"));
@@ -525,7 +523,7 @@ namespace PluginHost
             TRACE(Activity, (Core::Format(_T("Unavailable plugin [%s]:[%s]"), className.c_str(), callSign.c_str())));
 
             State(UNAVAILABLE);
-            _administrator.StateChange(this);
+            _administrator.Unavailable(callSign, this);
 
 #if THUNDER_RESTFULL_API
             _administrator.Notification(_T("{\"callsign\":\"") + callSign + _T("\",\"state\":\"unavailable\",\"reason\":\"") + textReason.Data() + _T("\"}"));
@@ -640,7 +638,7 @@ namespace PluginHost
         : _dispatcher(configuration.StackSize())
         , _connections(*this, configuration.Binder(), configuration.IdleTime())
         , _config(configuration)
-        , _services(*this, _config, configuration.StackSize())
+        , _services(*this, _config)
         , _controller()
         , _factoriesImplementation()
     {

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -159,14 +159,17 @@ namespace PluginHost
     };
 
     void Server::WorkerPoolImplementation::Dispatcher::Dispatch(Core::IDispatch* job) /* override */ {
-    #ifdef __CORE_EXCEPTION_CATCHING__
-        string callsign(_T("Unknown"));
+    #if defined(__CORE_EXCEPTION_CATCHING__) || defined(__CORE_WARNING_REPORTING__)
+        string callsign(_T("Callsign Unknown"));
         Channel::Job* rootObject = dynamic_cast<Channel::Job*>(job);
         if (rootObject != nullptr) {
             callsign = rootObject->Callsign();
         }
 
-        WARNING_REPORTING_THREAD_SETCALLSIGN(callsign.c_str());
+        WARNING_REPORTING_THREAD_SETCALLSIGN_GUARD(callsign.c_str());
+    #endif
+
+    #ifdef __CORE_EXCEPTION_CATCHING__
 
         try {
             job->Dispatch();
@@ -413,9 +416,45 @@ namespace PluginHost
         return (result);
     }
 
+    uint32_t Server::Service::Resume(const reason why) {
+        uint32_t result = Core::ERROR_NONE;
+
+        Lock();
+
+        IShell::state currentState(State());
+
+        if (currentState == IShell::ACTIVATION) {
+            result = Core::ERROR_INPROGRESS;
+        } else if ((currentState == IShell::DEACTIVATION) || (currentState == IShell::DESTROYED)) {
+            result = Core::ERROR_ILLEGAL_STATE;
+        } else if (currentState == IShell::DEACTIVATED) {
+            result = Activate(why);
+            currentState = State();
+        } 
+
+        if (currentState == IShell::ACTIVATED) {
+            // See if we need can and should RESUME.
+            IStateControl* stateControl = _handler->QueryInterface<PluginHost::IStateControl>();
+            if (stateControl == nullptr) {
+                result = Core::ERROR_BAD_REQUEST;
+            }
+            else {
+                // We have a StateControl interface, so at least start resuming, if not already resumed :-)
+                if (stateControl->State() == PluginHost::IStateControl::SUSPENDED) {
+                    result = stateControl->Request(PluginHost::IStateControl::RESUME);
+                }
+                stateControl->Release();
+            }
+        }
+
+        Unlock();
+
+        return (result);
+    }
+
+
     uint32_t Server::Service::Deactivate(const reason why)
     {
-
         uint32_t result = Core::ERROR_NONE;
 
         Lock();
@@ -491,6 +530,44 @@ namespace PluginHost
         }
 
         Unlock();
+
+        return (result);
+    }
+
+    uint32_t Server::Service::Suspend(const reason why) {
+
+        uint32_t result = Core::ERROR_NONE;
+
+        if (AutoStart() == false) {
+            // We need to shutdown completely
+            result = Deactivate(why);
+        }
+        else {
+            Lock();
+
+            IShell::state currentState(State());
+
+            if (currentState == IShell::DEACTIVATION) {
+                result = Core::ERROR_INPROGRESS;
+            } else if ((currentState == IShell::ACTIVATION) || (currentState == IShell::DESTROYED)) {
+                result = Core::ERROR_ILLEGAL_STATE;
+            } else if ((currentState == IShell::ACTIVATED) || (currentState == IShell::PRECONDITION)) {
+                // See if we need can and should SUSPEND.
+                IStateControl* stateControl = _handler->QueryInterface<PluginHost::IStateControl>();
+                if (stateControl == nullptr) {
+                    result = Core::ERROR_BAD_REQUEST;
+                }
+                else {
+                    // We have a StateControl interface, so at least start suspending, if not already suspended :-)
+                    if (stateControl->State() == PluginHost::IStateControl::RESUMED) {
+                        result = stateControl->Request(PluginHost::IStateControl::SUSPEND);
+                    }
+                    stateControl->Release();
+                }
+            }
+
+            Unlock();
+        }
 
         return (result);
     }

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -71,7 +71,6 @@ namespace PluginHost
     /* static */ const TCHAR* Server::CommunicatorConnector = _T("COMMUNICATOR_CONNECTOR");
 
     static const TCHAR _defaultControllerCallsign[] = _T("Controller");
-    static const TCHAR _defaultDispatcherCallsign[] = _T("Dispatcher");
 
     class DefaultSecurity : public ISecurity {
     public:
@@ -313,7 +312,7 @@ namespace PluginHost
 
         if (currentState == IShell::ACTIVATION) {
             result = Core::ERROR_INPROGRESS;
-        } else if ((currentState == IShell::DEACTIVATION) || (currentState == IShell::DESTROYED)) {
+        } else if ((currentState == IShell::UNAVAILABLE) || (currentState == IShell::DEACTIVATION) || (currentState == IShell::DESTROYED)) {
             result = Core::ERROR_ILLEGAL_STATE;
         } else if ((currentState == IShell::DEACTIVATED) || (currentState == IShell::PRECONDITION)) {
 
@@ -428,7 +427,7 @@ namespace PluginHost
 
         if (currentState == IShell::ACTIVATION) {
             result = Core::ERROR_INPROGRESS;
-        } else if ((currentState == IShell::DEACTIVATION) || (currentState == IShell::DESTROYED)) {
+        } else if ((currentState == IShell::UNAVAILABLE) || (currentState == IShell::DEACTIVATION) || (currentState == IShell::DESTROYED)) {
             result = Core::ERROR_ILLEGAL_STATE;
         } else if (currentState == IShell::DEACTIVATED) {
             result = Activate(why);
@@ -467,11 +466,9 @@ namespace PluginHost
             result = Core::ERROR_INPROGRESS;
         } else if ((currentState == IShell::ACTIVATION) || (currentState == IShell::DESTROYED)) {
             result = Core::ERROR_ILLEGAL_STATE;
-        } else if ((currentState == IShell::ACTIVATED) || (currentState == IShell::PRECONDITION)) {
+        } else if ((currentState == IShell::UNAVAILABLE) || (currentState == IShell::ACTIVATED) || (currentState == IShell::PRECONDITION)) {
 
             const Core::EnumerateType<PluginHost::IShell::reason> textReason(why);
-
-            ASSERT(_handler != nullptr);
 
             const string className(PluginHost::Service::Configuration().ClassName.Value());
             const string callSign(PluginHost::Service::Configuration().Callsign.Value());
@@ -479,6 +476,8 @@ namespace PluginHost
             _reason = why;
 
             if (currentState == IShell::ACTIVATED) {
+                ASSERT(_handler != nullptr);
+
                 State(DEACTIVATION);
                 _administrator.Deactivated(this);
 
@@ -522,15 +521,59 @@ namespace PluginHost
 #endif
 
             _administrator.Notification(PluginHost::Server::ForwardMessage(callSign, string(_T("{\"state\":\"deactivated\",\"reason\":\"")) + textReason.Data() + _T("\"}")));
-            if (State() != ACTIVATED) {
-                // We have no need for his module anymore..
-                ReleaseInterfaces();
-            }
+
+            ASSERT(State() != ACTIVATED);
+
+            // We have no need for his module anymore..
+            ReleaseInterfaces();
         }
 
         Unlock();
 
         return (result);
+    }
+
+    uint32_t Server::Service::Unavailable(const reason why) {
+        uint32_t result = Core::ERROR_NONE;
+
+        Lock();
+
+        IShell::state currentState(State());
+
+        if ((currentState == IShell::DEACTIVATION) || 
+            (currentState == IShell::ACTIVATION)   || 
+            (currentState == IShell::DESTROYED)    || 
+            (currentState == IShell::ACTIVATED)    ||
+            (currentState == IShell::PRECONDITION)) {
+            result = Core::ERROR_ILLEGAL_STATE;
+        }
+        else if (currentState == IShell::DEACTIVATED) {
+
+            const Core::EnumerateType<PluginHost::IShell::reason> textReason(why);
+
+            const string className(PluginHost::Service::Configuration().ClassName.Value());
+            const string callSign(PluginHost::Service::Configuration().Callsign.Value());
+
+            _reason = why;
+
+            SYSLOG(Logging::Shutdown, (_T("Unavailable plugin [%s]:[%s]"), className.c_str(), callSign.c_str()));
+
+            TRACE(Activity, (Core::Format(_T("Unavailable plugin [%s]:[%s]"), className.c_str(), callSign.c_str())));
+
+            State(UNAVAILABLE);
+            _administrator.Unavailable(this);
+
+#if THUNDER_RESTFULL_API
+            _administrator.Notification(_T("{\"callsign\":\"") + callSign + _T("\",\"state\":\"unavailable\",\"reason\":\"") + textReason.Data() + _T("\"}"));
+#endif
+
+            _administrator.Notification(PluginHost::Server::ForwardMessage(callSign, string(_T("{\"state\":\"unavailable\",\"reason\":\"")) + textReason.Data() + _T("\"}")));
+        }
+
+        Unlock();
+
+        return (result);
+
     }
 
     uint32_t Server::Service::Suspend(const reason why) {
@@ -548,7 +591,7 @@ namespace PluginHost
 
             if (currentState == IShell::DEACTIVATION) {
                 result = Core::ERROR_INPROGRESS;
-            } else if ((currentState == IShell::ACTIVATION) || (currentState == IShell::DESTROYED)) {
+            } else if ((currentState == IShell::UNAVAILABLE) || (currentState == IShell::ACTIVATION) || (currentState == IShell::DESTROYED)) {
                 result = Core::ERROR_ILLEGAL_STATE;
             } else if ((currentState == IShell::ACTIVATED) || (currentState == IShell::PRECONDITION)) {
                 // See if we need can and should SUSPEND.

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -1662,10 +1662,8 @@ namespace PluginHost {
             {
                 return (reinterpret_cast<ISubSystem*>(_subSystems.QueryInterface(ISubSystem::ID)));
             }
-            void Activated(PluginHost::IShell* entry)
+            void Activated(const string& callsign, PluginHost::IShell* entry)
             {
-                string callsign = entry->Callsign();
-
                 _notificationLock.Lock();
 
                 std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
@@ -1678,10 +1676,8 @@ namespace PluginHost {
                 _notificationLock.Unlock();
             }
 
-            void Deactivated(PluginHost::IShell* entry)
+            void Deactivated(const string& callsign, PluginHost::IShell* entry)
             {
-                string callsign = entry->Callsign();
-
                 _notificationLock.Lock();
 
                 std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
@@ -1694,10 +1690,8 @@ namespace PluginHost {
                 _notificationLock.Unlock();
             }
 
-            void Unavailable(PluginHost::IShell* entry)
+            void Unavailable(const string& callsign, PluginHost::IShell* entry)
             {
-                string callsign = entry->Callsign();
-
                 _notificationLock.Lock();
 
                 std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -862,14 +862,16 @@ namespace PluginHost {
 
             // Methods to Activate and Deactivate the aggregated Plugin to this shell.
             // These are Blocking calls!!!!!
-            virtual uint32_t Activate(const reason) override;
-            virtual uint32_t Deactivate(const reason) override;
-            uint32_t Suspend(const reason);
-            uint32_t Resume(const reason);
-            virtual reason Reason() const
+            uint32_t Activate(const reason) override;
+            uint32_t Deactivate(const reason) override;
+            uint32_t Unavailable(const reason) override;
+            reason Reason() const override
             {
                 return (_reason);
             }
+
+            uint32_t Suspend(const reason);
+            uint32_t Resume(const reason);
             bool HasVersionSupport(const string& number) const
             {
 
@@ -981,8 +983,7 @@ namespace PluginHost {
                 _pluginHandling.Lock();
 
                 ASSERT(State() != ACTIVATED);
-                ASSERT(_handler != nullptr);
-
+  
                 IPlugin* currentIF = _handler;
 
                 if (_webRequest != nullptr) {
@@ -1018,10 +1019,13 @@ namespace PluginHost {
 
                 _pluginHandling.Unlock();
 
-                currentIF->Release();
+                if (currentIF != nullptr) {
 
-                // Could be that we can now drop the dynamic library...
-                Core::ServiceAdministrator::Instance().FlushLibraries();
+                    currentIF->Release();
+
+                    // Could be that we can now drop the dynamic library...
+                    Core::ServiceAdministrator::Instance().FlushLibraries();
+                }
             }
 
         private:
@@ -1673,6 +1677,7 @@ namespace PluginHost {
 
                 _notificationLock.Unlock();
             }
+
             void Deactivated(PluginHost::IShell* entry)
             {
                 string callsign = entry->Callsign();
@@ -1683,6 +1688,22 @@ namespace PluginHost {
 
                 while (currentlist.size()) {
                     currentlist.front()->Deactivated(callsign, entry);
+                    currentlist.pop_front();
+                }
+
+                _notificationLock.Unlock();
+            }
+
+            void Unavailable(PluginHost::IShell* entry)
+            {
+                string callsign = entry->Callsign();
+
+                _notificationLock.Lock();
+
+                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+
+                while (currentlist.size()) {
+                    currentlist.front()->Unavailable(callsign, entry);
                     currentlist.pop_front();
                 }
 

--- a/Source/WPEFramework/json/Controller.json
+++ b/Source/WPEFramework/json/Controller.json
@@ -7,7 +7,7 @@
     "description": "Controller JSON-RPC interface"
   },
   "common": {
-    "$ref": "common.json"
+    "$ref": "../../interfaces/json/common.json"
   },
   "definitions": {
     "state": {
@@ -310,55 +310,9 @@
         }
       ]
     },
-    "Controller.1.resume": {
-      "summary": "Resumes a plugin",
-      "description": "This is a more intelligent method, compared to the Activate, on the controller to move a plugin to a *resumed* state depending on its current state. If required, it will activate and move to the resumed state, regardless of the flags in the config (AutoStart/Resumed)",
-      "events": [
-        "statechange"
-      ],
-      "params": {
-        "type": "object",
-        "properties": {
-          "callsign": {
-            "description": "Plugin callsign",
-            "type": "string",
-            "example": "Netflix"
-          }
-        }
-      },
-      "result": {
-        "$ref": "#/common/results/void"
-      },
-      "errors": [
-        {
-          "description": "The plugin will be activated once its activation preconditions are met",
-          "$ref": "#/common/errors/pendingconditions"
-        },
-        {
-          "description": "The plugin is currently being activated",
-          "$ref": "#/common/errors/inprogress"
-        },
-        {
-          "description": "The plugin does not exist",
-          "$ref": "#/common/errors/unknownkey"
-        },
-        {
-          "description": "Failed to activate the plugin",
-          "$ref": "#/common/errors/openingfailed"
-        },
-        {
-          "description": "Current state of the plugin does not allow activation",
-          "$ref": "#/common/errors/illegalstate"
-        },
-        {
-          "description": "Activation of the plugin is not allowed (e.g. Controller)",
-          "$ref": "#/common/errors/privilegedrequest"
-        }
-      ]
-    },
-    "Controller.1.suspend": {
-      "summary": "Suspends a plugin",
-      "description": "This is a more intelligent method, compared to the Deactivate, on the controller to move a plugin to a *suspended* state depending on its current state. Depending on the AutoStart flag, this method will Deactivate the plugin [AutoStart == false] or only Suspend the plugin [AutoStart == true]",
+    "Controller.1.unavailable": {
+      "summary": "Set a plugin unavailable for interaction",
+      "description": "Use this method to mark a plugin as unavailable, i.e. move from Deactivated to Unavailable state. If a plugin is Unavailable, the actual plugin (.so) is no longer loaded into the memory of the process. The plugin will not respond to any JSON-RPC requests and it can not be startedunless it is first deactivated (which triggers a state transition.",
       "events": [
         "statechange"
       ],
@@ -368,7 +322,7 @@
           "callsign": {
             "description": "Callsign of the plugin",
             "type": "string",
-            "example": "Amazon"
+            "example": "DeviceInfo"
           }
         }
       },
@@ -377,15 +331,11 @@
       },
       "errors": [
         {
-          "description": "The plugin is currently being deactivated",
-          "$ref": "#/common/errors/inprogress"
-        },
-        {
           "description": "The plugin does not exist",
           "$ref": "#/common/errors/unknownkey"
         },
         {
-          "description": "Current state of the plugin does not allow deactivation",
+          "description": "Current state of the plugin does not allow setting to Unavailable",
           "$ref": "#/common/errors/illegalstate"
         },
         {
@@ -393,7 +343,7 @@
           "$ref": "#/common/errors/closingfailed"
         },
         {
-          "description": "Deactivation of the plugin is not allowed (e.g. Controller)",
+          "description": "Marking the plugin as unavailable is not allowed (e.g. Controller)",
           "$ref": "#/common/errors/privilegedrequest"
         }
       ]

--- a/Source/bluetooth/BluetoothUtils.cpp
+++ b/Source/bluetooth/BluetoothUtils.cpp
@@ -19,8 +19,6 @@
 
 #include "BluetoothUtils.h"
 
-#define BDADDR_ANY (&(bdaddr_t){ { 0, 0, 0, 0, 0, 0 } })
-
 namespace WPEFramework {
 
 namespace Bluetooth {

--- a/Source/bluetooth/HCISocket.cpp
+++ b/Source/bluetooth/HCISocket.cpp
@@ -81,7 +81,6 @@ void HCISocket::Scan(const uint16_t scanTime, const bool limited)
         /* The inquiry API limits the scan time to 326 seconds, so split it into mutliple inquiries if neccessary. */
         const uint16_t lapTime = 30; /* sec */
         uint16_t timeLeft = scanTime;
-        bool started = false;
 
         Command::Inquiry inquiry;
         Command::InquiryCancel inquiryCancel;

--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef __WEBBRIDGESUPPORT_CONFIGURATION_H
-#define __WEBBRIDGESUPPORT_CONFIGURATION_H
+#pragma once
 
 #include "Module.h"
 #include "Config.h"
@@ -29,6 +28,14 @@
 namespace WPEFramework {
 namespace Plugin {
     class EXTERNAL Config : public Core::JSON::Container {
+    public:
+        enum startup : uint8_t {
+            UNAVAILABLE,
+            DEACTIVATED,
+            SUSPENDED,
+            RESUMED
+	};
+
     public:
         Config()
             : Core::JSON::Container()
@@ -45,6 +52,7 @@ namespace Plugin {
             , PersistentPathPostfix()
             , VolatilePathPostfix()
             , StartupOrder(50)
+            , Startup(startup::DEACTIVATED)
         {
             Add(_T("callsign"), &Callsign);
             Add(_T("locator"), &Locator);
@@ -59,6 +67,7 @@ namespace Plugin {
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("startuporder"), &StartupOrder);
+            Add(_T("startup"), &Startup);
         }
         Config(const Config& copy)
             : Core::JSON::Container()
@@ -75,6 +84,7 @@ namespace Plugin {
             , PersistentPathPostfix(copy.PersistentPathPostfix)
             , VolatilePathPostfix(copy.VolatilePathPostfix)
             , StartupOrder(copy.StartupOrder)
+            , Startup(copy.Startup)
         {
             Add(_T("callsign"), &Callsign);
             Add(_T("locator"), &Locator);
@@ -88,10 +98,10 @@ namespace Plugin {
             Add(_T("configuration"), &Configuration);
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
+            Add(_T("startuporder"), &StartupOrder);
+            Add(_T("startup"), &Startup);
         }
-        ~Config()
-        {
-        }
+        ~Config() override = default;
 
         Config& operator=(const Config& RHS)
         {
@@ -108,6 +118,7 @@ namespace Plugin {
             PersistentPathPostfix = RHS.PersistentPathPostfix;
             VolatilePathPostfix = RHS.VolatilePathPostfix;
             StartupOrder = RHS.StartupOrder;
+            Startup = RHS.Startup;
 
             return (*this);
         }
@@ -138,6 +149,7 @@ namespace Plugin {
         Core::JSON::String PersistentPathPostfix;
         Core::JSON::String VolatilePathPostfix;
         Core::JSON::DecUInt32 StartupOrder;
+        Core::JSON::EnumType<startup> Startup;
 
         static Core::NodeId IPV4UnicastNode(const string& ifname);
 
@@ -181,5 +193,3 @@ namespace Plugin {
     };
 }
 }
-
-#endif // __WEBBRIDGESUPPORT_CONFIGURATION_H

--- a/Source/plugins/IPlugin.h
+++ b/Source/plugins/IPlugin.h
@@ -54,6 +54,7 @@ namespace PluginHost {
             //! @}
             virtual void Activated(const string& callsign, IShell* plugin) = 0;
             virtual void Deactivated(const string& callsign, IShell* plugin) = 0;
+            virtual void Unavailable(const string& callsign, IShell* plugin) = 0;
         };
 
         ~IPlugin() override = default;

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -50,6 +50,7 @@ namespace PluginHost {
 
         // State of the IPlugin interface associated with this shell.
         enum state : uint8_t {
+            UNAVAILABLE,
             DEACTIVATED,
             DEACTIVATION,
             ACTIVATED,
@@ -95,10 +96,9 @@ namespace PluginHost {
             }
 
         public:
-            static Core::ProxyType<Core::IDispatch>
-            Create(IShell* shell, IShell::state toState, IShell::reason why);
+            static Core::ProxyType<Core::IDispatch> Create(IShell* shell, IShell::state toState, IShell::reason why);
 
-            virtual void Dispatch()
+            void Dispatch() override
             {
                 ASSERT(_shell != nullptr);
 
@@ -209,10 +209,11 @@ namespace PluginHost {
         virtual state State() const = 0;
         virtual void* /* @interface:id */ QueryInterfaceByCallsign(const uint32_t id, const string& name) = 0;
 
-        // Methods to Activate and Deactivate the aggregated Plugin to this shell.
+        // Methods to Activate/Deactivate and Unavailable the aggregated Plugin to this shell.
         // NOTE: These are Blocking calls!!!!!
         virtual uint32_t Activate(const reason) = 0;
         virtual uint32_t Deactivate(const reason) = 0;
+        virtual uint32_t Unavailable(const reason) = 0;
         virtual reason Reason() const = 0;
 
         // Method to access, in the main process space, the channel factory to submit JSON objects to be send.

--- a/Source/plugins/MetaData.cpp
+++ b/Source/plugins/MetaData.cpp
@@ -34,9 +34,10 @@ ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Channel::state)
 
     ENUM_CONVERSION_END(PluginHost::MetaData::Channel::state)
 
-        ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Service::state)
+    ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Service::state)
 
-            { PluginHost::MetaData::Service::DEACTIVATED, _TXT("deactivated") },
+    { PluginHost::MetaData::Service::UNAVAILABLE, _TXT("unavailable") },
+    { PluginHost::MetaData::Service::DEACTIVATED, _TXT("deactivated") },
     { PluginHost::MetaData::Service::DEACTIVATION, _TXT("deactivation") },
     { PluginHost::MetaData::Service::ACTIVATED, _TXT("activated") },
     { PluginHost::MetaData::Service::ACTIVATION, _TXT("activation") },
@@ -46,15 +47,15 @@ ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Channel::state)
 
     ENUM_CONVERSION_END(PluginHost::MetaData::Service::state)
 
-        ENUM_CONVERSION_BEGIN(PluginHost::ISubSystem::IInternet::network_type)
+    ENUM_CONVERSION_BEGIN(PluginHost::ISubSystem::IInternet::network_type)
 
-            { PluginHost::ISubSystem::IInternet::UNKNOWN, _TXT("Unknown") },
+    { PluginHost::ISubSystem::IInternet::UNKNOWN, _TXT("Unknown") },
     { PluginHost::ISubSystem::IInternet::IPV4, _TXT("IPv4") },
     { PluginHost::ISubSystem::IInternet::IPV6, _TXT("IPv6") },
 
     ENUM_CONVERSION_END(PluginHost::ISubSystem::IInternet::network_type)
 
-        namespace PluginHost
+namespace PluginHost
 {
 
     /* static */ const TCHAR* ISubSystem::IInternet::ToString(const network_type value)

--- a/Source/plugins/MetaData.h
+++ b/Source/plugins/MetaData.h
@@ -40,6 +40,7 @@ namespace PluginHost {
 
         public:
             enum state {
+                UNAVAILABLE = PluginHost::IShell::UNAVAILABLE,
                 DEACTIVATED = PluginHost::IShell::DEACTIVATED,
                 DEACTIVATION = PluginHost::IShell::DEACTIVATION,
                 ACTIVATED = PluginHost::IShell::ACTIVATED,

--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -19,6 +19,7 @@
 
 #include "Module.h"
 #include "IShell.h"
+#include "Configuration.h"
 
 namespace WPEFramework {
 
@@ -46,6 +47,16 @@ ENUM_CONVERSION_BEGIN(PluginHost::IShell::reason)
     { PluginHost::IShell::WATCHDOG_EXPIRED, _TXT("WatchdogExpired") },
 
 ENUM_CONVERSION_END(PluginHost::IShell::reason)
+
+ENUM_CONVERSION_BEGIN(Plugin::Config::startup)
+
+    { Plugin::Config::startup::UNAVAILABLE, _TXT("Unavailable") },
+    { Plugin::Config::startup::DEACTIVATED, _TXT("Deactivated") },
+    { Plugin::Config::startup::SUSPENDED,   _TXT("Suspended")   },
+    { Plugin::Config::startup::RESUMED,     _TXT("Resumed")     },
+    { Plugin::Config::startup::RESUMED,     _TXT("Activated")   },
+
+ENUM_CONVERSION_END(Plugin::Config::startup)
 
 namespace PluginHost
 {

--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -24,6 +24,7 @@ namespace WPEFramework {
 
 ENUM_CONVERSION_BEGIN(PluginHost::IShell::state)
 
+    { PluginHost::IShell::UNAVAILABLE, _TXT("Unavailable") },
     { PluginHost::IShell::DEACTIVATED, _TXT("Deactivated") },
     { PluginHost::IShell::DEACTIVATION, _TXT("Deactivation") },
     { PluginHost::IShell::ACTIVATED, _TXT("Activated") },

--- a/Source/plugins/Types.h
+++ b/Source/plugins/Types.h
@@ -170,6 +170,9 @@ namespace PluginHost {
                     _adminLock.Unlock();
                 }
             }
+            void Unavailable(const string& name, PluginHost::IShell* plugin) override
+            {
+            }
 
         private:
             mutable Core::CriticalSection _adminLock;


### PR DESCRIPTION
Adding the state Unavailable to a Plugin. 
If a plugin is marked as Unavailable, it can not be started. Unavailable plugins should first be moved to the Deactivated state. Once they are in the Deactivated state they can be started. The reason for adding this state is to send a notification if a plugin is available, keeping Thunder an Event driven system (and no polling is required to see the availability of plugins).

This feature is to be used for:
1) Downloadable plugins, a Plugin responsible for downloading can move the plugin from Unavailable to Deactivated if all the prerequisites (download/decrypt/installation) are completed successfully.
2) Up selling / provisioning / Timed. If certain features should only be made available after it is bought or if the feature needs to be provisioned before it can be used or features that can only be used in specific time-slots..