### PR TITLE
Development/fix lost interfaces

### DIFF
--- a/Source/core/Netlink.cpp
+++ b/Source/core/Netlink.cpp
@@ -63,7 +63,7 @@ namespace Core {
             message->nlmsg_type = Type();
             message->nlmsg_flags = Flags();
             message->nlmsg_seq = _mySequence;
-            message->nlmsg_pid = 0; /* send to the kernel */
+            message->nlmsg_pid = 0; /* sender ID, we don't make use of it */
 
             result = nlmsg_len;
         }
@@ -83,14 +83,11 @@ namespace Core {
                 _flags = header->nlmsg_flags;
                 _mySequence = header->nlmsg_seq;
 
+                if (header->nlmsg_type != NLMSG_DONE) {
+                    Read(reinterpret_cast<const uint8_t *>(NLMSG_DATA(header)), header->nlmsg_len - sizeof(header));
+                }
 
-                if (Read (reinterpret_cast<const uint8_t *>(NLMSG_DATA(header)), 
-                         header->nlmsg_len - sizeof(header)) == 0) {
-		    completed = false;
-                }
-                else {
-                    completed = (header->nlmsg_type == NLMSG_DONE) || ((header->nlmsg_flags & NLM_F_MULTI) == 0);
-                }
+                completed = (header->nlmsg_type == NLMSG_DONE) || ((header->nlmsg_flags & NLM_F_MULTI) == 0);
             }
 
             header = NLMSG_NEXT(header, dataLeft);

--- a/Source/core/Netlink.h
+++ b/Source/core/Netlink.h
@@ -378,8 +378,8 @@ namespace Core {
         typedef std::list<Message> PendingList;
 
     public:
-        SocketNetlink(const NodeId& destination)
-            : SocketDatagram(true, destination, NodeId(), 512, 4096)
+        SocketNetlink(const NodeId& source)
+            : SocketDatagram(true, source, NodeId(), 512, 8192)
             , _adminLock()
         {
         }

--- a/Source/core/NetworkInfo.cpp
+++ b/Source/core/NetworkInfo.cpp
@@ -866,12 +866,15 @@ namespace Core {
                 private:
                     uint16_t Write(uint8_t stream[], const uint16_t maxLength) const override
                     {
-                        const uint16_t length = sizeof(struct rtgenmsg);
+                        const uint16_t length = sizeof(struct ifinfomsg);
                         ASSERT(length <= maxLength);
 
-                        struct rtgenmsg* message(reinterpret_cast<struct rtgenmsg*>(stream));
-                        ::memset(message, 0, sizeof(struct rtgenmsg));
-                        message->rtgen_family = AF_UNSPEC;
+                        struct ifinfomsg* message(reinterpret_cast<struct ifinfomsg*>(stream));
+                        ::memset(message, 0, sizeof(struct ifinfomsg));
+                        message->ifi_family = AF_UNSPEC;
+                        message->ifi_index = 0 /* all of them */;
+                        message->ifi_change = 0xFFFFFFFF;
+
 
                         return (length);
                     }

--- a/Source/core/NetworkInfo.cpp
+++ b/Source/core/NetworkInfo.cpp
@@ -762,6 +762,7 @@ namespace Core {
                         result = Update(false, reinterpret_cast<const struct ifaddrmsg*>(stream), length);
                         break;
                     default:
+                        TRACE_L1("NetworkInfo: unhandled Netlink notification type [%i]", Type());
                         break;
                     }
 
@@ -915,8 +916,10 @@ namespace Core {
             LinkSocket(const LinkSocket&) = delete;
             LinkSocket& operator=(const LinkSocket&) = delete;
 
-            LinkSocket(IPNetworks& parent)
-                : SocketNetlink(NodeId(NETLINK_ROUTE, 0, (RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR)))
+            LinkSocket(IPNetworks& parent, bool listener)
+                : SocketNetlink(NodeId(NETLINK_ROUTE,
+                                       0 /* kernel takes care of assigining a unique socket ID */,
+                                       (listener? (RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR) : 0)))
                 , _messageSink(parent)
             {
             }
@@ -929,17 +932,27 @@ namespace Core {
             void Open()
             {
                 if (SocketDatagram::IsOpen() != true) {
-                    if (SocketDatagram::Open(1000) == ERROR_NONE) {
-                        // Must request the complete interface structure first, synchronously,
-                        // further updates are only notifications of changes.
-                        RequestUpdate();
+                    if (SocketDatagram::Open(1000) != ERROR_NONE) {
+                        TRACE_L1("NetworkInfo: Failed to open Netlink socket");
                     }
                 }
             }
             void Close()
             {
-                if (SocketDatagram::IsOpen() == true) {
-                    SocketDatagram::Close(Core::infinite);
+                SocketDatagram::Close(Core::infinite);
+            }
+
+        public:
+            void RequestStatus()
+            {
+                TRACE_L1("NetworkInfo: Requesting interface information update via Netlink...");
+
+                if (Exchange(Message::GetLink(), _messageSink, 2000) != ERROR_NONE) {
+                    TRACE_L1("NetworkInfo: Failed to retrieve interface information");
+                } else {
+                    if (Exchange(Message::GetAddress(), _messageSink, 2000) != ERROR_NONE) {
+                        TRACE_L1("NetworkInfo: Failed to retrieve interface address information");
+                    }
                 }
             }
 
@@ -948,20 +961,6 @@ namespace Core {
             {
                 // Spontaneous notification...
                 return (_messageSink.Deserialize(stream, length));
-            }
-
-        private:
-            void RequestUpdate()
-            {
-                TRACE_L1("NetworkInfo: Requesting interface information update via Netlink...");
-
-                if (Exchange(Message::GetLink(), _messageSink, 500) != ERROR_NONE) {
-                    TRACE_L1("NetworkInfo: Failed to retrieve interface information");
-                } else {
-                    if (Exchange(Message::GetAddress(), _messageSink, 500) != ERROR_NONE) {
-                        TRACE_L1("NetworkInfo: Failed to retrieve interface address information");
-                    }
-                }
             }
 
         private:
@@ -1044,11 +1043,21 @@ namespace Core {
             : _adminLock()
             , _channel(ProxyType<Channel>::Create())
             , _networks()
-            , _linkSocket(*this)
+            , _linkSocket(*this, true)
             , _observers()
         {
             ASSERT(IsValid());
+
+            // Listen for link updates...
             _linkSocket.Open();
+
+            // Request link status explicilty in case any interfaces were constructed before the listener started.
+            LinkSocket request(*this, false);
+            request.Open();
+            if (request.IsOpen() == true) {
+                request.RequestStatus();
+                request.Close();
+            }
         }
 
     public:
@@ -1071,7 +1080,7 @@ namespace Core {
         {
             return ((_channel.IsValid()) && (_channel->IsValid() == true));
         }
-        void Load (std::list<Core::ProxyType<Network> >& list) {
+        void Load(std::list<Core::ProxyType<Network>>& list) {
             _adminLock.Lock();
             for (const Element& element : _networks) {
                 list.push_back(element.second);
@@ -1140,20 +1149,24 @@ namespace Core {
             }
         }
         void Added(const uint32_t id, const Core::IPNode& node) {
+            _adminLock.Lock();
             Map::iterator index(_networks.find(id));
             if (index != _networks.end()) {
                 if (index->second->Added(node) == true) {
                     NotifyAddressUpdate(index->second->Name(), node, true);
                 }
             }
+            _adminLock.Unlock();
         }
         void Removed(const uint32_t id, const Core::IPNode& node) {
+            _adminLock.Lock();
             Map::iterator index(_networks.find(id));
             if (index != _networks.end()) {
                 if (index->second->Removed(node) == true ) {
                     NotifyAddressUpdate(index->second->Name(), node, false);
                 }
             }
+            _adminLock.Unlock();
         }
 
     private:


### PR DESCRIPTION
Part of the fix for METROL-334. This change here is fixing a lost Netlink datagram related to eth0 creation on the PI.