### PR TITLE
CyclicBuffer: Updates

### DIFF
--- a/Source/core/CyclicBuffer.h
+++ b/Source/core/CyclicBuffer.h
@@ -175,7 +175,7 @@ namespace Core {
         }
         inline bool IsValid() const
         {
-            return (_buffer.IsValid() && (_administration != nullptr));
+            return (_administration != nullptr);
         }
         inline const File& Storage() const
         {

--- a/Source/core/CyclicBuffer.h
+++ b/Source/core/CyclicBuffer.h
@@ -175,7 +175,7 @@ namespace Core {
         }
         inline bool IsValid() const
         {
-            return (_buffer.IsValid());
+            return (_buffer.IsValid() && (_administration != nullptr));
         }
         inline const File& Storage() const
         {
@@ -252,7 +252,7 @@ namespace Core {
         void AdminLock();
         void AdminUnlock();
         void Reevaluate();
-        uint32_t SignalLock(const uint32_t waitTime);
+        uint32_t SignalLock(uint32_t& waitTime);
 
     private:
         enum state {


### PR DESCRIPTION
1. Allow write if the requested size is less than free size, to avoid infinite loop
2. Updated AssureFreeSpace logic to avoid inifinite looping with free and required with same size condition
3. Set/Reset Overwritten flag once freeing the space for write (in overwrite enabled mode)
4. Add assert if buffer create with readonly mode
5. Check _administrator pointer also for buffer validity
6. Lock deadlock issue fixes