### PR TITLE
 Changes for automatic documentation using jsongenerator

### DIFF
--- a/Tools/cmake/FindJsonGenerator.cmake.in
+++ b/Tools/cmake/FindJsonGenerator.cmake.in
@@ -31,7 +31,7 @@ function(JsonGenerator)
     endif()
 
     set(optionsArgs CODE STUBS DOCS NO_STYLE_WARNINGS COPY_CTOR NO_REF_NAMES)
-    set(oneValueArgs OUTPUT IFDIR INDENT DEF_STRING DEF_INT_SIZE PATH)
+    set(oneValueArgs OUTPUT IFDIR CPPIFDIR INDENT DEF_STRING DEF_INT_SIZE PATH)
     set(multiValueArgs INPUT INCLUDE_PATH)
 
     cmake_parse_arguments(Argument "${optionsArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -76,6 +76,10 @@ function(JsonGenerator)
         list(APPEND _execute_command  "-i" "${Argument_IFDIR}")
     endif()
 
+    if (Argument_CPPIFDIR)
+        list(APPEND _execute_command  "-j" "${Argument_CPPIFDIR}")
+    endif()
+
     if (Argument_OUTPUT)
         file(MAKE_DIRECTORY "${Argument_OUTPUT}")
         list(APPEND _execute_command  "--output" "${Argument_OUTPUT}")
@@ -106,3 +110,12 @@ function(JsonGenerator)
 endfunction(JsonGenerator)
 
 message(STATUS "JsonGenerator ready ${JSON_GENERATOR}")
+
+function(DocGenerator)
+
+    set(GENERATOR_SEARCH_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/${NAMESPACE})
+    set(CPPIFDIR_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/WPEFramework/interfaces/)
+    JsonGenerator(INPUT ${CMAKE_CURRENT_SOURCE_DIR}/${PLUGIN_NAME}Plugin.json DOCS OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/doc" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} CPPIFDIR ${CPPIFDIR_PATH})
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/${PLUGIN_NAME}Plugin.md DESTINATION "${CMAKE_INSTALL_PREFIX}/share/doc")
+endfunction(DocGenerator)


### PR DESCRIPTION
 This PR contains the changes for automatic documentation for wpeframework plugins using jsongenerator.This adds a function
 DocGenerator() which contains the logic to generate document automatically and installs it to image.
 This PR also contains option for including the cpp interface headerfile path that will substitute the {cppinterfacedir} tag
 in JsonGeneratortool command for document generation.