### PR TITLE
DELIA-54331: Don't set the receive buffer

### DIFF
--- a/Source/plugins/Channel.cpp
+++ b/Source/plugins/Channel.cpp
@@ -28,7 +28,7 @@ namespace PluginHost {
 #pragma warning(disable : 4355)
 #endif
     Channel::Channel(const SOCKET& connector, const Core::NodeId& remoteId)
-        : BaseClass(true, false, 5, _requestAllocator, false, connector, remoteId, 1024, 1024)
+        : BaseClass(true, false, 5, _requestAllocator, false, connector, remoteId, 1024, -1)
         , _adminLock()
         , _ID(0)
         , _nameOffset(~0)

--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -132,7 +132,7 @@ namespace JSONRPC {
     
             public:
                 ChannelImpl(CommunicationChannel* parent, const Core::NodeId& remoteNode, const string& callsign, const string& query)
-                    : BaseClass(5, FactoryImpl::Instance(), callsign, _T("JSON"), query, "", false, false, false, remoteNode.AnyInterface(), remoteNode, 256, 256)
+                    : BaseClass(5, FactoryImpl::Instance(), callsign, _T("JSON"), query, "", false, false, false, remoteNode.AnyInterface(), remoteNode, 256, -1)
                     , _parent(*parent)
                 {
                 }


### PR DESCRIPTION
Reason for change: TCP delays caused by the receive buffer
set after connect/accept to a value less than the localhost
MSS and the TCP window advertised on connect/accept.
Test Procedure: Check performance.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>