### PR TITLE
BCOM-5717: Wpeframework killed due to invalid memory access

### DIFF
--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -588,6 +588,8 @@ namespace Core {
         {
             ASSERT(a_Index < m_Current);
             ASSERT(m_List != nullptr);
+            ASSERT(a_Entry.IsValid() != false);
+            ASSERT(m_List[a_Index] != nullptr);
 
             // Remember the item on the location, It should be a relaes and an add for
             // the new one, To optimize for speed, just copy the count.
@@ -595,6 +597,7 @@ namespace Core {
 
             // If it is taken out, release the reference that we took during the add
             m_List[a_Index]->Release();
+            m_List[a_Index] = nullptr;
 
             // Delete one element.
             Core::InterlockedDecrement(m_Current);
@@ -603,6 +606,10 @@ namespace Core {
             if (a_Index < m_Current) {
                 // Kill the entry, (again dirty but quick).
                 memmove(&(m_List[a_Index]), &(m_List[a_Index + 1]), (m_Current - a_Index) * sizeof(IReferenceCounted*));
+            }
+	    else if (a_Index == m_Current)
+            {
+                m_List[m_Current] = nullptr;
             }
 
 #ifdef __DEBUG__
@@ -614,9 +621,12 @@ namespace Core {
         {
             ASSERT(a_Index < m_Current);
             ASSERT(m_List != nullptr);
+            ASSERT(a_Entry.IsValid() != false);
+            ASSERT(m_List[a_Index] != nullptr);
 
             // If it is taken out, release the reference that we took during the add
             m_List[a_Index]->Release();
+            m_List[a_Index] = nullptr;
 
             // Delete one element.
             Core::InterlockedDecrement(m_Current);
@@ -625,6 +635,10 @@ namespace Core {
             if (a_Index < m_Current) {
                 // Kill the entry, (again dirty but quick).
                 memmove(&(m_List[a_Index]), &(m_List[a_Index + 1]), (m_Current - a_Index) * sizeof(IReferenceCounted*));
+            }
+	    else if (a_Index == m_Current)
+            {
+                m_List[m_Current] = nullptr;
             }
 
 #ifdef __DEBUG__

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -588,7 +588,6 @@ namespace Core {
         {
             ASSERT(a_Index < m_Current);
             ASSERT(m_List != nullptr);
-            ASSERT(a_Entry.IsValid() != false);
             ASSERT(m_List[a_Index] != nullptr);
 
             // Remember the item on the location, It should be a relaes and an add for
@@ -607,10 +606,6 @@ namespace Core {
                 // Kill the entry, (again dirty but quick).
                 memmove(&(m_List[a_Index]), &(m_List[a_Index + 1]), (m_Current - a_Index) * sizeof(IReferenceCounted*));
             }
-	    else if (a_Index == m_Current)
-            {
-                m_List[m_Current] = nullptr;
-            }
 
 #ifdef __DEBUG__
             m_List[m_Current] = nullptr;
@@ -621,7 +616,6 @@ namespace Core {
         {
             ASSERT(a_Index < m_Current);
             ASSERT(m_List != nullptr);
-            ASSERT(a_Entry.IsValid() != false);
             ASSERT(m_List[a_Index] != nullptr);
 
             // If it is taken out, release the reference that we took during the add
@@ -635,10 +629,6 @@ namespace Core {
             if (a_Index < m_Current) {
                 // Kill the entry, (again dirty but quick).
                 memmove(&(m_List[a_Index]), &(m_List[a_Index + 1]), (m_Current - a_Index) * sizeof(IReferenceCounted*));
-            }
-	    else if (a_Index == m_Current)
-            {
-                m_List[m_Current] = nullptr;
             }
 
 #ifdef __DEBUG__

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -1134,7 +1134,7 @@ namespace Core {
         inline typename Core::TypeTraits::enable_if<ProxyContainerType<A, B, C>::TraitIsInitialized::value, bool>::type
             __IsInitialized() const
         {
-            reurn (ELEMENT::IsInitialized());
+            return (ELEMENT::IsInitialized());
         }
 
         template <typename A, typename B, typename C>


### PR DESCRIPTION
Reason for change: return statement added wrongly.
Test Procedure: Regression
Risks: None
Signed-off-by: Arun Vijay <asathy881@cable.comcast.com>