### PR TITLE
Build: Export CRITICAL_SECTION_LOCK_LOG compile setting

### DIFF
--- a/cmake/modules/CompileSettings.cmake
+++ b/cmake/modules/CompileSettings.cmake
@@ -54,6 +54,10 @@ if(PERFORMANCE_MONITOR)
     target_compile_definitions(CompileSettings INTERFACE -DTHUNDER_PERFORMANCE=1)
 endif()
 
+if(DEADLOCK_DETECTION)
+    target_compile_definitions(CompileSettings INTERFACE CRITICAL_SECTION_LOCK_LOG)
+endif()
+
 if(NOT BUILD_TYPE)
     set(BUILD_TYPE Production)
     message(AUTHOR_WARNING "BUILD_TYPE not set, assuming '${BUILD_TYPE}'")


### PR DESCRIPTION
While having the `DEADLOCK_DETECTION` CMake option turned on, an 'undefined symbol' error occurred when loading a shared library on a plugin.
Comparing the generated libraries, there was an obvious difference in the method signature. This is caused by the missing declaration of the `CRITICAL_SECTION_LOCK_LOG` compilation specifier, on the plugin side.

`CRITICAL_SECTION_LOCK_LOG` compilation specifier changes the implementation on CriticalSection, thus creating type misalignment when is not declared on both sides. Currently, it is not being exported.