### PR TITLE
[REFERENCELEAK] The new ProxyTypes did not release an existing refere…

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -601,6 +601,18 @@ namespace PluginHost {
                         }
                         break;
                     }
+                    case 'E': {
+                        uint32_t requests, responses, filebodies, jsonrequests;
+                        _dispatcher->Statistics(requests, responses, filebodies, jsonrequests);
+                        printf("\nProxyPool Elements:\n");
+                        printf("============================================================\n");
+                        printf("HTTP requests:    %d\n", requests);
+                        printf("HTTP responses:   %d\n", responses);
+                        printf("HTTP Files:       %d\n", filebodies);
+                        printf("JSONRPC messages: %d\n", jsonrequests);
+
+                        break;
+                    }
                     case 'P': {
                         Core::JSON::ArrayType<MetaData::Service> metaData;
                         _dispatcher->Services().GetMetaData(metaData);

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -149,6 +149,12 @@ namespace PluginHost {
             ~FactoriesImplementation() override = default;
 
         public:
+            void Statistics(uint32_t& requests, uint32_t& responses, uint32_t& fileBodies, uint32_t& jsonrpc) const {
+                requests = _requestFactory.Count();
+                responses = _responseFactory.Count();
+                fileBodies = _fileBodyFactory.Count();
+                jsonrpc = _jsonRPCFactory.Count();
+            }
             Core::ProxyType<Web::Request> Request() override
             {
                 return (_requestFactory.Element());
@@ -2381,7 +2387,7 @@ namespace PluginHost {
 #if THUNDER_PERFORMANCE
                         Core::ProxyType<TrackingJSONRPC> tracking (_element);
                         ASSERT (tracking.IsValid() == true);
-			tracking->Dispatch();
+			            tracking->Dispatch();
 #endif
                         Core::ProxyType<Core::JSONRPC::Message> message(_element);
                         ASSERT(message.IsValid() == true);
@@ -3066,6 +3072,9 @@ namespace PluginHost {
         virtual ~Server();
 
     public:
+        inline void Statistics(uint32_t& requests, uint32_t& responses, uint32_t& fileBodies, uint32_t& jsonrpc) const {
+            _factoriesImplementation.Statistics(requests, responses, fileBodies, jsonrpc);
+        }
         inline ChannelMap& Dispatcher()
         {
             return (_connections);

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -430,35 +430,43 @@ namespace WPEFramework {
                 return (ProxyType<CONTEXT>(*CreateObject(size, std::forward<Args>(args)...)));
             }
 
+            template <typename DERIVEDTYPE>
+            ProxyType<CONTEXT>& operator=(const ProxyType<DERIVEDTYPE>& rhs)
+            {
+                // If we already have one, lets remove the one we got first
+                if (_refCount != nullptr) _refCount->Release();
+
+                CopyConstruct<DERIVEDTYPE>(rhs, TemplateIntToType<Core::TypeTraits::same_or_inherits<CONTEXT, DERIVEDTYPE>::value>());
+
+                return(*this);
+            }
+
             ProxyType<CONTEXT>& operator=(const ProxyType<CONTEXT>& rhs)
             {
-                if (_refCount != rhs._refCount) {
-                    // Release the current holding object
-                    if (_refCount != nullptr) {
-                        _refCount->Release();
-                    }
+                // If we already have one, lets remove the one we got first
+                if (_refCount != nullptr) _refCount->Release();
 
-                    // Get the new object
-                    _refCount = rhs._refCount;
-                    _realObject = rhs._realObject;
+                CopyConstruct<CONTEXT>(rhs, TemplateIntToType<Core::TypeTraits::same_or_inherits<CONTEXT, CONTEXT>::value>());
 
-                    if (_refCount != nullptr) {
-                        _refCount->AddRef();
-                    }
-                }
-
-                return (*this);
+                return(*this);
             }
 
             template <typename DERIVEDTYPE>
             ProxyType<CONTEXT>& operator=(ProxyType<DERIVEDTYPE>&& rhs)
             {
+                // If we already have one, lets remove the one we got first
+                if (_refCount != nullptr) _refCount->Release();
+
                 MoveConstruct<DERIVEDTYPE>(std::move(rhs), TemplateIntToType<Core::TypeTraits::same_or_inherits<CONTEXT, DERIVEDTYPE>::value>());
 
                 return(*this);
             }
+
             ProxyType<CONTEXT>& operator=(ProxyType<CONTEXT>&& rhs)
             {
+                // If we already have one, lets remove the one we got first
+                if (_refCount != nullptr) _refCount->Release();
+
                 MoveConstruct<CONTEXT>(std::move(rhs), TemplateIntToType<Core::TypeTraits::same_or_inherits<CONTEXT, CONTEXT>::value>());
 
                 return(*this);
@@ -1494,6 +1502,9 @@ namespace WPEFramework {
                 _queue.emplace_back(std::move(source));
 
                 _lock.Unlock();
+            }
+            uint32_t Count() const {
+                return (_createdElements);
             }
 
         private:


### PR DESCRIPTION
…nce if the asignment operator overload was triggered.

This causes a small memory leak that could only be detected in case the memory graph got plottted. To prove the stability of the
proxypool, the WPEFramework application can now print the elements created in the factories as used by the WPEFramework plugin
server (press E) under continous load these should be stable.