### PR TITLE
[Proxy] Remove virtual inheritance

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -615,13 +615,11 @@ namespace Core {
     public:
         template <typename... Args>
         inline Void(Args&&...) {}
-        inline Void(const Void&) {}
-        inline ~Void() {}
+        inline Void(const Void&) = default;
+        inline Void(Void&&) = default;
+        inline ~Void() = default;
 
-        inline Void& operator=(const Void&)
-        {
-            return (*this);
-        }
+        inline Void& operator=(const Void&) = default;
     };
 
     struct EXTERNAL IReferenceCounted {
@@ -630,7 +628,7 @@ namespace Core {
         virtual uint32_t Release() const = 0;
     };
 
-    struct EXTERNAL IUnknown : virtual public IReferenceCounted  {
+    struct EXTERNAL IUnknown : public IReferenceCounted  {
         enum { ID = 0x00000000 };
 
         ~IUnknown() override = default;

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -1310,11 +1310,13 @@ namespace Core {
         inline typename Core::TypeTraits::enable_if<hasAcquire<TYPE, void (TYPE::*)(Core::ProxyType<STORED>& source)>::value, void>::type
             __Acquire(Core::ProxyType<ThisClass>& source)
         {
-            Core::ProxyType<STORED> base(std::move(source));
+            Core::ProxyType<STORED> base;
+            
+            base.Load(source._refCount, source._realObject);
 
             TYPE::Acquire(base);
 
-            source = std::move(base);
+            base.Reset();
         }
         template <typename TYPE = CONTEXT>
         inline typename Core::TypeTraits::enable_if<!hasAcquire<TYPE, void (TYPE::*)(Core::ProxyType<STORED>& source)>::value, void>::type
@@ -1331,11 +1333,13 @@ namespace Core {
         inline typename Core::TypeTraits::enable_if<hasRelinquish<TYPE, void (TYPE::*)(Core::ProxyType<STORED>&)>::value, void>::type
             __Relinquish(Core::ProxyType<ThisClass>& source)
         {
-            Core::ProxyType<STORED> base(std::move(source));
+            Core::ProxyType<STORED> base;
+
+            base.Load(source._refCount, source._realObject);
 
             TYPE::Relinquish(base);
 
-            source = std::move(base);
+            base.Reset();
         }
         template < typename TYPE = CONTEXT>
         inline typename Core::TypeTraits::enable_if<!hasRelinquish<TYPE, void (TYPE::*)(Core::ProxyType<STORED>&)>::value, void>::type

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -22,6 +22,7 @@
 
 // ---- Include system wide include files ----
 #include <memory>
+#include <atomic>
 
 // ---- Include local include files ----
 #include "Portability.h"
@@ -44,7 +45,7 @@ namespace Core {
     class ProxyType;
 
     template <typename CONTEXT>
-    class ProxyObject final : public CONTEXT, virtual public IReferenceCounted {
+    class ProxyObject final : public CONTEXT, public std::conditional<std::is_base_of<IReferenceCounted, CONTEXT>::value, Void, IReferenceCounted>::type {
     public:
         // ----------------------------------------------------------------
         // Never, ever allow reference counted objects to be assigned.
@@ -119,13 +120,13 @@ namespace Core {
         void AddRef() const override
         {
             const_cast<ProxyObject<CONTEXT>*>(this)->__Acquire();
-            Core::InterlockedIncrement(_refCount);
+            _refCount++;
         }
         uint32_t Release() const override
         {
             uint32_t result = Core::ERROR_NONE;
 
-            if (Core::InterlockedDecrement(_refCount) == 0) {
+            if ((_refCount--) == 0) {
                 delete this;
                 result = Core::ERROR_DESTRUCTION_SUCCEEDED;
             }
@@ -186,7 +187,7 @@ namespace Core {
             // At the moment these go out of scope, this CompositRelease has to be called. It is assuming the
             // last release but will not delete this object as that the the responsibility of the object that
             // has this object as a composit.
-            Core::InterlockedDecrement(_refCount);
+            _refCount--;
 
             ASSERT(_refCount == 0);
         }
@@ -309,7 +310,7 @@ namespace Core {
         }
 
     protected:
-        mutable uint32_t _refCount;
+        mutable std::atomic<uint32_t> _refCount;
     };
 
     // ------------------------------------------------------------------------------


### PR DESCRIPTION
Remove virtual inheritance after the cleanup and replace interlocked by std::atomic for better performance