### PR TITLE
Revert PUBLIC linking with Thunder components

### DIFF
--- a/Source/plugins/CMakeLists.txt
+++ b/Source/plugins/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(${TARGET}
         PRIVATE
           CompileSettingsDebug::CompileSettingsDebug
           ${NAMESPACE}Core::${NAMESPACE}Core
+	PUBLIC
           ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket
           ${NAMESPACE}Cryptalgo::${NAMESPACE}Cryptalgo
           ${NAMESPACE}Tracing::${NAMESPACE}Tracing


### PR DESCRIPTION
When using PRIVATE linking for some of the components,
linker returned undefined references like:
WPEFramework::Web::Request::Deserializer::EndOfLine()