### PR TITLE
[ONEM-22696] Fix for memleak on each socket connection.

### DIFF
--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -542,15 +542,21 @@ namespace WPEFramework {
             template <typename DERIVED>
             inline void CopyConstruct(const ProxyType<DERIVED>& source, const TemplateIntToType<false>&)
             {
-                DERIVED* sourceClass = source.operator->();
-                _realObject = (dynamic_cast<CONTEXT*>(sourceClass));
-
-                if (_realObject == nullptr) {
+                if (source.IsValid() == false) {
                     _refCount = nullptr;
                 }
                 else {
-                    _refCount = source._refCount;
-                    _refCount->AddRef();
+                    DERIVED* sourceClass = source.operator->();
+                    _realObject = (dynamic_cast<CONTEXT*>(sourceClass));
+
+                    if (_realObject == nullptr) {
+                        _refCount = nullptr;
+                    }
+                    else {
+                        _refCount = source._refCount;
+                        _refCount->AddRef();
+                    }
+
                 }
             }
             template <typename DERIVED>
@@ -569,14 +575,19 @@ namespace WPEFramework {
             template <typename DERIVED>
             inline void MoveConstruct(ProxyType<DERIVED>&& source, const TemplateIntToType<false>&)
             {
-                _realObject = (dynamic_cast<CONTEXT*>(source.operator->()));
-
-                if (_realObject == nullptr) {
+                if (source.IsValid() == false) {
                     _refCount = nullptr;
                 }
                 else {
-                    _refCount = source._refCount;
-                    source.Reset();
+                    _realObject = (dynamic_cast<CONTEXT*>(source.operator->()));
+
+                    if (_realObject == nullptr) {
+                        _refCount = nullptr;
+                    }
+                    else {
+                        _refCount = source._refCount;
+                        source.Reset();
+                    }
                 }
             }
             template <typename... Args>

--- a/Source/core/SocketServer.h
+++ b/Source/core/SocketServer.h
@@ -263,7 +263,8 @@ namespace Core {
                     if ((index->second->IsClosed() == true) || ((index->second->IsSuspended() == true) && (index->second->Close(100) == Core::ERROR_NONE))) {
                         // Step forward but remember where we were and delete that one....
                         index = _clients.erase(index);
-                    } else {
+                    }
+                    else {
                         index++;
                     }
                 }
@@ -272,7 +273,6 @@ namespace Core {
             }
             virtual void Accept(SOCKET& newClient, const NodeId& remoteId)
             {
-
                 ProxyType<HANDLECLIENT> client = ProxyType<HANDLECLIENT>::Create(newClient, remoteId, &_parent);
 
                 ASSERT(client.IsValid() == true);
@@ -281,6 +281,18 @@ namespace Core {
                 if (client->Open(0) == ERROR_NONE) {
 
                     _lock.Lock();
+
+                    // Check if we can remove closed clients.
+                    typename ClientMap::iterator index = _clients.begin();
+
+                    while (index != _clients.end()) {
+                        if (index->second->IsClosed() == true) {
+                            index = _clients.erase(index);
+                        }
+                        else {
+                            ++index;
+                        }
+                    }
 
                     // If the CLient has a method to receive it's Id pass it on..
                     __Id(*client, _nextClient);
@@ -305,7 +317,6 @@ namespace Core {
             // Check for Id  method on Object
             // -----------------------------------------------------
             HAS_MEMBER(Id, hasId);
-
 
             template <typename SUBJECT=HANDLECLIENT>
             inline typename Core::TypeTraits::enable_if<hasId<SUBJECT, void (SUBJECT::*)(uint32_t)>::value, void>::type


### PR DESCRIPTION
In case the IdleTimer is set to 0 (no checking on dead connections) the created connections, never get cleared. This is the master fix and equal to the patch for R2 => [https://github.com/rdkcentral/Thunder/pull/772].
This patch will clear closed sockets on every new connection.
During testing we found that if the ProxyType during casting requires an invalid proxy, it ASSERTS. Now checking
for an invalid proxy before we cast.