### PR TITLE
Virtual Input: Loading key map from an JSON Array

### DIFF
--- a/Source/plugins/VirtualInput.h
+++ b/Source/plugins/VirtualInput.h
@@ -226,6 +226,7 @@ namespace PluginHost {
                 _passThrough = enabled;
             }
             uint32_t Load(const string& mappingFile);
+            uint32_t LoadFromArray(const Core::JSON::ArrayType<KeyMapEntry>& mappingTable);
             uint32_t Save(const string& mappingFile);
 
             inline const ConversionInfo* operator[](const uint32_t code) const


### PR DESCRIPTION
Keymaps are curently loaded from a single method (VirtualInput::Keymap::Load()) that requires the key map file name as input paramter. This commit adds a new method to load the keymap from analysing an array of 'KeyMapEntry' data types.
This serves for those use cases where a keymap is embedded on a file containing other types of data.
In order to re-use code, VirtualInput::Keymap::Load() method calls the new VirtualInput::KeyMap::LoadFromArray() method.
