### PR TITLE
[FRAME] Extend the functionality of the Frame template.

### DIFF
--- a/Source/com/Messages.h
+++ b/Source/com/Messages.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef __COM_MESSAGES_H
-#define __COM_MESSAGES_H
+#pragma once
 
 #include "Module.h"
 
@@ -40,18 +39,17 @@ namespace RPC {
     namespace Data {
         static const uint16_t IPC_BLOCK_SIZE = 512;
 
-        class Frame : public Core::FrameType<IPC_BLOCK_SIZE> {
+        class Frame : public Core::FrameType<IPC_BLOCK_SIZE, true, uint16_t> {
         private:
+            using BaseClass = Core::FrameType < IPC_BLOCK_SIZE, true, uint16_t>;
+
+        public:
             Frame(Frame&) = delete;
             Frame& operator=(const Frame&) = delete;
 
-        public:
-            Frame()
-            {
+            Frame() : BaseClass() {
             }
-            ~Frame()
-            {
-            }
+            ~Frame() = default;
 
         public:
             friend class Input;
@@ -77,18 +75,13 @@ namespace RPC {
         };
 
         class Input {
-        private:
+        public:
             Input(const Input&) = delete;
             Input& operator=(const Input&) = delete;
 
-        public:
-            Input()
-                : _data()
-            {
+            Input() : _data() {
             }
-            ~Input()
-            {
-            }
+            ~Input() = default;
 
         public:
             inline void Clear()
@@ -151,18 +144,13 @@ namespace RPC {
         };
 
         class Output {
-        private:
+        public:
             Output(const Output&) = delete;
             Output& operator=(const Output&) = delete;
 
-        public:
-            Output()
-                : _data()
-            {
+            Output() : _data() {
             }
-            ~Output()
-            {
-            }
+            ~Output() = default;
 
         public:
             inline void Clear()
@@ -201,8 +189,6 @@ namespace RPC {
 
         class Init {
         private:
-            Init(const Init&) = delete;
-            Init& operator=(const Init&) = delete;
             uint32_t ParentId() const 
             {
                 uint32_t exchangeId = 0;
@@ -223,6 +209,9 @@ namespace RPC {
             };
 
         public:
+            Init(const Init&) = delete;
+            Init& operator=(const Init&) = delete;
+
             Init()
                 : _id(0)
                 , _implementation(0)
@@ -232,9 +221,7 @@ namespace RPC {
             {
                 _className[0] = '\0';
             }
-            ~Init()
-            {
-            }
+            ~Init() = default;
 
         public:
             bool IsOffer() const
@@ -330,18 +317,13 @@ namespace RPC {
         };
 
         class Setup {
-        private:
+        public:
             Setup(const Setup&) = delete;
             Setup& operator=(const Setup&) = delete;
 
-        public:
-            Setup()
-                : _data()
-            {
+            Setup() : _data() {
             }
-            ~Setup()
-            {
-            }
+            ~Setup() = default;
 
         public:
             inline void Clear()
@@ -435,5 +417,3 @@ namespace RPC {
     typedef Core::IPCMessageType<2, Data::Input, Data::Output> InvokeMessage;
 }
 }
-
-#endif // __COM_MESSAGES_H

--- a/Source/core/Time.cpp
+++ b/Source/core/Time.cpp
@@ -112,11 +112,11 @@ namespace Core {
 
     static uint32_t WeekFromString(const string& buffer, const uint8_t delimeter, const bool fromName, uint8_t& wday) {
         uint32_t index = 0;
-        SkipLeadingSpaces(buffer.c_str(), buffer.size(), index);
+        SkipLeadingSpaces(buffer.c_str(), static_cast<uint8_t>(buffer.size()), index);
         string weekDayName = buffer.substr(index, buffer.find_first_of(delimeter, index));
         if (weekDayName.size() > 0) {
             wday = (fromName ? WeekFromName(weekDayName.c_str()) : (weekDayName.size() == 3) ? WeekFromAbbrevation(weekDayName.c_str()) : static_cast<uint8_t>(~0));
-            index += weekDayName.length() + 1;
+            index += static_cast<uint32_t>(weekDayName.length()) + 1;
         }
         return index;
     }
@@ -299,9 +299,9 @@ namespace Core {
                 index += MonthFromString(&(buffer.c_str()[index]), static_cast<uint8_t>(buffer.size() - index), month);
 
                 if (month != static_cast<uint8_t>(~0)) {
-                    SkipLeadingSpaces(buffer.c_str(), buffer.size(), index);
+                    SkipLeadingSpaces(buffer.c_str(), static_cast<uint8_t>(buffer.size()), index);
 
-                    if (((index + 7) < buffer.size()) && ::isdigit(buffer[index]) == true) {
+                    if (((index + 7) < buffer.size()) && (::isdigit(buffer[index]) != 0)) {
                         // Now we should be on the day
                         day = static_cast<uint8_t>(buffer[index] - '0');
                         if (::isdigit(buffer[index + 1]) != 0) {
@@ -342,7 +342,7 @@ namespace Core {
         index += WeekFromString(buffer, ',', false, wday);
 
         if (wday != static_cast<uint8_t>(~0)) {
-           SkipLeadingSpaces(buffer.c_str(), buffer.size(), index);
+           SkipLeadingSpaces(buffer.c_str(), static_cast<uint8_t>(buffer.size()), index);
 
             if ((index + 14) < static_cast<uint32_t>(buffer.size())) {
                 // Now we should be on the day
@@ -374,7 +374,7 @@ namespace Core {
 
 
                                 // Seems like we have a valid time, let see if we need to change the timezone..
-                                SkipLeadingSpaces(buffer.c_str(), buffer.size(), index);
+                                SkipLeadingSpaces(buffer.c_str(), static_cast<uint8_t>(buffer.size()), index);
 
                                 if ((index + 2) < static_cast<uint32_t>(buffer.size())) {
                                     uint32_t value = (static_cast<uint8_t>(buffer[index + 0]) << 16) | (static_cast<uint8_t>(buffer[index + 1]) << 8) | (static_cast<uint8_t>(buffer[index + 2]) << 0);
@@ -409,7 +409,7 @@ namespace Core {
 
         if (wday != static_cast<uint8_t>(~0)) {
 
-            SkipLeadingSpaces(buffer.c_str(), buffer.size(), index);
+            SkipLeadingSpaces(buffer.c_str(), static_cast<uint8_t>(buffer.size()), index);
             if ((index + 14) <= static_cast<uint32_t>(buffer.size())) {
                 // Now we should be on the day
                 day = static_cast<uint8_t>(buffer[index] - '0');
@@ -439,7 +439,7 @@ namespace Core {
                                 (year != static_cast<uint8_t>(~0))) {
                                 bool localTime = true;
 
-                                SkipLeadingSpaces(buffer.c_str(), buffer.size(), index);
+                                SkipLeadingSpaces(buffer.c_str(), static_cast<uint8_t>(buffer.size()), index);
 
                                 if ((index + 2) < static_cast<uint32_t>(buffer.size())) {
                                     uint32_t value = (static_cast<uint8_t>(buffer[index + 0]) << 16) |
@@ -511,7 +511,7 @@ namespace Core {
                                             uint32_t length = (static_cast<uint32_t>(buffer.length() -
                                                               static_cast<size_t>((endptr - cbuffer) + 1)));
                                             miliseconds = NumberType<uint32_t>(TextFragment(&(endptr[1]), length)).Value();
-                                            length = NumberType<uint32_t>(TextFragment(&(endptr[1]), length)).Text().length();
+                                            length = static_cast<uint32_t>(NumberType<uint32_t>(TextFragment(&(endptr[1]), length)).Text().length());
                                             endptr += length + 1;
                                         } else {
                                             result = false;


### PR DESCRIPTION
Sometimes the ordering in a binary serialzed frame is LSB, sometimes it is MSB. Allow the template to
cope with both situations, the default is MSB as that was as it was used sofar.
Also sometimes we only need to work with very small frames <255 bytes. using the the uint16_t for maintaining
location and size is a bit of overkill. Maybe in the future we would like to enlarge the 64Kb boundary to
4Gb, and the variables than need to be uint32_t :-)
Make the variable sizes for creating the buffers a template parameter, again making the default equal to
what it was.