### PR TITLE
DELIA-51490: Thunder error codes

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -661,7 +661,7 @@ namespace PluginHost {
                     Unlock();
 
                     result = Core::proxy_cast<Core::JSONRPC::Message>(Factories::Instance().JSONRPC());
-                    result->Error.SetError(Core::ERROR_BAD_REQUEST);
+                    result->Error.SetError(Core::ERROR_UNAVAILABLE);
                     result->Error.Text = _T("Service is not active");
                     result->Id = message.Id;
                 }
@@ -2664,6 +2664,10 @@ namespace PluginHost {
                     }
 
                     State(CLOSED, false);
+                } else if (IsUpgrading() == true) {
+                  if (Allowed(Path(), Query()) == false) {
+                    AbortUpgrade(Web::STATUS_FORBIDDEN, _T("Security prohibites this connection."));
+                  }
                 } else if (IsWebSocket() == true) {
                     ASSERT(_service.IsValid() == false);
                     bool serviceCall;

--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -385,6 +385,10 @@ namespace JSONRPC {
             {
                 _channel.Submit(message);
             }
+            bool IsSuspended() const
+            {
+                return (_channel.IsSuspended());
+            }
     
         protected:
             void StateChange()
@@ -1041,7 +1045,9 @@ namespace JSONRPC {
         {
             uint32_t result = Core::ERROR_UNAVAILABLE;
 
-            if (_channel.IsValid() == true) {
+            if ((_channel.IsValid() == true) && (_channel->IsSuspended() == true)) {
+                result = Core::ERROR_ASYNC_FAILED;
+            } else if (_channel.IsValid() == true) {
 
                 result = Core::ERROR_ASYNC_FAILED;
 
@@ -1080,6 +1086,8 @@ namespace JSONRPC {
                         if (response.IsValid() == true) {
                             result = Core::ERROR_NONE;
                         }
+                    } else {
+                      result = Core::ERROR_TIMEDOUT;
                     }
 
                     _adminLock.Lock();
@@ -1098,8 +1106,9 @@ namespace JSONRPC {
         {
             uint32_t result = Core::ERROR_UNAVAILABLE;
 
-            if (_channel.IsValid() == false) {
-            } else {
+            if ((_channel.IsValid() == true) && (_channel->IsSuspended() == true)) {
+                result = Core::ERROR_ASYNC_FAILED;
+            } else if (_channel.IsValid() == true) {
 
                 result = Core::ERROR_ASYNC_FAILED;
 

--- a/Source/websocket/WebSocketLink.h
+++ b/Source/websocket/WebSocketLink.h
@@ -1081,6 +1081,11 @@ namespace Web {
                     _parent.StateChange();
 
                     _adminLock.Unlock();
+                } else if ((_webSocketMessage.IsValid() == true) && (element->ErrorCode == Web::STATUS_FORBIDDEN)) {
+                    ASSERT((_state & UPGRADING) != 0);
+
+                    // Not allowed websocket
+                    Close(0);
                 } else {
                     _parent.Received(element);
                 }


### PR DESCRIPTION
Reason for change: json rpc errors should indicate
ERROR_TIMEDOUT (11) if timed out,
ERROR_UNAVAILABLE (2) if not activated,
or ERROR_ASYNC_FAILED (3) otherwise.
Test Procedure: See ticket.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>
(cherry picked from commit 929f8559a3c3e065a3946ea068c3edececd485cf)