### PR TITLE
DELIA-49364: Thunder doesn't handle invalid JSON properly

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -140,7 +140,7 @@ namespace Core {
 
                     if (loaded == 0) {
                         TRACE_L1("Failed to parse json. \n%s\n", text.c_str());
-		        break;
+                        break;
                     }
                     handled += loaded;
                 }

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -139,7 +139,8 @@ namespace Core {
                     DEBUG_VARIABLE(loaded);
 
                     if (loaded == 0) {
-                        break;
+                        TRACE_L1("Failed to parse json. \n%s\n", text.c_str());
+		        break;
                     }
                     handled += loaded;
                 }


### PR DESCRIPTION
Reason for change: Added the Trace Log for handle invalid JSON
Test Procedure:  refer the ticket for details
Risks: Low