### PR TITLE
Virtual Input: Import/Export keymap from/to JSON array

### DIFF
--- a/Source/plugins/VirtualInput.h
+++ b/Source/plugins/VirtualInput.h
@@ -225,8 +225,10 @@ namespace PluginHost {
             {
                 _passThrough = enabled;
             }
-            uint32_t Load(const string& mappingFile);
-            uint32_t Save(const string& mappingFile);
+            DEPRECATED uint32_t Load(const string& mappingFile);
+            uint32_t Import(const Core::JSON::ArrayType<KeyMapEntry>& mappingTable);
+            DEPRECATED uint32_t Save(const string& mappingFile);
+            void Export(Core::JSON::ArrayType<KeyMapEntry>& mappingTable);
 
             inline const ConversionInfo* operator[](const uint32_t code) const
             {


### PR DESCRIPTION
Keymaps are curently loaded/saved using methods that imply that a dedicated file
exists to store the keymap. That is not always the real use case, since this map
can be embedded on a file containing other types of data.
For the above reason, this commit adds new methods to Import/Export the keymap
by parsing/filling a JSON array of 'KeyMapEntry' data types.
In order to re-use code:
 * 'VirtualInput::Keymap::Load' calls the new 'VirtualInput::KeyMap::Import'
 * 'VirtualInput::Keymap::Save' calls the new 'VirtualInput::KeyMap::Export'
By having these new methods, we can consider that 'VirtualInput::Keymap::Load'
and 'VirtualInput::Keymap::Save' can be considered DEPRECATED.