### PR TITLE
COMRPC: Complete: Request AddRef() if refcnt is at least 1 and not just 1

### DIFF
--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -331,7 +331,7 @@ namespace ProxyStub {
                 // We completed the first cycle. Clear Pending, if it was active..
                 _mode ^= CACHING_ADDREF;
 
-                if (_refCount == 1) {
+                if (_refCount >= 1) {
                     response.AddImplementation(_implementation, _interfaceId);
                 }
             }


### PR DESCRIPTION
The UnknownProxy::Complete() method, used by stubs in the implementation
side of an RPC call for methods having an interface pointer as argument,
is only requesting the caller (proxy for the method) to AddRef() the
real object representing the argument, if the method's implementation
did one, and only one AddRef() to it locally, i.e., if '_refCount' is 1.

In case the implementation does more than one AddRef() on its interface
pointer argument, then Complete() won't do the required
'response.AddImplementation(_implementation, _interfaceId)' call to
request the AddRef() on the real object in the caller side. It will
still, however and correctly, request a Release() on it once the ref
count reaches zero, but the AddRef() to balance with this Release() was
missed, so the real object will die prematurely and unexpectedly,
causing all sorts of problems (e.g. framework crashes due to
use-after-free scenarios).

The AddRef() on the real objects representing the method's arguments
should be requested by Complete() not only when the local '_refCount' is
1 (meaning the implementation did 1 and only 1 AddRef() on it), but when
'_refCount' is at least 1 (meaning the implementation did at least 1
AddRef() on it), so fix the 'if' condition accordingly.

In more detail:

The UnknownProxy::Complete() method is used by stubs in interface
methods having themselves proxy interface pointers as arguments, to
evaluate if an AddRef() should be done on the "other side", because the
invoked implementation may have itself held references on the proxy
object/argument.

This is done in every stub for methods that have interface pointers as
arguments, after having invoked the actual methods, with the following
sequence of calls (stub example for
IResourceMonitor::Configure(PluginHost::IShell*)):

    Stub Code:
     After calling the implementation (with the proxy object as
     argument), it calls 'RPC::Administrator::Instance().Release()' to
     evaluate the lifetime of the proxy object:

        // call implementation
        Exchange::IResourceMonitor* implementation = reinterpret_cast<Exchange::IResourceMonitor*>(input.Implementation());
        ASSERT((implementation != nullptr) && "Null Exchange::IResourceMonitor implementation pointer");
        const uint32_t output = implementation->Configure(param0_proxy);
        writer.Number<const uint32_t>(output);

        if (param0_proxy_inst != nullptr) {
            RPC::Administrator::Instance().Release(param0_proxy_inst, message->Response());
        }

    Administrator Code:
     Just calls proxy->Complete():

        // This Release is only called from the Stub code, once the invoke is completed...
        void Administrator::Release(ProxyStub::UnknownProxy* proxy, Data::Output& response)
        {
            proxy->Complete(response);
        }

    UnknownProxyType Code:
     Just calls the UnknownProxy::Complete():

        inline void Complete(RPC::Data::Frame::Reader& reader) const
        {
            return (_unknown.Complete(reader));
        }

    UnknownProxy Code (represented just the AddRef() related part):
     Evaluates the local ref count that the implementation left on the
     object (means how many AddRef()s it did on it), represented by
     '_refCount', to see if it needs to request an AddRef() on the real
     object (request is encapsulated in the RPC response), which is done
     by the 'response.AddImplementation()' call:

        inline void Complete(RPC::Data::Output& response)
        {
            uint32_t result = Release();

            _adminLock.Lock();

            if ((_mode & CACHING_ADDREF) != 0) {

                // We completed the first cycle. Clear Pending, if it was active..
                _mode ^= CACHING_ADDREF;

                if (_refCount == 1) {
                    response.AddImplementation(_implementation, _interfaceId);
                }
            }
            else if ((_mode & CACHING_RELEASE) != 0)  {

            [...]

        }

So, as can be seen, the AddRef() on the remote real object is only
requested if there was *only one* local AddRef(), whereas it should be
done as long as there was *at least one* AddRef().

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>