### PR TITLE
[Metrol305] Changes for notifying syslog logging.

### DIFF
--- a/Source/tracing/CMakeLists.txt
+++ b/Source/tracing/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PUBLIC_HEADERS
         TraceMedia.h
         TraceUnit.h
         Logging.h
+        ISyslogMonitorClient.h
         SyslogMonitor.h
         tracing.h
         Module.h

--- a/Source/tracing/CMakeLists.txt
+++ b/Source/tracing/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PUBLIC_HEADERS
         TraceMedia.h
         TraceUnit.h
         Logging.h
+        SyslogMonitor.h
         tracing.h
         Module.h
         )

--- a/Source/tracing/ISyslogMonitorClient.h
+++ b/Source/tracing/ISyslogMonitorClient.h
@@ -20,11 +20,10 @@
 #include "Module.h"
 namespace WPEFramework {
 namespace Logging {
-    class EXTERNAL ISyslogMonitorClient
+    struct EXTERNAL ISyslogMonitorClient
     {
-        public:
-            virtual void NotifyLog(const std::string& logmessage) = 0;
-            virtual ~ISyslogMonitorClient(){}
+        virtual void NotifyLog(const std::string& logmessage) = 0;
+        virtual ~ISyslogMonitorClient() = default;
     };
 }
 }

--- a/Source/tracing/ISyslogMonitorClient.h
+++ b/Source/tracing/ISyslogMonitorClient.h
@@ -1,0 +1,30 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 Metrological Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+namespace WPEFramework {
+namespace Logging {
+    class EXTERNAL ISyslogMonitorClient
+    {
+        public:
+            virtual void NotifyLog(const std::string& logmessage) = 0;
+            virtual ~ISyslogMonitorClient(){}
+    };
+}
+}

--- a/Source/tracing/SyslogMonitor.h
+++ b/Source/tracing/SyslogMonitor.h
@@ -18,24 +18,20 @@
  */
 
 #include "Module.h"
+#include "ISyslogMonitorClient.h"
 namespace WPEFramework {
 namespace Logging {
-    class EXTERNAL SyslogMonitorClient
-    {
-        public:
-            virtual void NotifyLog(const std::string& logmessage) = 0;
-    };
     class EXTERNAL SyslogMonitor
     {
         public:
             SyslogMonitor(const SyslogMonitor& ) = delete;
             SyslogMonitor& operator= (const SyslogMonitor& ) = delete;
-            void RegisterClient(SyslogMonitorClient* client)
+            void RegisterClient(ISyslogMonitorClient* client)
             {
                 _monitorClients.push_back(client);
                 return;
             }
-            void UnregisterClient(SyslogMonitorClient* client)
+            void UnregisterClient(ISyslogMonitorClient* client)
             {
                 auto iter = std::find(begin(_monitorClients), end(_monitorClients), client);
                 if( iter != _monitorClients.end())
@@ -46,8 +42,8 @@ namespace Logging {
             }
             static SyslogMonitor& Instance()
             {
-                static SyslogMonitor syslogMonitor;
-                return syslogMonitor;
+                static SyslogMonitor& _syslogMonitor = Core::SingletonType<SyslogMonitor>::Instance();
+                return _syslogMonitor;
             }
             void SendLogMessage(const std::string& logMessage)
             {
@@ -58,11 +54,11 @@ namespace Logging {
                 return;
             }
             ~SyslogMonitor() = default;
-        private:
+        protected:
             SyslogMonitor():_monitorClients(){}
 
         private:
-            std::vector<SyslogMonitorClient*> _monitorClients;
+            std::vector<ISyslogMonitorClient*> _monitorClients;
     };
 }
 }

--- a/Source/tracing/SyslogMonitor.h
+++ b/Source/tracing/SyslogMonitor.h
@@ -1,0 +1,68 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 Metrological Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+namespace WPEFramework {
+namespace Logging {
+    class EXTERNAL SyslogMonitorClient
+    {
+        public:
+            virtual void NotifyLog(const std::string& logmessage) = 0;
+    };
+    class EXTERNAL SyslogMonitor
+    {
+        public:
+            SyslogMonitor(const SyslogMonitor& ) = delete;
+            SyslogMonitor& operator= (const SyslogMonitor& ) = delete;
+            void RegisterClient(SyslogMonitorClient* client)
+            {
+                _monitorClients.push_back(client);
+                return;
+            }
+            void UnregisterClient(SyslogMonitorClient* client)
+            {
+                auto iter = std::find(begin(_monitorClients), end(_monitorClients), client);
+                if( iter != _monitorClients.end())
+                {
+                    _monitorClients.erase(iter);
+                }
+                return;
+            }
+            static SyslogMonitor& Instance()
+            {
+                static SyslogMonitor syslogMonitor;
+                return syslogMonitor;
+            }
+            void SendLogMessage(const std::string& logMessage)
+            {
+                for(auto& client: _monitorClients)
+                {
+                    client->NotifyLog(logMessage);
+                }
+                return;
+            }
+            ~SyslogMonitor() = default;
+        private:
+            SyslogMonitor():_monitorClients(){}
+
+        private:
+            std::vector<SyslogMonitorClient*> _monitorClients;
+    };
+}
+}


### PR DESCRIPTION
When WPEFramework does a Syslog, it will notify the
message to the registered monitoring clients