### PR TITLE
[WORKERPOOL] Refactor of the workerpool to close all loopholes.

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -845,6 +845,7 @@ namespace PluginHost {
                         printf("  [P]lugins\n");
                         printf("  [C]hannels\n");
                         printf("  [S]erver stats\n");
+                        printf("  [E]lements in the ProxyPools\n");
                         printf("  [T]rigger resource monitor\n");
                         printf("  [M]etadata resource monitor\n");
                         printf("  [R]esource monitor stack\n");

--- a/Source/WPEProcess/Process.cpp
+++ b/Source/WPEProcess/Process.cpp
@@ -92,7 +92,7 @@ namespace Process {
                 }
             }
             void Destructed() override {
-                Core::ProxyType<Core::IDispatch> job(_job.Aquire());
+                Core::ProxyType<Core::IDispatch> job(_job.Submit());
 
                 if (job.IsValid() == true) {
                     _parent.Submit(job);
@@ -148,9 +148,8 @@ namespace Process {
         }
         void Stop()
         {
-            Core::WorkerPool::Shutdown();
+            Core::WorkerPool::Stop();
         }
-
 
     protected:
         void Procedure(Core::IPCChannel& channel, Core::ProxyType<Core::IIPC>& data) override

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -316,7 +316,7 @@ namespace RPC {
             _channel = Core::ProxyType<Core::IPCChannel>(channel);
             _handler = handler;
         }
-        virtual void Dispatch() override
+        void Dispatch() override
         {
             if (_message->Label() == InvokeMessage::Id()) {
                 Invoke(_channel, _message);
@@ -411,7 +411,7 @@ namespace RPC {
             }
             void Deinitialize() override {
             }
-            void Dispatch(Core::IDispatchType<void>* job) override {
+            void Dispatch(Core::IDispatch* job) override {
                 job->Dispatch();
             }
         };
@@ -422,7 +422,7 @@ namespace RPC {
 
         InvokeServerType()
             : _dispatcher()
-            , _threadPoolEngine(THREADPOOLCOUNT,STACKSIZE,MESSAGESLOTS, &_dispatcher)
+            , _threadPoolEngine(THREADPOOLCOUNT,STACKSIZE,MESSAGESLOTS, &_dispatcher, nullptr)
             , _handler(nullptr)
         {
             _threadPoolEngine.Run();
@@ -455,7 +455,7 @@ namespace RPC {
                 ASSERT(_handler != nullptr);
                 _handler->Procedure(source, message);
             } else {
-                Core::ProxyType<Job> job(Job::Instance());
+                Core::ProxyType<RPC::Job> job(Job::Instance());
 
                 job->Set(source, message, _handler);
                 _threadPoolEngine.Submit(Core::ProxyType<Core::IDispatch>(job), Core::infinite);

--- a/Source/core/SerialPort.cpp
+++ b/Source/core/SerialPort.cpp
@@ -267,11 +267,15 @@ namespace Core {
                             if (::GetOverlappedResult(port->Descriptor(), &(port->m_WriteInfo), &info, FALSE)) {
                                 port->Write(static_cast<uint16_t>(info));
                             }
+                            #ifdef __DEBUG__
                             else {
                                 DWORD result = GetLastError();
 
-                                TRACE_L1("Oopsie daisy, could not write Serial Port: Error: %s :-(", LastError(result).c_str());
+                                if (result != ERROR_IO_INCOMPLETE) {
+                                    TRACE_L1("Oopsie daisy, could not write Serial Port: Error: 0x%X => %s :-(", result, LastError(result).c_str());
+                                }
                             }
+                            #endif
                         }
                     }
 

--- a/Source/core/ThreadPool.h
+++ b/Source/core/ThreadPool.h
@@ -234,7 +234,7 @@ namespace Core {
             }
             void Revoked() {
                 state expected = REVOKING;
-                bool result = _state.compare_exchange_strong(expected, IDLE);
+                VARIABLE_IS_NOT_USED bool result = _state.compare_exchange_strong(expected, IDLE);
                 ASSERT(result == true);
             }
             operator IMPLEMENTATION& () {

--- a/Source/core/ThreadPool.h
+++ b/Source/core/ThreadPool.h
@@ -29,12 +29,22 @@ namespace Core {
 
     class EXTERNAL ThreadPool {
     public:
-        struct IDispatcher {
+        struct EXTERNAL IJob : public IDispatch {
+            ~IJob() override = default;
+
+            virtual ProxyType<IDispatch> Resubmit(Time& time) = 0;
+        };
+        struct EXTERNAL IScheduler {
+            virtual ~IScheduler() = default;
+
+            virtual void Schedule(const Time& time, const ProxyType<IDispatch>& job) = 0;
+        };
+        struct EXTERNAL IDispatcher {
             virtual ~IDispatcher() = default;
 
             virtual void Initialize() = 0;
             virtual void Deinitialize() = 0;
-            virtual void Dispatch(Core::IDispatchType<void>*) = 0;
+            virtual void Dispatch(IDispatch*) = 0;
         };
 
     private:
@@ -43,7 +53,7 @@ namespace Core {
         public:
             MeasurableJob()
                 : _job()
-                , _time(Core::NumberType<uint64_t>::Max())
+                , _time(NumberType<uint64_t>::Max())
             {
             }
 
@@ -52,12 +62,12 @@ namespace Core {
              *        time job was in queue and it's execution time.
              *        
              *        NOTE: Constructor is not marked as explicit to allow implicit
-             *        conversion from Core::ProxyType<IDispatch> to MeasurableJob in
+             *        conversion from ProxyType<IDispatch> to MeasurableJob in
              *        QueueType methods such as Post or Insert.
              */
-            MeasurableJob(const Core::ProxyType<IDispatch>& job)
+            MeasurableJob(const ProxyType<IDispatch>& job)
                 : _job(job)
-                , _time(Core::Time::Now().Ticks())
+                , _time(Time::Now().Ticks())
             {
             }
 
@@ -78,11 +88,11 @@ namespace Core {
             {
                 ASSERT(dispatcher != nullptr);
                 ASSERT(_job.IsValid());
-                ASSERT(_time != Core::NumberType<uint64_t>::Max());
+                ASSERT(_time != NumberType<uint64_t>::Max());
 
-                Core::IDispatch* request = &(*_job);
+                IDispatch* request = &(*_job);
 
-                REPORT_OUTOFBOUNDS_WARNING(WarningReporting::JobTooLongWaitingInQueue, static_cast<uint32_t>((Core::Time::Now().Ticks() - _time) / Core::Time::TicksPerMillisecond));
+                REPORT_OUTOFBOUNDS_WARNING(WarningReporting::JobTooLongWaitingInQueue, static_cast<uint32_t>((Time::Now().Ticks() - _time) / Time::TicksPerMillisecond));
                 REPORT_DURATION_WARNING({ dispatcher->Dispatch(request); }, WarningReporting::JobTooLongToFinish);
 
                 _job.Release();
@@ -94,25 +104,28 @@ namespace Core {
             }
 
         private:
-            Core::ProxyType<IDispatch> _job;
+            ProxyType<IDispatch> _job;
             uint64_t _time;
         };
-        typedef Core::QueueType< MeasurableJob > MessageQueue;
+        typedef QueueType< MeasurableJob > MessageQueue;
         #else
-        typedef Core::QueueType< Core::ProxyType<IDispatch> > MessageQueue;
+        typedef QueueType< ProxyType<IDispatch> > MessageQueue;
         #endif
 
-    public:
-        
+    public:   
         template<typename IMPLEMENTATION>
         class JobType {
         private:
             enum state : uint8_t {
                 IDLE,
-                SUBMITTED
+                SUBMITTED,
+                EXECUTING,
+                RESUBMIT,
+                SCHEDULE,
+                REVOKING
             };
 
-            class Worker : public Core::IDispatch {
+            class Worker : public IJob {
             public:
                 Worker() = delete;
                 Worker(const Worker&) = delete;
@@ -120,10 +133,12 @@ namespace Core {
 
                 Worker(JobType<IMPLEMENTATION>& parent) : _parent(parent) {
                 }
-                ~Worker() override {
-                }
+                ~Worker() override = default;
 
-            private:
+            public:
+                ProxyType<IDispatch> Resubmit(Time& time) override {
+                    return (_parent.Resubmit(time));
+                }
                 void Dispatch() override {
                     _parent.Dispatch();
                 }
@@ -144,13 +159,13 @@ namespace Core {
                 : _implementation(args...)
                 , _state(IDLE)
                 , _job(*this)
+                , _time()
             {
                 _job.AddRef();
             }
             #ifdef __WINDOWS__
             #pragma warning(default: 4355)
             #endif
-
             ~JobType()
             {
                 ASSERT (_state == IDLE);
@@ -161,23 +176,66 @@ namespace Core {
             bool IsIdle() const {
                 return (_state == IDLE);
             }
-            Core::ProxyType<Core::IDispatch> Aquire() {
+            ProxyType<IDispatch> Idle() {
 
-                state expected = IDLE;
-                Core::ProxyType<Core::IDispatch> result;
+                state idle = IDLE;
 
-                if (_state.compare_exchange_strong(expected, SUBMITTED) == true) {
-                    result = Core::ProxyType<Core::IDispatch>(Core::ProxyType<Worker>(_job));
+                ProxyType<IDispatch> result;
+
+                if (_state.compare_exchange_strong(idle, SUBMITTED) == true) {
+                    result = ProxyType<IDispatch>(ProxyType<Worker>(_job));
                 }
 
                 return (result);
             }
-            Core::ProxyType<Core::IDispatch> Reset() {
+            ProxyType<IDispatch> Submit() {
 
-                state expected = SUBMITTED;
-                _state.compare_exchange_strong(expected, IDLE);
+                state executing = EXECUTING;
+                state schedule = SCHEDULE;
+                state idle = IDLE;
 
-                return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Worker>(_job)));
+                ProxyType<IDispatch> result;
+
+                if ( (_state.compare_exchange_strong(executing, RESUBMIT)  == false) &&
+                     (_state.compare_exchange_strong(schedule,  RESUBMIT)  == false) &&
+                     (_state.compare_exchange_strong(idle,      SUBMITTED) == true ) ) {
+                    result = ProxyType<IDispatch>(ProxyType<Worker>(_job));
+                }
+
+                return (result);
+            }
+            ProxyType<IDispatch> Reschedule(const Time& time) {
+
+                state executing = EXECUTING;
+                state submitted = SUBMITTED;
+                state resubmit = RESUBMIT;
+                state idle = IDLE;
+
+                ProxyType<IDispatch> result;
+
+                if ( (_state.compare_exchange_strong(executing,   SCHEDULE) == false) &&
+                     (_state.compare_exchange_strong(resubmit,    SCHEDULE) == false) &&
+                     ( (_state.compare_exchange_strong(submitted, SCHEDULE) == true)  || 
+                       (_state.compare_exchange_strong(idle,      SCHEDULE) == true) ) ) {
+                    result = ProxyType<IDispatch>(ProxyType<Worker>(_job));
+                }
+                else {
+                    _time = time;
+                }
+
+                return (result);
+            }
+            ProxyType<IDispatch> Revoke() {
+                ProxyType<IDispatch> result;
+                if (RevokeRequired() == true) {
+                    result = ProxyType<IDispatch>(ProxyType<Worker>(_job));
+                }
+                return (result);
+            }
+            void Revoked() {
+                state expected = REVOKING;
+                bool result = _state.compare_exchange_strong(expected, IDLE);
+                ASSERT(result == true);
             }
             operator IMPLEMENTATION& () {
                 return (_implementation);
@@ -186,17 +244,49 @@ namespace Core {
                 return (_implementation);
             }
 
-        protected:
-             Core::ProxyType<Core::IDispatch> Forced() {
-                return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Worker>(_job)));
-            }
-            
-
         private:
-            void Dispatch()
-            {
+            friend class ThreadPool;
+
+            ProxyType<IDispatch> Resubmit(Time& time) {
+                ProxyType<IDispatch> result;
+                state executing = EXECUTING;
+
+                if (_state.compare_exchange_strong(executing, IDLE) == false) {
+                    state resubmit = RESUBMIT;
+                    state schedule = SCHEDULE;
+                    if (_state.compare_exchange_strong(resubmit, SUBMITTED) == true) {
+                        result = ProxyType<IDispatch>(ProxyType<Worker>(_job));
+                    }
+                    else if (_state.compare_exchange_strong(schedule, SUBMITTED) == true) {
+                        time = _time;
+                        result = ProxyType<IDispatch>(ProxyType<Worker>(_job));
+                    }
+                }
+                return (result);
+            }
+            bool RevokeRequired() {
+
+                bool result = (_state == REVOKING);
+
+                if (result == false) {
+                    state submitted = SUBMITTED;
+                    state executing = EXECUTING;
+                    state resubmit = RESUBMIT;
+                    state schedule = SCHEDULE;
+
+                    if ((_state.compare_exchange_strong(submitted, REVOKING) == true) ||
+                        (_state.compare_exchange_strong(executing, REVOKING) == true) ||
+                        (_state.compare_exchange_strong(resubmit,  REVOKING) == true) ||
+                        (_state.compare_exchange_strong(schedule,  REVOKING) == true) ) {
+                        result = true;
+                    }
+                }
+
+                return (result);
+            }
+            void Dispatch() {
                 state expected = SUBMITTED;
-                if (_state.compare_exchange_strong(expected, IDLE) == true) {
+                if (_state.compare_exchange_strong(expected, EXECUTING) == true) {
                     _implementation.Dispatch();
                 }
             }
@@ -205,6 +295,7 @@ namespace Core {
             IMPLEMENTATION _implementation;
             std::atomic<state> _state;
             ProxyObject<Worker> _job;
+            Time _time;
         };
 
         class EXTERNAL Minion {
@@ -212,9 +303,9 @@ namespace Core {
             Minion(const Minion&) = delete;
             Minion& operator=(const Minion&) = delete;
 
-            Minion(MessageQueue& queue, IDispatcher* dispatcher)
-                : _dispatcher(dispatcher)
-                , _queue(queue)
+            Minion(ThreadPool& parent, IDispatcher* dispatcher)
+                : _parent(parent)
+                , _dispatcher(dispatcher)
                 , _adminLock()
                 , _signal(false, true)
                 , _interestCount(0)
@@ -232,21 +323,20 @@ namespace Core {
             bool IsActive() const {
                 return (_currentRequest.IsValid());
             }
-            uint32_t Completed (const Core::ProxyType<Core::IDispatch>& job, const uint32_t waitTime) {
-                uint32_t result = Core::ERROR_NONE;
+            uint32_t Completed (const ProxyType<IDispatch>& job, const uint32_t waitTime) {
+                uint32_t result = ERROR_UNKNOWN_KEY;
 
                 _adminLock.Lock();
-                _interestCount++;
 
                 if (_currentRequest != job) {
                     _adminLock.Unlock();
                 }
                 else {
+                    _interestCount++;
                     _adminLock.Unlock();
                     result = _signal.Lock(waitTime);
+                    _interestCount--;
                 }
-
-                _interestCount--;
 
                 return(result);
             }
@@ -254,20 +344,28 @@ namespace Core {
             {
 		        _dispatcher->Initialize();
 
-                while (_queue.Extract(_currentRequest, Core::infinite) == true) {
+                while (_parent._queue.Extract(_currentRequest, infinite) == true) {
 
                     ASSERT(_currentRequest.IsValid() == true);
 
                     _runs++;
 
-                    
+                    IDispatch* request = &(*_currentRequest);
+
                     #ifdef __CORE_WARNING_REPORTING__
                     _currentRequest.Process(_dispatcher);
                     #else
-                    Core::IDispatch* request = &(*_currentRequest);
                     _dispatcher->Dispatch(request); 
-                    _currentRequest.Release();
                     #endif
+
+                    IJob* job = dynamic_cast<IJob*>(request);
+
+                    if (job != nullptr) {
+                        // Maybe we need to reschedule this request....
+                        _parent.Closure(*job);
+                    }
+
+                    _currentRequest.Release();
 
                     // if someone is observing this run, (WaitForCompletion) make sure that
                     // thread, sees that his object was running and is now completed.
@@ -285,39 +383,39 @@ namespace Core {
                     _adminLock.Unlock();
                 }
 
-		_dispatcher->Deinitialize();
+		        _dispatcher->Deinitialize();
             }
 
         private:
+            ThreadPool& _parent;
             IDispatcher* _dispatcher;
-            MessageQueue& _queue;
-            Core::CriticalSection _adminLock;
-            Core::Event _signal;
+            CriticalSection _adminLock;
+            Event _signal;
             std::atomic<uint32_t> _interestCount;
             #ifdef __CORE_WARNING_REPORTING__
             MeasurableJob _currentRequest;
             #else
-            Core::ProxyType<Core::IDispatch> _currentRequest;
+            ProxyType<IDispatch> _currentRequest;
             #endif
             uint32_t _runs;
         };
 
     private:
-        class EXTERNAL Executor : public Core::Thread {
+        class EXTERNAL Executor : public Thread {
         public:
             Executor() = delete;
             Executor(const Executor&) = delete;
             Executor& operator=(const Executor&) = delete;
 
-            Executor(MessageQueue& queue, IDispatcher* dispatcher, const uint32_t stackSize, const TCHAR* name)
-                : Core::Thread(stackSize == 0 ? Core::Thread::DefaultStackSize() : stackSize, name)
-                , _minion(queue, dispatcher)
+            Executor(ThreadPool& parent, IDispatcher* dispatcher, const uint32_t stackSize, const TCHAR* name)
+                : Thread(stackSize == 0 ? Thread::DefaultStackSize() : stackSize, name)
+                , _minion(parent, dispatcher)
             {
             }
             ~Executor() override
             {
                 Thread::Stop();
-                Wait(Core::Thread::STOPPED, Core::infinite);
+                Wait(Thread::STOPPED, infinite);
             }
 
         public:
@@ -328,10 +426,10 @@ namespace Core {
                 return (_minion.IsActive());
             }
             void Run () {
-                Core::Thread::Run();
+                Thread::Run();
             }
             void Stop () {
-                Core::Thread::Wait(Core::Thread::STOPPED|Core::Thread::BLOCKED, Core::infinite);
+                Thread::Wait(Thread::STOPPED|Thread::BLOCKED, infinite);
             }
             Minion& Me() {
                 return (_minion);
@@ -341,8 +439,8 @@ namespace Core {
             uint32_t Worker() override
             {
                 _minion.Process();
-                Core::Thread::Block();
-                return (Core::infinite);
+                Thread::Block();
+                return (infinite);
             }
 
         private:
@@ -353,12 +451,13 @@ namespace Core {
         ThreadPool(const ThreadPool& a_Copy) = delete;
         ThreadPool& operator=(const ThreadPool& a_RHS) = delete;
 
-        ThreadPool(const uint8_t count, const uint32_t stackSize, const uint32_t queueSize, IDispatcher* dispatcher) 
+        ThreadPool(const uint8_t count, const uint32_t stackSize, const uint32_t queueSize, IDispatcher* dispatcher, IScheduler* scheduler) 
             : _queue(queueSize)
+            , _scheduler(scheduler)
         {
             const TCHAR* name = _T("WorkerPool::Thread");
             for (uint8_t index = 0; index < count; index++) {
-                _units.emplace_back(_queue, dispatcher, stackSize, name);
+                _units.emplace_back(*this, dispatcher, stackSize, name);
             }
         }
         ~ThreadPool() {
@@ -409,9 +508,12 @@ namespace Core {
 
             return (ptr != _units.cend() ? ptr->Id() : 0);
         }
-        void Submit(const Core::ProxyType<IDispatch>& job, const uint32_t waitTime)
+        void Submit(const ProxyType<IDispatch>& job, const uint32_t waitTime)
         {
-            if (Core::Thread::ThreadId() == ResourceMonitor::Instance().Id()) {
+            ASSERT(job.IsValid() == true);
+            ASSERT(_queue.HasEntry(job) == false);
+
+            if (Thread::ThreadId() == ResourceMonitor::Instance().Id()) {
                 _queue.Post(job);
             }
             else {
@@ -419,35 +521,36 @@ namespace Core {
             }
 
         }
-        void Post(const Core::ProxyType<IDispatch>& job)
+        uint32_t Revoke(const ProxyType<IDispatch>& job, const uint32_t waitTime)
         {
-            _queue.Post(job);
-        }
-        uint32_t Revoke(const Core::ProxyType<IDispatch>& job, const uint32_t waitTime)
-        {
-            uint32_t result = Core::ERROR_NONE;
+            uint32_t result = ERROR_UNKNOWN_KEY;
 
-            _queue.Remove(job);
+            ASSERT(job.IsValid() == true);
 
-            // Check if it is currently being executed and wait till it is done.
-            std::list<Executor>::iterator index = _units.begin();
+            if (_queue.Remove(job) == true) {
+                result = ERROR_NONE;
+            }
+            else {
+                // Check if it is currently being executed and wait till it is done.
+                std::list<Executor>::iterator index = _units.begin();
 
-            while (index != _units.end()) {
-                // If we are the running job, no need to revoke ourselves, I guess we know what we are doing :-)
-                // and we would cause a deadlock if we are waiting for our selves to complete :-)
-                if (index->Id() != Core::Thread::ThreadId()) {
-                    uint32_t outcome = index->Me().Completed(job, waitTime);
-                    if (outcome != Core::ERROR_NONE) {
-                        result = outcome;
+                while ((result == ERROR_UNKNOWN_KEY) && (index != _units.end())) {
+                    // If we are the running job, no need to revoke ourselves, I guess we know what we are doing :-)
+                    // and we would cause a deadlock if we are waiting for our selves to complete :-)
+                    if (index->Id() == Thread::ThreadId()) {
+                        result = ERROR_NONE;
                     }
+                    else {
+                        uint32_t outcome = index->Me().Completed(job, waitTime);
+                        if ( (outcome == ERROR_NONE) || (outcome == ERROR_TIMEDOUT) ) {
+                            result = outcome;
+                        }
+                    }
+                    index++;
                 }
-                index++;
             }
 
             return (result);
-        }
-        MessageQueue& Queue() {
-            return (_queue);
         }
         void Run()
         {
@@ -469,8 +572,26 @@ namespace Core {
         }
 
     private:
+        void Closure(IJob& job) {
+            Time scheduleTime;
+            _queue.Lock();
+            ProxyType<IDispatch> resubmit = job.Resubmit(scheduleTime);
+            if (resubmit.IsValid() == true) {
+                if ((scheduleTime.IsValid() == false) || (_scheduler == nullptr) || (scheduleTime < Time::Now()) ) {
+                    _queue.Post(resubmit);
+                }
+                else {
+                    // See if we have a hook that can process scheduled entries :-)
+                    _scheduler->Schedule(scheduleTime, resubmit);
+                }
+            }
+            _queue.Unlock();
+        }
+
+    private:
         MessageQueue _queue;
         std::list<Executor> _units;
+        IScheduler* _scheduler;
     };
 
 }

--- a/Source/core/Time.h
+++ b/Source/core/Time.h
@@ -358,16 +358,16 @@ public:
         {
             return (static_cast<uint16_t>(time.tm_yday));
         }
-        bool IsValidDateTime(const uint16_t year, const uint8_t month, const uint8_t day, const uint8_t hour, const uint8_t minute, const uint8_t second, const uint16_t millisecond) const
-        {
-            return (IsValidDate(year, month, day) && (hour < 24) &&
-                   (minute < 60) && (second < 60) && (millisecond < 1000));
-        }
-
-        bool IsValidDate(const uint16_t year, const uint8_t month, const uint8_t day) const;
         struct tm TMHandle() const;
 
 #endif
+        bool IsValidDateTime(const uint16_t year, const uint8_t month, const uint8_t day, const uint8_t hour, const uint8_t minute, const uint8_t second, const uint16_t millisecond) const
+        {
+            return (IsValidDate(year, month, day) && (hour < 24) &&
+                (minute < 60) && (second < 60) && (millisecond < 1000));
+        }
+
+        bool IsValidDate(const uint16_t year, const uint8_t month, const uint8_t day) const;
 
         Time ToLocal() const;
         Time ToUTC() const;

--- a/Source/core/core.vcxproj
+++ b/Source/core/core.vcxproj
@@ -85,6 +85,7 @@
     <ClInclude Include="TextFragment.h" />
     <ClInclude Include="TextReader.h" />
     <ClInclude Include="Thread.h" />
+    <ClInclude Include="ThreadPool.h" />
     <ClInclude Include="Time.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="Trace.h" />

--- a/Source/core/core.vcxproj.filters
+++ b/Source/core/core.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClInclude Include="CallsignTLS.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ThreadPool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CyclicBuffer.cpp">

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -109,6 +109,9 @@ namespace PluginHost {
         public:
             static Core::ProxyType<Core::IDispatch> Create(IShell* shell, IShell::state toState, IShell::reason why);
 
+            //
+            // Core::IDispatch implementation
+            // -------------------------------------------------------------------------------
             void Dispatch() override
             {
                 ASSERT(_shell != nullptr);

--- a/Source/plugins/VirtualInput.h
+++ b/Source/plugins/VirtualInput.h
@@ -40,12 +40,11 @@ namespace PluginHost {
         };
 
         class RepeatKeyTimer : public Core::IDispatch {
-        private:
+        public:
             RepeatKeyTimer() = delete;
             RepeatKeyTimer(const RepeatKeyTimer&) = delete;
             RepeatKeyTimer& operator=(const RepeatKeyTimer&) = delete;
 
-        public:
 #ifdef __WINDOWS__
 #pragma warning(disable : 4355)
 #endif
@@ -62,9 +61,7 @@ namespace PluginHost {
 #ifdef __WINDOWS__
 #pragma warning(default : 4355)
 #endif
-            ~RepeatKeyTimer() override
-            {
-            }
+            ~RepeatKeyTimer() override = default;
 
         public:
             void AddReference()

--- a/Source/tracing/TraceControl.h
+++ b/Source/tracing/TraceControl.h
@@ -31,6 +31,9 @@
 // ---- Referenced classes and types ----
 
 // ---- Helper types and constants ----
+#define TRACE_ENABLED(CATEGORY)                                                         \
+    WPEFramework::Trace::TraceType<CATEGORY, &WPEFramework::Core::System::MODULE_NAME>::IsEnabled()
+
 #define TRACE(CATEGORY, PARAMETERS)                                                    \
     if (WPEFramework::Trace::TraceType<CATEGORY, &WPEFramework::Core::System::MODULE_NAME>::IsEnabled() == true) { \
         CATEGORY __data__ PARAMETERS;                                                  \


### PR DESCRIPTION
The current implementation of the Workerpool does allow for a Job to be running on
multiple threads of the workerpool. Thuis is due to the fact that in the current
implementation the Job can be resubmitted once it is started.
This means that if a job is running, during this time the Job can be scheduled
for execution again. Which means that the job could already start/run on another
thread while the first instance is still running.

This is conceptually not correct and might potentially cause starvation of the
threadpool (what if the job never ends due to a bug or takes very ong to execute
and gets submitted in a short tiem frame periodically).

To prevent this starvation, the job now has a more eleborated states. See:
core/ThreadPool.h class JobType::state.