### PR TITLE
[CONFIG] new keyword, according to the spec was called differently. a…

### DIFF
--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -67,7 +67,7 @@ namespace Plugin {
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("startuporder"), &StartupOrder);
-            Add(_T("startup"), &Startup);
+            Add(_T("startmode"), &Startup);
         }
         Config(const Config& copy)
             : Core::JSON::Container()
@@ -99,7 +99,7 @@ namespace Plugin {
             Add(_T("persistentpathpostfix"), &PersistentPathPostfix);
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("startuporder"), &StartupOrder);
-            Add(_T("startup"), &Startup);
+            Add(_T("startmode"), &Startup);
         }
         ~Config() override = default;
 


### PR DESCRIPTION
…dapted to be inline with the spec.