### PR TITLE
Revert "ONEM-23136 Export symbols related to module name (#857)"

### DIFF
--- a/Source/core/SystemInfo.h
+++ b/Source/core/SystemInfo.h
@@ -239,9 +239,9 @@ namespace Core {
     namespace WPEFramework {                                                                                           \
         namespace Core {                                                                                               \
             namespace System {                                                                                         \
-                EXTERNAL const char* MODULE_NAME = SOLUTIONS_GENERICS_SYSTEM_PREPROCESSOR_2(MODULE_NAME);              \
-                EXTERNAL const char* ModuleName() { return (MODULE_NAME); }                                            \
-                EXTERNAL const char* ModuleBuildRef() { return (SOLUTIONS_GENERICS_SYSTEM_PREPROCESSOR_2(buildref)); } \
+                const char* MODULE_NAME = SOLUTIONS_GENERICS_SYSTEM_PREPROCESSOR_2(MODULE_NAME);              \
+                const char* ModuleName() { return (MODULE_NAME); }                                            \
+                const char* ModuleBuildRef() { return (SOLUTIONS_GENERICS_SYSTEM_PREPROCESSOR_2(buildref)); } \
             }                                                                                                          \
         }                                                                                                              \
     }                                                                                                                  \


### PR DESCRIPTION
This reverts commit f3bb3ccdf055b3b82bbb17ea8bf04b30c9754c35.