### PR TITLE
Unavailable state for plugins

### DIFF
--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -298,6 +298,7 @@ namespace Plugin {
         uint32_t endpoint_activate(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_clone(const JsonData::Controller::CloneParamsInfo& params, Core::JSON::String& response);
         uint32_t endpoint_deactivate(const JsonData::Controller::ActivateParamsInfo& params);
+        uint32_t endpoint_unavailable(const JsonData::Controller::ActivateParamsInfo& params);
         uint32_t endpoint_startdiscovery(const JsonData::Controller::StartdiscoveryParamsData& params);
         uint32_t endpoint_storeconfig();
         uint32_t endpoint_delete(const JsonData::Controller::DeleteParamsData& params);

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -1671,22 +1671,6 @@ namespace PluginHost {
 
                 _notificationLock.Unlock();
             }
-
-            void Unavailable(PluginHost::IShell* entry)
-            {
-                string callsign = entry->Callsign();
-
-                _notificationLock.Lock();
-
-                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
-
-                while (currentlist.size()) {
-                    currentlist.front()->Unavailable(callsign, entry);
-                    currentlist.pop_front();
-                }
-
-                _notificationLock.Unlock();
-            }
             void Register(PluginHost::IPlugin::INotification* sink)
             {
                 _notificationLock.Lock();

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -863,15 +863,16 @@ namespace PluginHost {
 
             // Methods to Activate and Deactivate the aggregated Plugin to this shell.
             // These are Blocking calls!!!!!
-            virtual uint32_t Activate(const reason) override;
-            virtual uint32_t Deactivate(const reason) override;
-            virtual reason Reason() const
+            uint32_t Activate(const reason) override;
+            uint32_t Deactivate(const reason) override;
+            uint32_t Unavailable(const reason) override;
+            reason Reason() const override
             {
                 return (_reason);
             }
+
             bool HasVersionSupport(const string& number) const
             {
-
                 return (number.length() > 0) && (std::all_of(number.begin(), number.end(), [](TCHAR item) { return std::isdigit(item); })) && (Service::IsSupported(static_cast<uint8_t>(atoi(number.c_str()))));
             }
 
@@ -980,8 +981,7 @@ namespace PluginHost {
                 _pluginHandling.Lock();
 
                 ASSERT(State() != ACTIVATED);
-                ASSERT(_handler != nullptr);
-
+  
                 IPlugin* currentIF = _handler;
 
                 if (_webRequest != nullptr) {
@@ -1017,10 +1017,13 @@ namespace PluginHost {
 
                 _pluginHandling.Unlock();
 
-                currentIF->Release();
+                if (currentIF != nullptr) {
 
-                // Could be that we can now drop the dynamic library...
-                Core::ServiceAdministrator::Instance().FlushLibraries();
+                    currentIF->Release();
+
+                    // Could be that we can now drop the dynamic library...
+                    Core::ServiceAdministrator::Instance().FlushLibraries();
+                }
             }
 
         private:
@@ -1663,6 +1666,22 @@ namespace PluginHost {
 
                 while (currentlist.size()) {
                     currentlist.front()->StateChange(entry);
+                    currentlist.pop_front();
+                }
+
+                _notificationLock.Unlock();
+            }
+
+            void Unavailable(PluginHost::IShell* entry)
+            {
+                string callsign = entry->Callsign();
+
+                _notificationLock.Lock();
+
+                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+
+                while (currentlist.size()) {
+                    currentlist.front()->Unavailable(callsign, entry);
                     currentlist.pop_front();
                 }
 

--- a/Source/WPEFramework/json/Controller.json
+++ b/Source/WPEFramework/json/Controller.json
@@ -310,6 +310,44 @@
         }
       ]
     },
+    "Controller.1.unavailable": {
+      "summary": "Set a plugin unavailable for interaction",
+      "description": "Use this method to mark a plugin as unavailable, i.e. move from Deactivated to Unavailable state. If a plugin is Unavailable, the actual plugin (.so) is no longer loaded into the memory of the process. The plugin will not respond to any JSON-RPC requests and it can not be startedunless it is first deactivated (which triggers a state transition.",
+      "events": [
+        "statechange"
+      ],
+      "params": {
+        "type": "object",
+        "properties": {
+          "callsign": {
+            "description": "Callsign of the plugin",
+            "type": "string",
+            "example": "DeviceInfo"
+          }
+        }
+      },
+      "result": {
+        "$ref": "#/common/results/void"
+      },
+      "errors": [
+        {
+          "description": "The plugin does not exist",
+          "$ref": "#/common/errors/unknownkey"
+        },
+        {
+          "description": "Current state of the plugin does not allow setting to Unavailable",
+          "$ref": "#/common/errors/illegalstate"
+        },
+        {
+          "description": "Failed to activate the plugin",
+          "$ref": "#/common/errors/closingfailed"
+        },
+        {
+          "description": "Marking the plugin as unavailable is not allowed (e.g. Controller)",
+          "$ref": "#/common/errors/privilegedrequest"
+        }
+      ]
+    },
     "Controller.1.startdiscovery": {
       "summary": "Starts the network discovery",
       "description": "Use this method to initiate SSDP network discovery process.",

--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef __WEBBRIDGESUPPORT_CONFIGURATION_H
-#define __WEBBRIDGESUPPORT_CONFIGURATION_H
+#pragma once
 
 #include "Module.h"
 #include "Config.h"
@@ -29,6 +28,14 @@
 namespace WPEFramework {
 namespace Plugin {
     class EXTERNAL Config : public Core::JSON::Container {
+    public:
+        enum startup : uint8_t {
+            UNAVAILABLE,
+            DEACTIVATED,
+            SUSPENDED,
+            RESUMED
+	};
+
     public:
         Config()
             : Core::JSON::Container()
@@ -45,6 +52,7 @@ namespace Plugin {
             , PersistentPathPostfix()
             , VolatilePathPostfix()
             , StartupOrder(50)
+            , Startup(startup::DEACTIVATED)
         {
             Add(_T("callsign"), &Callsign);
             Add(_T("locator"), &Locator);
@@ -59,6 +67,7 @@ namespace Plugin {
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("startuporder"), &StartupOrder);
+            Add(_T("startup"), &Startup);
         }
         Config(const Config& copy)
             : Core::JSON::Container()
@@ -75,6 +84,7 @@ namespace Plugin {
             , PersistentPathPostfix(copy.PersistentPathPostfix)
             , VolatilePathPostfix(copy.VolatilePathPostfix)
             , StartupOrder(copy.StartupOrder)
+            , Startup(copy.Startup)
         {
             Add(_T("callsign"), &Callsign);
             Add(_T("locator"), &Locator);
@@ -88,10 +98,10 @@ namespace Plugin {
             Add(_T("configuration"), &Configuration);
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
+            Add(_T("startuporder"), &StartupOrder);
+            Add(_T("startup"), &Startup);
         }
-        ~Config()
-        {
-        }
+        ~Config() override = default;
 
         Config& operator=(const Config& RHS)
         {
@@ -108,6 +118,7 @@ namespace Plugin {
             PersistentPathPostfix = RHS.PersistentPathPostfix;
             VolatilePathPostfix = RHS.VolatilePathPostfix;
             StartupOrder = RHS.StartupOrder;
+            Startup = RHS.Startup;
 
             return (*this);
         }
@@ -138,6 +149,7 @@ namespace Plugin {
         Core::JSON::String PersistentPathPostfix;
         Core::JSON::String VolatilePathPostfix;
         Core::JSON::DecUInt32 StartupOrder;
+        Core::JSON::EnumType<startup> Startup;
 
         static Core::NodeId IPV4UnicastNode(const string& ifname);
 
@@ -181,5 +193,3 @@ namespace Plugin {
     };
 }
 }
-
-#endif // __WEBBRIDGESUPPORT_CONFIGURATION_H

--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -67,7 +67,7 @@ namespace Plugin {
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("startuporder"), &StartupOrder);
-            Add(_T("startup"), &Startup);
+            Add(_T("startmode"), &Startup);
         }
         Config(const Config& copy)
             : Core::JSON::Container()
@@ -99,7 +99,7 @@ namespace Plugin {
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("startuporder"), &StartupOrder);
-            Add(_T("startup"), &Startup);
+            Add(_T("startmode"), &Startup);
         }
         ~Config() override = default;
 

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -50,6 +50,7 @@ namespace PluginHost {
 
         // State of the IPlugin interface associated with this shell.
         enum state : uint8_t {
+            UNAVAILABLE,
             DEACTIVATED,
             DEACTIVATION,
             ACTIVATED,
@@ -95,10 +96,9 @@ namespace PluginHost {
             }
 
         public:
-            static Core::ProxyType<Core::IDispatch>
-            Create(IShell* shell, IShell::state toState, IShell::reason why);
+            static Core::ProxyType<Core::IDispatch> Create(IShell* shell, IShell::state toState, IShell::reason why);
 
-            virtual void Dispatch()
+            void Dispatch() override
             {
                 ASSERT(_shell != nullptr);
 
@@ -209,10 +209,11 @@ namespace PluginHost {
         virtual state State() const = 0;
         virtual void* /* @interface:id */ QueryInterfaceByCallsign(const uint32_t id, const string& name) = 0;
 
-        // Methods to Activate and Deactivate the aggregated Plugin to this shell.
+        // Methods to Activate/Deactivate and Unavailable the aggregated Plugin to this shell.
         // NOTE: These are Blocking calls!!!!!
         virtual uint32_t Activate(const reason) = 0;
         virtual uint32_t Deactivate(const reason) = 0;
+        virtual uint32_t Unavailable(const reason) = 0;
         virtual reason Reason() const = 0;
 
         // Method to access, in the main process space, the channel factory to submit JSON objects to be send.

--- a/Source/plugins/MetaData.cpp
+++ b/Source/plugins/MetaData.cpp
@@ -34,9 +34,10 @@ ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Channel::state)
 
     ENUM_CONVERSION_END(PluginHost::MetaData::Channel::state)
 
-        ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Service::state)
+    ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Service::state)
 
-            { PluginHost::MetaData::Service::DEACTIVATED, _TXT("deactivated") },
+    { PluginHost::MetaData::Service::UNAVAILABLE, _TXT("unavailable") },
+    { PluginHost::MetaData::Service::DEACTIVATED, _TXT("deactivated") },
     { PluginHost::MetaData::Service::DEACTIVATION, _TXT("deactivation") },
     { PluginHost::MetaData::Service::ACTIVATED, _TXT("activated") },
     { PluginHost::MetaData::Service::ACTIVATION, _TXT("activation") },
@@ -46,15 +47,15 @@ ENUM_CONVERSION_BEGIN(PluginHost::MetaData::Channel::state)
 
     ENUM_CONVERSION_END(PluginHost::MetaData::Service::state)
 
-        ENUM_CONVERSION_BEGIN(PluginHost::ISubSystem::IInternet::network_type)
+    ENUM_CONVERSION_BEGIN(PluginHost::ISubSystem::IInternet::network_type)
 
-            { PluginHost::ISubSystem::IInternet::UNKNOWN, _TXT("Unknown") },
+    { PluginHost::ISubSystem::IInternet::UNKNOWN, _TXT("Unknown") },
     { PluginHost::ISubSystem::IInternet::IPV4, _TXT("IPv4") },
     { PluginHost::ISubSystem::IInternet::IPV6, _TXT("IPv6") },
 
     ENUM_CONVERSION_END(PluginHost::ISubSystem::IInternet::network_type)
 
-        namespace PluginHost
+namespace PluginHost
 {
 
     /* static */ const TCHAR* ISubSystem::IInternet::ToString(const network_type value)

--- a/Source/plugins/MetaData.h
+++ b/Source/plugins/MetaData.h
@@ -40,6 +40,7 @@ namespace PluginHost {
 
         public:
             enum state {
+                UNAVAILABLE = PluginHost::IShell::UNAVAILABLE,
                 DEACTIVATED = PluginHost::IShell::DEACTIVATED,
                 DEACTIVATION = PluginHost::IShell::DEACTIVATION,
                 ACTIVATED = PluginHost::IShell::ACTIVATED,

--- a/Source/plugins/Service.h
+++ b/Source/plugins/Service.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef __WEBBRIDGESUPPORT_SERVICE__
-#define __WEBBRIDGESUPPORT_SERVICE__
+#pragma once
 
 #include "Module.h"
 #include "Channel.h"
@@ -32,21 +31,13 @@ namespace WPEFramework {
 namespace PluginHost {
 
     class EXTERNAL Service : public IShell {
-        // This object is created by the instance that instantiates the plugins. As the lifetime
-        // of this object is controlled by the server, instantiating this object, do not allow
-        // this obnject to be copied or created by any other instance.
     private:
-        Service() = delete;
-        Service(const Service&) = delete;
-        Service& operator=(const Service&) = delete;
-
         class EXTERNAL Config {
-        private:
+        public:
             Config() = delete;
             Config(const Config&) = delete;
             Config& operator=(const Config&) = delete;
 
-        public:
             Config(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& dataPath, const string& volatilePath)
             {
                 const string& callSign(plugin.Callsign.Value());
@@ -148,85 +139,132 @@ namespace PluginHost {
         };
 
     public:
+        // This object is created by the instance that instantiates the plugins. As the lifetime
+        // of this object is controlled by the server, instantiating this object, do not allow
+        // this obnject to be copied or created by any other instance.
+        Service() = delete;
+        Service(const Service&) = delete;
+        Service& operator=(const Service&) = delete;
+
         Service(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& dataPath, const string& volatilePath)
             : _adminLock()
-#if THUNDER_RUNTIME_STATISTICS
+            #if THUNDER_RUNTIME_STATISTICS
             , _processedRequests(0)
             , _processedObjects(0)
-#endif
+            #endif
             , _state(DEACTIVATED)
             , _config(plugin, webPrefix, persistentPath, dataPath, volatilePath)
-#if THUNDER_RESTFULL_API
+            #if THUNDER_RESTFULL_API
             , _notifiers()
-#endif
+            #endif
         {
+            if ( (plugin.Startup.IsSet() == true) && (plugin.Startup.Value() == Plugin::Config::UNAVAILABLE) ) {
+                _state = UNAVAILABLE;
+            }
         }
-        ~Service()
-        {
-        }
+        ~Service() override = default;
 
     public:
-        bool IsWebServerRequest(const string& segment) const;
-
-#if THUNDER_RESTFULL_API
-        void Notification(const string& message);
-#endif
-        virtual string Versions() const
+        string Versions() const override
         {
             return (_config.Configuration().Versions.Value());
         }
-        virtual uint32_t StartupOrder() const
+        uint32_t StartupOrder() const
         {
             return (_config.Configuration().StartupOrder.Value());
         }
-        virtual string Locator() const
+        string Locator() const override
         {
             return (_config.Configuration().Locator.Value());
         }
-        virtual string ClassName() const
+        string ClassName() const override
         {
             return (_config.Configuration().ClassName.Value());
         }
-        virtual string Callsign() const
+        string Callsign() const override
         {
             return (_config.Configuration().Callsign.Value());
         }
-        virtual string WebPrefix() const
+        string WebPrefix() const override
         {
             return (_config.WebPrefix());
         }
-        virtual string ConfigLine() const
+        string ConfigLine() const override
         {
             return (_config.Configuration().Configuration.Value());
         }
-        virtual string PersistentPath() const
+        string PersistentPath() const override
         {
             return (_config.PersistentPath());
         }
-        virtual string VolatilePath() const
+        string VolatilePath() const override
         {
             return (_config.VolatilePath());
         }
-        virtual string DataPath() const
+        string DataPath() const override
         {
             return (_config.DataPath());
         }
-        virtual state State() const
+        state State() const override
         {
             return (_state);
         }
-        virtual bool AutoStart() const
+        bool AutoStart() const override
         {
-            return (_config.Configuration().AutoStart.Value());
+            bool result = _config.Configuration().AutoStart.Value();
+
+            if (_config.Configuration().Startup.IsSet() == true) {
+                Plugin::Config::startup value = _config.Configuration().Startup.Value();
+                result = (value == Plugin::Config::startup::SUSPENDED) || (value == Plugin::Config::startup::RESUMED);
+            }
+
+            return (result);
         }
-        virtual bool Resumed() const
+        bool Resumed() const override
         {
-            return (_config.Configuration().Resumed.IsSet() ? _config.Configuration().Resumed.Value() : (_config.Configuration().AutoStart.Value() == false));
+            bool result = (_config.Configuration().Resumed.IsSet() ? _config.Configuration().Resumed.Value() : (_config.Configuration().AutoStart.Value() == false));
+
+            if (_config.Configuration().Startup.IsSet() == true) {
+                result = (_config.Configuration().Startup.Value() == Plugin::Config::startup::RESUMED);
+            }
+
+            return (result);
         }
-        virtual bool IsSupported(const uint8_t number) const
+        bool IsSupported(const uint8_t number) const override
         {
             return (_config.IsSupported(number));
         }
+
+        // As a service, the plugin could act like a WebService. The Webservice hosts files from a location over the
+        // HTTP protocol. This service is hosting files at:
+        // http://<bridge host ip>:<bridge port>/Service/<Callsign>/<PostFixURL>/....
+        // Root directory of the files to be services by the URL are in case the passed in value is empty:
+        // <DataPath>/<PostFixYRL>
+        void EnableWebServer(const string& postFixURL, const string& fileRootPath) override
+        {
+            // The postFixURL should *NOT* contain a starting or trailing slash!!!
+            ASSERT((postFixURL.length() > 0) && (postFixURL[0] != '/') && (postFixURL[postFixURL.length() - 1] != '/'));
+
+            // The postFixURL should *NOT* contain a starting or trailing slash!!!
+            // We signal the request to service web files via a non-empty _webServerFilePath.
+            _webURLPath = postFixURL;
+
+            if (fileRootPath.empty() == true) {
+                _webServerFilePath = _config.DataPath() + postFixURL + '/';
+            } else {
+                // File path needs to end in a slash to indicate it is a directory and not a file.
+                ASSERT(fileRootPath[fileRootPath.length() - 1] == '/');
+
+                _webServerFilePath = fileRootPath;
+            }
+        }
+        void DisableWebServer() override
+        {
+            // We signal the request to ervice web files via a non-empty _webServerFilePath.
+            _webServerFilePath.clear();
+            _webURLPath.clear();
+        }
+
         inline const Plugin::Config& Configuration() const
         {
             return (_config.Configuration());
@@ -246,9 +284,10 @@ namespace PluginHost {
         inline void GetMetaData(MetaData::Service& metaData) const
         {
             metaData = _config.Configuration();
-#if THUNDER_RESTFULL_API
+            #if THUNDER_RESTFULL_API
             metaData.Observers = static_cast<uint32_t>(_notifiers.size());
-#endif
+            #endif
+
             // When we do this, we need to make sure that the Service does not change state, otherwise it might
             // be that the the plugin is deinitializing and the IStateControl becomes invalid during our run.
             // Now we can first check if
@@ -258,57 +297,11 @@ namespace PluginHost {
 
             Unlock();
 
-#if THUNDER_RUNTIME_STATISTICS
+            #if THUNDER_RUNTIME_STATISTICS
             metaData.ProcessedRequests = _processedRequests;
             metaData.ProcessedObjects = _processedObjects;
-#endif
+            #endif
         }
-
-        // As a service, the plugin could act like a WebService. The Webservice hosts files from a location over the
-        // HTTP protocol. This service is hosting files at:
-        // http://<bridge host ip>:<bridge port>/Service/<Callsign>/<PostFixURL>/....
-        // Root directory of the files to be services by the URL are in case the passed in value is empty:
-        // <DataPath>/<PostFixYRL>
-        virtual void EnableWebServer(const string& postFixURL, const string& fileRootPath)
-        {
-            // The postFixURL should *NOT* contain a starting or trailing slash!!!
-            ASSERT((postFixURL.length() > 0) && (postFixURL[0] != '/') && (postFixURL[postFixURL.length() - 1] != '/'));
-
-            // The postFixURL should *NOT* contain a starting or trailing slash!!!
-            // We signal the request to service web files via a non-empty _webServerFilePath.
-            _webURLPath = postFixURL;
-
-            if (fileRootPath.empty() == true) {
-                _webServerFilePath = _config.DataPath() + postFixURL + '/';
-            } else {
-                // File path needs to end in a slash to indicate it is a directory and not a file.
-                ASSERT(fileRootPath[fileRootPath.length() - 1] == '/');
-
-                _webServerFilePath = fileRootPath;
-            }
-        }
-        virtual void DisableWebServer()
-        {
-            // We signal the request to ervice web files via a non-empty _webServerFilePath.
-            _webServerFilePath.clear();
-            _webURLPath.clear();
-        }
-        virtual Core::ProxyType<Core::JSON::IElement> Inbound(const string& identifier) = 0;
-
-        virtual void Notify(const string& message) = 0;
-        virtual void* QueryInterface(const uint32_t id) = 0;
-        virtual void* QueryInterfaceByCallsign(const uint32_t id, const string& name) = 0;
-        virtual void Register(IPlugin::INotification* sink) = 0;
-        virtual void Unregister(IPlugin::INotification* sink) = 0;
-
-        // Use the base framework (webbridge) to start/stop processes and the service in side of the given binary.
-        virtual ICOMLink* COMLink() = 0;
-
-        // Methods to Activate and Deactivate the aggregated Plugin to this shell.
-        // These are Blocking calls!!!!!
-        virtual uint32_t Activate(const PluginHost::IShell::reason) = 0;
-        virtual uint32_t Deactivate(const PluginHost::IShell::reason) = 0;
-
         inline uint32_t ConfigLine(const string& newConfiguration)
         {
             uint32_t result = Core::ERROR_ILLEGAL_STATE;
@@ -346,6 +339,14 @@ namespace PluginHost {
             return (result);
         }
 
+        bool IsWebServerRequest(const string& segment) const;
+
+        #if THUNDER_RESTFULL_API
+        void Notification(const string& message);
+        #endif
+ 
+        virtual Core::ProxyType<Core::JSON::IElement> Inbound(const string& identifier) = 0;
+
     protected:
         inline void Lock() const
         {
@@ -363,7 +364,7 @@ namespace PluginHost {
         {
             _errorMessage = message;
         }
-#if THUNDER_RESTFULL_API
+        #if THUNDER_RESTFULL_API
         inline bool Subscribe(Channel& channel)
         {
             _notifierLock.Lock();
@@ -393,8 +394,8 @@ namespace PluginHost {
 
             _notifierLock.Unlock();
         }
-#endif
-#if THUNDER_RUNTIME_STATISTICS
+        #endif
+        #if THUNDER_RUNTIME_STATISTICS
         inline void IncrementProcessedRequests()
         {
             _processedRequests++;
@@ -403,19 +404,21 @@ namespace PluginHost {
         {
             _processedObjects++;
         }
-#endif
+        #endif
+
         void FileToServe(const string& webServiceRequest, Web::Response& response);
 
     private:
         mutable Core::CriticalSection _adminLock;
-#if THUNDER_RESTFULL_API
-        Core::CriticalSection _notifierLock;
-#endif
 
-#if THUNDER_RUNTIME_STATISTICS
+        #if THUNDER_RESTFULL_API
+        Core::CriticalSection _notifierLock;
+        #endif
+
+        #if THUNDER_RUNTIME_STATISTICS
         uint32_t _processedRequests;
         uint32_t _processedObjects;
-#endif
+        #endif
 
         state _state;
         Config _config;
@@ -426,12 +429,10 @@ namespace PluginHost {
         string _webURLPath;
         string _webServerFilePath;
 
-#if THUNDER_RESTFULL_API
+        #if THUNDER_RESTFULL_API
         // Keep track of people who want to be notified of changes.
         std::list<Channel*> _notifiers;
-#endif
+        #endif
     };
 }
 }
-
-#endif // __WEBBRIDGESUPPORT_SERVICE__

--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -19,6 +19,7 @@
 
 #include "Module.h"
 #include "IShell.h"
+#include "Configuration.h"
 
 namespace WPEFramework {
 
@@ -46,6 +47,16 @@ ENUM_CONVERSION_BEGIN(PluginHost::IShell::reason)
     { PluginHost::IShell::WATCHDOG_EXPIRED, _TXT("WatchdogExpired") },
 
 ENUM_CONVERSION_END(PluginHost::IShell::reason)
+
+ENUM_CONVERSION_BEGIN(Plugin::Config::startup)
+
+    { Plugin::Config::startup::UNAVAILABLE, _TXT("Unavailable") },
+    { Plugin::Config::startup::DEACTIVATED, _TXT("Deactivated") },
+    { Plugin::Config::startup::SUSPENDED,   _TXT("Suspended")   },
+    { Plugin::Config::startup::RESUMED,     _TXT("Resumed")     },
+    { Plugin::Config::startup::RESUMED,     _TXT("Activated")   },
+
+ENUM_CONVERSION_END(Plugin::Config::startup)
 
 namespace PluginHost
 {

--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -24,6 +24,7 @@ namespace WPEFramework {
 
 ENUM_CONVERSION_BEGIN(PluginHost::IShell::state)
 
+    { PluginHost::IShell::UNAVAILABLE, _TXT("Unavailable") },
     { PluginHost::IShell::DEACTIVATED, _TXT("Deactivated") },
     { PluginHost::IShell::DEACTIVATION, _TXT("Deactivation") },
     { PluginHost::IShell::ACTIVATED, _TXT("Activated") },


### PR DESCRIPTION
Adding the state Unavailable to a Plugin.
If a plugin is marked as Unavailable, it can not be started. Unavailable plugins should first be moved to the Deactivated state. Once they are in the Deactivated state they can be started. The reason for adding this state is to send a notification if a plugin is available, keeping Thunder an Event driven system (and no polling is required to see the availability of plugins).

This feature is to be used for:

Downloadable plugins, a Plugin responsible for downloading can move the plugin from Unavailable to Deactivated if all the prerequisites (download/decrypt/installation) are completed successfully.
Up selling / provisioning / Timed. If certain features should only be made available after it is bought or if the feature needs to be provisioned before it can be used or features that can only be used in specific time-slots..