### PR TITLE
[NETLINK] Netlink functionality for userspace Connectors.

### DIFF
--- a/Source/core/Netlink.cpp
+++ b/Source/core/Netlink.cpp
@@ -84,10 +84,10 @@ namespace Core {
                 _mySequence = header->nlmsg_seq;
 
                 if ((header->nlmsg_len - sizeof(header)) > 0) {
-                    Read(reinterpret_cast<const uint8_t *>(NLMSG_DATA(header)), header->nlmsg_len - sizeof(header));
+                    completed = (Read(reinterpret_cast<const uint8_t *>(NLMSG_DATA(header)), header->nlmsg_len - sizeof(header)) > 0);
                 }
 
-                completed = (header->nlmsg_type == NLMSG_DONE) || ((header->nlmsg_flags & NLM_F_MULTI) == 0);
+                completed = completed && ((header->nlmsg_type == NLMSG_DONE) || ((header->nlmsg_flags & NLM_F_MULTI) == 0));
             }
 
             header = NLMSG_NEXT(header, dataLeft);


### PR DESCRIPTION
The userspace connector fucntionality requires multi messages support. If, for example,
the OneWire userspace connector is used, multiple commands can be send in 1 netlink message,
as a response multiple answers will be send on these  requests. By passing back 0, on read,
one can signal that more data is expected before the full netlink exchange should be considered
completed.

Checked all corresponding Network (netlink functionality) and saw that these netlink messages all,
always return the size of the message that was offerd (a value <> 0). Tested the funtionality on
linux and no regression was observed. The Onewire functionality is now operational as well again.