### PR TITLE
Fix for converting shortUuid into long uuid

### DIFF
--- a/Source/bluetooth/Profile.h
+++ b/Source/bluetooth/Profile.h
@@ -368,6 +368,14 @@ namespace Bluetooth {
                         }
                         return (result);
                     }
+                    string Uuid(bool full) const {
+                        bool naturalOrder = false;
+                        
+                        if (full && _uuid.HasShort())
+                            naturalOrder = true;
+
+                        return _uuid.ToString(full, naturalOrder);
+                    }
                     uint16_t Handle() const {
                         return (_handle);
                     }
@@ -445,6 +453,15 @@ namespace Bluetooth {
 
                     return (index != _descriptors.end() ? &(*index) : nullptr);
                 }
+                string Uuid(bool full) const {
+                    bool naturalOrder = false;
+
+                    if (full && _type.HasShort())
+                        naturalOrder = true;
+
+                    return _type.ToString(full, naturalOrder);
+                }
+
                 uint16_t Handle() const {
                     return (_handle);
                 }

--- a/Source/bluetooth/UUID.h
+++ b/Source/bluetooth/UUID.h
@@ -109,7 +109,33 @@ namespace Bluetooth {
         {
              return (_uuid[0] == 2 ? &(_uuid[15]) :  &(_uuid[1]));
         }
-        string ToString(const bool full = false) const
+        string ConvertRemainingBytes() const
+        {
+            static const TCHAR hexArray[] = "0123456789abcdef";
+
+            string result;
+            uint8_t index = 0;
+
+            result.resize(23);
+            result[index++] = '-';
+            for (uint8_t byte = 8 + 2; byte > 8; byte--) {
+                result[index++] = hexArray[_uuid[byte] >> 4];
+                result[index++] = hexArray[_uuid[byte] & 0xF];
+            }
+            result[index++] = '-';
+            for (uint8_t byte = 6 + 2; byte > 6; byte--) {
+                result[index++] = hexArray[_uuid[byte] >> 4];
+                result[index++] = hexArray[_uuid[byte] & 0xF];
+            }
+            result[index++] = '-';
+            for (uint8_t byte = 0 + 6; byte > 0; byte--) {
+                result[index++] = hexArray[_uuid[byte] >> 4];
+                result[index++] = hexArray[_uuid[byte] & 0xF];
+            }
+
+            return result;
+        }
+        string ToString(const bool full = false, const bool naturalOrder = false) const
         {
             static const TCHAR hexArray[] = "0123456789abcdef";
 
@@ -117,31 +143,33 @@ namespace Bluetooth {
             string result;
 
             if ((HasShort() == false) || (full == true)) {
-                result.resize(36);
-                for (uint8_t byte = 12 + 4; byte > 12; byte--) {
-                    result[index++] = hexArray[_uuid[byte] >> 4];
-                    result[index++] = hexArray[_uuid[byte] & 0xF];
+                result.resize(13);
+                if (naturalOrder == true) {
+                    for (uint8_t byte = 10 + 2; byte > 10; byte--) {
+                        result[index++] = hexArray[_uuid[byte] >> 4];
+                        result[index++] = hexArray[_uuid[byte] & 0xF];
+                    }
+                    for (uint8_t byte = 12 + 4; byte > 14; byte--) {
+                        result[index++] = hexArray[_uuid[byte] >> 4];
+                        result[index++] = hexArray[_uuid[byte] & 0xF];
+                    }
+                    result[index++] = '-';
+                    for (uint8_t byte = 10 + 4; byte > 12; byte--) {
+                        result[index++] = hexArray[_uuid[byte] >> 4];
+                        result[index++] = hexArray[_uuid[byte] >> 4];
+                    }
+                } else {
+                    for (uint8_t byte = 12 + 4; byte > 12; byte--) {
+                        result[index++] = hexArray[_uuid[byte] >> 4];
+                        result[index++] = hexArray[_uuid[byte] & 0xF];
+                    }
+                    result[index++] = '-';
+                    for (uint8_t byte = 10 + 2; byte > 10; byte--) {
+                        result[index++] = hexArray[_uuid[byte] >> 4];
+                        result[index++] = hexArray[_uuid[byte] & 0xF];
+                    }
                 }
-                result[index++] = '-';
-                for (uint8_t byte = 10 + 2; byte > 10; byte--) {
-                    result[index++] = hexArray[_uuid[byte] >> 4];
-                    result[index++] = hexArray[_uuid[byte] & 0xF];
-                }
-                result[index++] = '-';
-                for (uint8_t byte = 8 + 2; byte > 8; byte--) {
-                    result[index++] = hexArray[_uuid[byte] >> 4];
-                    result[index++] = hexArray[_uuid[byte] & 0xF];
-                }
-                result[index++] = '-';
-                for (uint8_t byte = 6 + 2; byte > 6; byte--) {
-                    result[index++] = hexArray[_uuid[byte] >> 4];
-                    result[index++] = hexArray[_uuid[byte] & 0xF];
-                }
-                result[index++] = '-';
-                for (uint8_t byte = 0 + 6; byte > 0; byte--) {
-                    result[index++] = hexArray[_uuid[byte] >> 4];
-                    result[index++] = hexArray[_uuid[byte] & 0xF];
-                }
+                result = result + ConvertRemainingBytes();
             }
             else {
                 result.resize(4);


### PR DESCRIPTION
 This patch is for getting 128-bit UUID value.A UUID is 128-bit
 value and to reduce burden of storing and transferring 128-bit
 value, range of values preallocated as shortUUIDs in 16-bit.
 All the standarad UUIDs represented in shortUUID and non-standard
 UUID(eg:OAD, voice) represented in 128-bit full value.

 There is already an existing api named ToString() which can be used
 to get both long and short Uuids as string value. But this api is
 representing first 32-bit value of UUId in reverse order(for example:
 0002a26-0000-1000-8000-00805f9b34fb(128-bit value) representing as
 2a26000-0000-1000-8000-00805f9b34fb).They are representing value like
 this for make easy to calculate shortUUID from this as 0x2a26.
 To Fix this introduced new api to get original longUUID value