### PR TITLE
SFINAE errors when using SignedFileBody based transfer.

### DIFF
--- a/Source/websocket/WebSerializer.h
+++ b/Source/websocket/WebSerializer.h
@@ -271,6 +271,10 @@ namespace Web {
         {
             return (_hash);
         }
+        uint16_t Serialize(uint8_t stream[], const uint16_t maxLength) const override
+        {
+            return Core::File::Read(stream, maxLength);
+        }
 
     protected:
         uint32_t Deserialize() override

--- a/Source/websocket/WebTransfer.h
+++ b/Source/websocket/WebTransfer.h
@@ -244,7 +244,7 @@ namespace Web {
                         _request.Verb = Web::Request::HTTP_PUT;
                         _request.Path = '/' + destination.Path().Value();
                         _request.Host = destination.Host().Value();
-                        _request.Body(_fileBody);
+                        _request.Body(Core::ProxyType<FILEBODY>(_fileBody));
 
                         // Maybe we need to add a hash value...
                         _CalculateHash(_request);
@@ -380,7 +380,7 @@ namespace Web {
         HAS_MEMBER(Hash, hasHash);
 
         template < typename ACTUALFILEBODY = FILEBODY>
-        inline typename Core::TypeTraits::enable_if<hasHash<ACTUALFILEBODY, typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
+        inline typename Core::TypeTraits::enable_if<hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
         _CalculateHash(Web::Request& request)
         {
             uint8_t   buffer[64];
@@ -398,27 +398,30 @@ namespace Web {
                 size -= chunk;
             }
 
-            _fileBody.Position(pos);
+            _fileBody.Position(false, pos);
 
-            request.ContentSignature = Signature(hash.HashType(), hash.Result());
+            const Crypto::EnumHashType type = ACTUALFILEBODY::HashType::Type;
+            request.ContentSignature = Signature(type, hash.Result());
         }
 
         template < typename ACTUALFILEBODY = FILEBODY>
-        inline typename Core::TypeTraits::enable_if<!hasHash<ACTUALFILEBODY, typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
+        inline typename Core::TypeTraits::enable_if<!hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
         _CalculateHash()
         {
         }
 
         template <typename ACTUALFILEBODY = FILEBODY>
-        inline typename Core::TypeTraits::enable_if<hasHash<ACTUALFILEBODY, typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
+        inline typename Core::TypeTraits::enable_if<hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, bool>::type
         _ValidateHash(const Core::OptionalType<Signature>& signature) const
         {
             // See if this is a valid. frame
-            return ((signature.IsSet() == false) || (signature.Value().Equal(_fileBody.HashType(), _fileBody.Hash().Result()) == true));
+            typename ACTUALFILEBODY::HashType& hash = const_cast<typename ACTUALFILEBODY::HashType&>(_fileBody.Hash());
+            const Crypto::EnumHashType type = ACTUALFILEBODY::HashType::Type;
+            return ((signature.IsSet() == false) || (signature.Value().Equal(type, hash.Result()) == true));
         }
 
         template < typename ACTUALFILEBODY = FILEBODY>
-        inline typename Core::TypeTraits::enable_if<!hasHash<ACTUALFILEBODY, typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
+        inline typename Core::TypeTraits::enable_if<!hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, bool>::type
         _ValidateHash(const Core::OptionalType<Signature>& signature) const
         {
             return (true);
@@ -484,7 +487,7 @@ namespace Web {
                     _response->Message = _T("File: ") + element->Path + _T(" could not be stored server side.");
                 } else {
                     // See if the keys we received correspond.
-                    if (_ValidateHash<LINK, FILEBODY>(element->ContentSignature) == true) {
+                    if (_ValidateHash<FILEBODY>(element->ContentSignature) == true) {
                         string message = Authorize(*element);
 
                         if (message.empty() == true) {
@@ -549,46 +552,48 @@ namespace Web {
     private:
         HAS_MEMBER(Hash, hasHash);
 
-        template <typename ACTUALLINK, typename ACTUALFILEBODY>
-        inline typename Core::TypeTraits::enable_if<ClientTransferType<ACTUALLINK, ACTUALFILEBODY>::TraitHasHash::value, void>::type
+        template < typename ACTUALFILEBODY = FILEBODY>
+        inline typename Core::TypeTraits::enable_if<hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
         _CalculateHash(Web::Response& request)
         {
             uint8_t   buffer[64];
-            typename ACTUALFILEBODY::HashType& hash = _fileBody.Hash();
-            uint32_t  pos  = _fileBody.Position();
-            std::size_t  size = _fileBody.Size() - pos;
+            typename ACTUALFILEBODY::HashType& hash = _fileBody->Hash();
+            uint32_t  pos  = _fileBody->Position();
+            std::size_t  size = _fileBody->Size() - pos;
 
             hash.Reset();
 
             // Read all Data to calculate the HASH/HMAC
             while (size > 0) {
                 uint16_t chunk = std::min(static_cast<uint16_t>(sizeof(buffer)), static_cast<uint16_t>(size));
-                _fileBody.Serialize(buffer, chunk);
+                _fileBody->Serialize(buffer, chunk);
                 hash.Input(buffer, chunk);
                 size -= chunk;
             }
 
-            _fileBody.Position(pos);
-
-            request.ContentSignature = Signature(hash.HashType(), hash.Result());
+            _fileBody->Position(false,pos);
+            const Crypto::EnumHashType type = ACTUALFILEBODY::HashType::Type;
+            request.ContentSignature = Signature(type, hash.Result());
         }
 
-        template <typename ACTUALLINK, typename ACTUALFILEBODY>
-        inline typename Core::TypeTraits::enable_if<!ClientTransferType<ACTUALLINK, ACTUALFILEBODY>::TraitHasHash::value, void>::type
-        _CalculateHash()
+        template < typename ACTUALFILEBODY = FILEBODY>
+        inline typename Core::TypeTraits::enable_if<!hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, void>::type
+        _CalculateHash(Web::Response& request)
         {
         }
 
-        template <typename ACTUALLINK, typename ACTUALFILEBODY>
-        inline typename Core::TypeTraits::enable_if<ClientTransferType<ACTUALLINK, ACTUALFILEBODY>::TraitHasHash::value, bool>::type
+        template <typename ACTUALFILEBODY = FILEBODY>
+        inline typename Core::TypeTraits::enable_if<hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, bool>::type
         _ValidateHash(const Core::OptionalType<Signature>& signature) const
         {
             // See if this is a valid. frame
-            return ((signature.IsSet() == false) || (signature.Value().Equal(_fileBody.HashType(), _fileBody.Hash().Result()) == true));
+            typename ACTUALFILEBODY::HashType& hash = _fileBody->Hash();
+            const Crypto::EnumHashType type = ACTUALFILEBODY::HashType::Type;
+            return ((signature.IsSet() == false) || (signature.Value().Equal(type, hash.Result()) == true));
         }
 
-        template <typename ACTUALLINK, typename ACTUALFILEBODY>
-        inline typename Core::TypeTraits::enable_if<!ClientTransferType<ACTUALLINK, ACTUALFILEBODY>::TraitHasHash::value, bool>::type
+        template <typename ACTUALFILEBODY = FILEBODY>
+        inline typename Core::TypeTraits::enable_if<!hasHash<ACTUALFILEBODY, const typename ACTUALFILEBODY::HashType& (ACTUALFILEBODY::*)() const>::value, bool>::type
         _ValidateHash(const Core::OptionalType<Signature>& signature) const
         {
             return (true);


### PR DESCRIPTION
- Reason for change : Build Error, Bug Fixes
  Fixed substitution failure errors with _CalculateHash() and _ValidateHash() functions.
  A few other compilation erros fixed when using SignedFileBodyType<HASHALGORITHM>
  This happens while enabling SignedFileBody transfer related test cases in Echotest Suite.