### PR TITLE
[Library] Delete when not referenced anymore

### DIFF
--- a/Source/core/Library.cpp
+++ b/Source/core/Library.cpp
@@ -141,6 +141,7 @@ namespace Core {
                 ::FreeLibrary(_refCountedHandle->_handle);
 #endif
                 TRACE_L1("Unloaded library: %s", _refCountedHandle->_name.c_str());
+                delete _refCountedHandle;
             } else {
                 Core::InterlockedDecrement(_refCountedHandle->_referenceCount);
             }


### PR DESCRIPTION
Delete ref counted handle when not used. This is already fixed on master.