### PR TITLE
DELIA-52583: fix JSONRPC::LinkType timeout (#761)

### DIFF
--- a/Source/websocket/WebSocketLink.h
+++ b/Source/websocket/WebSocketLink.h
@@ -1081,6 +1081,8 @@ namespace Web {
                     _parent.StateChange();
 
                     _adminLock.Unlock();
+
+                    ACTUALLINK::Trigger();
                 } else if ((_webSocketMessage.IsValid() == true) && (element->ErrorCode == Web::STATUS_FORBIDDEN)) {
                     ASSERT((_state & UPGRADING) != 0);
 


### PR DESCRIPTION
Reason for change: If socket becomes open before
WaitForOpen, jsonrpc is submitted before WEBSOCKET
as a result nothing is sent and Invoke times out.
Trigger will make sure the submitted jsonrpc is sent
when the state becomes WEBSOCKET. If nothing has
been submitted it will do nothing.
Test Procedure: Invoke on JSONRPC::LinkType
doesn't timeout.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>