### PR TITLE
ThreadPool: Fix missing virtual declaration to JobType destructor

### DIFF
--- a/Source/core/ThreadPool.h
+++ b/Source/core/ThreadPool.h
@@ -85,7 +85,7 @@ namespace Core {
             #pragma warning(default: 4355)
             #endif
 
-            ~JobType()
+            virtual ~JobType()
             {
                 ASSERT (_state == IDLE);
                 _job.CompositRelease();


### PR DESCRIPTION
Adding virtual declaration to the destructor of Core::ThreadPool::JobType class.
This class serves as base class to Core::IWorkerPool::JobType, hence if one uses a pointer of the base class type, the correct destruction sequence will not be met.