### PR TITLE
[CONNECTOR] Move the connector library functionality into existing co…

### DIFF
--- a/Source/WPEFramework/CMakeLists.txt
+++ b/Source/WPEFramework/CMakeLists.txt
@@ -60,7 +60,6 @@ target_link_libraries(${TARGET}
           ${NAMESPACE}COMProcess::${NAMESPACE}COMProcess  # For COM executable define
           ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket
           ${NAMESPACE}COM::${NAMESPACE}COM
-          ${NAMESPACE}Connector::${NAMESPACE}Connector
         )
         
 if (PROCESSCONTAINERS)

--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -19,7 +19,6 @@
 
 #include "Controller.h"
 #include "SystemInfo.h"
-#include "connector/Connector.h"
 
 namespace WPEFramework {
 
@@ -72,7 +71,7 @@ namespace Plugin {
         _resumes.clear();
         _service = service;
         
-        connector_announce(service);
+        RPC::ConnectorController::Instance().Announce(service);
         
         _skipURL = static_cast<uint8_t>(_service->WebPrefix().length());
 
@@ -114,8 +113,6 @@ namespace Plugin {
     {
         ASSERT(_service == service);
 
-        connector_revoke(service);
-
         // Detach the SubSystems, we are shutting down..
         PluginHost::ISubSystem* subSystems(_service->SubSystems());
 
@@ -135,6 +132,8 @@ namespace Plugin {
 
         /* stop the file serving over http.... */
         service->DisableWebServer();
+
+        RPC::ConnectorController::Instance().Revoke(service);
     }
 
     /* virtual */ string Controller::Information() const

--- a/Source/com/ConnectorType.cpp
+++ b/Source/com/ConnectorType.cpp
@@ -108,5 +108,13 @@ Core::ProxyType<RPC::IIPCServer> WorkerPoolInvokeServer()
     return Core::ProxyType<RPC::IIPCServer>(Core::SingletonProxyType<Engine>::Instance(&Core::IWorkerPool::Instance()));
 };
 
+ConnectorController::ConnectorController() : _controller(nullptr) {
+}
+
+ConnectorController::~ConnectorController() {
+    ASSERT(_controller == nullptr);
+}
+
+/* static */ ConnectorController ConnectorController::_instance;
 
 } } 

--- a/Source/plugins/Types.h
+++ b/Source/plugins/Types.h
@@ -22,7 +22,6 @@
 
 #include "IPlugin.h"
 #include "IShell.h"
-#include "connector/Connector.h"
 
 namespace WPEFramework {
 namespace PluginHost {
@@ -269,9 +268,15 @@ namespace RPC {
         }
         uint32_t Open(const uint32_t waitTime, const Core::NodeId& node, const string& callsign)
         {
+            Core::IUnknown* controller = RPC::ConnectorController::Instance().Controller();
+
             ASSERT(_controller == nullptr);
 
-            _controller = connector_controller();
+            if (controller != nullptr) {
+                // Seems like we already have a connection to the IShell of the Controller plugin, reuse it.
+                _controller = controller->QueryInterface<PluginHost::IShell>();
+                controller->Release();
+            }
             if (_controller == nullptr) {
                 _controller = _administrator.template Aquire<PluginHost::IShell>(waitTime, node, _T(""), ~0);
             }


### PR DESCRIPTION
…m library.

This allows for less dependencies and build issues, also the COM library is already included
in the convenience libraries. Now with the COnnector part of COM there is no need for an
additional dependency in the convenience libraries.