### PR TITLE
WorkerPool: Make Submit() return bool instead of void for error handling

### DIFF
--- a/Source/core/WorkerPool.h
+++ b/Source/core/WorkerPool.h
@@ -47,13 +47,17 @@ namespace Core {
             }
 
         public:
-            void Submit()
+            bool Submit()
             {
+                bool result = false;
                 Core::ProxyType<Core::IDispatch> job(ThreadPool::JobType<IMPLEMENTATION>::Aquire());
 
                 if (job.IsValid()) {
                     Core::IWorkerPool::Instance().Submit(job);
+                    result = true;
                 }
+
+                return result;
             }
             bool Schedule(const Core::Time& time)
             {


### PR DESCRIPTION
Changing the API of IWorkerPool::JobType::Submit from

void Submit()

to

bool Submit()

so to reflect the success of the Submit operation towards ThreadPool.
Current implementation will trigger silent errors, where a failed submission
will pass unnoticed.