### PR TITLE
Build: Custom tracing level

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -64,6 +64,7 @@ option(WCHAR_SUPPORT
         "Enable support for WCHAR." OFF)
 option(DISABLE_TRACING
         "Disable tracing in debug" OFF)
+set(ENABLED_TRACING_LEVEL 0 CACHE STRING "If tracing is enabled, this sets its default level.")
 option(HIDE_NON_EXTERNAL_SYMBOLS 
         "Hide all non EXTERNAL tagged symbols" OFF)
 

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -148,6 +148,9 @@ set(PUBLIC_HEADERS
 if(DISABLE_TRACING)
     target_compile_definitions(${TARGET} PUBLIC _TRACE_LEVEL=0)
     message(STATUS "Force trace level to 0")
+else()
+    target_compile_definitions(${TARGET} PUBLIC _TRACE_LEVEL=${ENABLED_TRACING_LEVEL})
+    message(STATUS "Force trace level to ${ENABLED_TRACING_LEVEL}")
 endif()
 
 if(WARNING_REPORTING)


### PR DESCRIPTION
This adds the capability to set a custom tracing level onto WPEFramework, thus permitting the usage of existing TRACE_Lx in an easy way.

This is disabled by default. A configuration should be provided to override these settings.