### PR TITLE
Feature/autogenerate document using jsongenerator

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -39,6 +39,11 @@ configure_file( "${CMAKE_SOURCE_DIR}/cmake/FindJsonGenerator.cmake.in"
                 @ONLY
 )
 
+configure_file( "${CMAKE_SOURCE_DIR}/cmake/FindDocGenerator.cmake.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/FindDocGenerator.cmake"
+                @ONLY
+)
+
 install(FILES 
         "${CMAKE_CURRENT_BINARY_DIR}/FindProxyStubGenerator.cmake"
     DESTINATION ${GENERIC_CMAKE_MODULE_PATH}
@@ -46,6 +51,11 @@ install(FILES
 
 install(FILES 
         "${CMAKE_CURRENT_BINARY_DIR}/FindJsonGenerator.cmake"
+    DESTINATION ${GENERIC_CMAKE_MODULE_PATH}
+)
+
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/FindDocGenerator.cmake"
     DESTINATION ${GENERIC_CMAKE_MODULE_PATH}
 )
 

--- a/Tools/cmake/FindDocGenerator.cmake.in
+++ b/Tools/cmake/FindDocGenerator.cmake.in
@@ -1,0 +1,17 @@
+find_package(JsonGenerator REQUIRED)
+
+function(DocGenerator)
+    set(oneValueArgs INPUT)
+
+    cmake_parse_arguments(Argument "${oneValueArgs}" ${ARGN} )
+
+    if(Argument_INPUT)
+        set(PLUGIN_NAME ${ARGN})
+    endif()
+
+    set(GENERATOR_SEARCH_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/${NAMESPACE})
+    set(CPPIFDIR_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/WPEFramework/interfaces/)
+    JsonGenerator(INPUT ${CMAKE_CURRENT_SOURCE_DIR}/${PLUGIN_NAME}Plugin.json DOCS OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/doc" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} CPPIFDIR ${CPPIFDIR_PATH})
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/${PLUGIN_NAME}Plugin.md DESTINATION "${CMAKE_INSTALL_PREFIX}/share/doc")
+endfunction(DocGenerator)

--- a/Tools/cmake/FindJsonGenerator.cmake.in
+++ b/Tools/cmake/FindJsonGenerator.cmake.in
@@ -31,7 +31,7 @@ function(JsonGenerator)
     endif()
 
     set(optionsArgs CODE STUBS DOCS NO_STYLE_WARNINGS COPY_CTOR NO_REF_NAMES)
-    set(oneValueArgs OUTPUT IFDIR INDENT DEF_STRING DEF_INT_SIZE PATH)
+    set(oneValueArgs OUTPUT IFDIR CPPIFDIR INDENT DEF_STRING DEF_INT_SIZE PATH)
     set(multiValueArgs INPUT INCLUDE_PATH)
 
     cmake_parse_arguments(Argument "${optionsArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -74,6 +74,10 @@ function(JsonGenerator)
 
     if (Argument_IFDIR)
         list(APPEND _execute_command  "-i" "${Argument_IFDIR}")
+    endif()
+
+    if (Argument_CPPIFDIR)
+        list(APPEND _execute_command  "-j" "${Argument_CPPIFDIR}")
     endif()
 
     if (Argument_OUTPUT)


### PR DESCRIPTION
This PR contains the changes needed for automatic generation of document using JsonGenerator tool. This involves adding a
cmake file which contains function DocGenerator().This function implements the logic for doc generation and installation for
wpeframework-plugins. This also adds option for including the cpp interface header file path that will substitute the {cppinterfacedir} tag in JsonGenerator tool command for document generation.