### PR TITLE
[SerialPort] Start off with valid default port settings

### DIFF
--- a/Source/core/SerialPort.cpp
+++ b/Source/core/SerialPort.cpp
@@ -320,6 +320,11 @@ namespace Core {
         , _sendOffset(0)
         , _sendBytes(0)
         , _descriptor(INVALID_HANDLE_VALUE)
+        , _baudRate(BAUDRATE_57600)
+        , _parity(NONE)
+        , _dataBits(BITS_8)
+        , _stopBits(BITS_1)
+        , _flowControl(OFF)
     {
         Construct(DefaultSendBuffer, DefaultReceiveBuffer);
     }
@@ -335,6 +340,11 @@ namespace Core {
         , _sendOffset(0)
         , _sendBytes(0)
         , _descriptor(INVALID_HANDLE_VALUE)
+        , _baudRate(BAUDRATE_57600)
+        , _parity(NONE)
+        , _dataBits(BITS_8)
+        , _stopBits(BITS_1)
+        , _flowControl(OFF)
     {
         Construct(DefaultSendBuffer, DefaultReceiveBuffer);
     }
@@ -358,6 +368,11 @@ namespace Core {
         , _sendOffset(0)
         , _sendBytes(0)
         , _descriptor(INVALID_HANDLE_VALUE)
+        , _baudRate(BAUDRATE_57600)
+        , _parity(NONE)
+        , _dataBits(BITS_8)
+        , _stopBits(BITS_1)
+        , _flowControl(OFF)
     {
         Construct(sendBufferSize, receiveBufferSize);
         Configuration(port, baudRate, parity, dataBits, stopBits, flowControl);

--- a/Source/core/SerialPort.h
+++ b/Source/core/SerialPort.h
@@ -311,7 +311,6 @@ namespace Core {
         uint8_t* _sendBuffer;
         uint8_t* _receiveBuffer;
         uint16_t _readBytes;
-        uint16_t _WriteBytes;
         uint16_t _sendOffset;
         uint16_t _sendBytes;
 


### PR DESCRIPTION
... otherwise calling tcsetattr with some random values (even if called again shortly afterwards with valid settings) seems breaking the serial port on Linux and/or Rbpi (... and prevent bluetooth setup too! :)