### PR TITLE
ONEM-22285: do not modify local json config files

### DIFF
--- a/cmake/project.cmake.in
+++ b/cmake/project.cmake.in
@@ -234,11 +234,12 @@ macro(write_config)
             endif()
         endif()
 
-        json_write("${CMAKE_CURRENT_BINARY_DIR}/config/${plugin}.json" ${plugin_config})
+        json_write("${CMAKE_CURRENT_BINARY_DIR}/config/${plugin}.generated.json" ${plugin_config})
 
         install(
-                FILES ${CMAKE_CURRENT_BINARY_DIR}/config/${plugin}.json DESTINATION
-                "${CMAKE_INSTALL_PREFIX}/../etc/${NAMESPACE}/plugins/"
+                FILES ${CMAKE_CURRENT_BINARY_DIR}/config/${plugin}.generated.json
+                RENAME ${plugin}.json
+                DESTINATION "${CMAKE_INSTALL_PREFIX}/../etc/${NAMESPACE}/plugins/"
                 COMPONENT ${_component})
     endforeach()
 


### PR DESCRIPTION
Currently some local json files are modified in the plugin repository:
$ git status
        modified:   ActivityMonitor/ActivityMonitor.json
        modified:   ContinueWatching/ContinueWatching.json
        modified:   DeviceDiagnostics/DeviceDiagnostics.json
        modified:   FrameRate/FrameRate.json
        modified:   StateObserver/StateObserver.json
        modified:   Warehouse/Warehouse.json

This fix solves this problem, by adding generated.json suffix to
generated files.