### PR TITLE
[CyclicBuffer] Refactor read method, check on tail position after writing

### DIFF
--- a/Source/core/CyclicBuffer.cpp
+++ b/Source/core/CyclicBuffer.cpp
@@ -284,67 +284,78 @@ namespace Core {
         ASSERT(IsValid() == true);
 
         bool foundData = false;
+        uint32_t result = 0;
+        uint32_t oldTail = 0;
+        uint32_t head = 0;
+        uint32_t offset = 0;
 
-        uint32_t result;
         while (!foundData) {
-            uint32_t oldTail = _administration->_tail;
-            uint32_t head = _administration->_head;
-            uint32_t offset = oldTail & _administration->_tailIndexMask;
+            oldTail = _administration->_tail;
+            head = _administration->_head;
+            offset = oldTail & _administration->_tailIndexMask;
 
             result = Used(head, offset);
             if (result == 0) {
-                // No data, just return 0.
-                return 0;
+                //no data, no need in trying reading
+                break;
             }
 
             Cursor cursor(*this, oldTail, length);
             result = GetReadSize(cursor);
 
-            if ((result == 0) || ((result > length) && (partialRead == false))) {
-                // No data, or too much, return 0.
-                return 0;
-            }
-
-            uint32_t bufferLength = std::min(length, result);
-
-            foundData = true;
-            offset += cursor.Offset();
-            uint32_t roundCount = oldTail / (1 + _administration->_tailIndexMask);
-            if ((offset + result) < _administration->_size) {
-                memcpy(buffer, _realBuffer + offset, bufferLength);
-
-                uint32_t newTail = offset + result + roundCount * (1 + _administration->_tailIndexMask);
-                if (!_administration->_tail.compare_exchange_weak(oldTail, newTail)) {
-                    foundData = false;
-                }
+            //data was found if result is greater than 0 and the tail was not moved by the writer.
+            //If it was moved, the package size could have been overwritten
+            //by random data and can be invalid - we cannot trust it
+            if ((result == 0) || (oldTail != _administration->_tail)) {
+                foundData = false;
             } else {
-                uint32_t part1 = 0;
-                uint32_t part2 = 0;
-                
-                if(_administration->_size < offset){
-                    part2 = result - (offset - _administration->_size);
-                }
-                else {
-                    part1 = _administration->_size - offset;
-                    part2 = result - part1;
-                }
+                foundData = true;
 
-                memcpy(buffer, _realBuffer + offset, std::min(part1, bufferLength));
+                ASSERT(result != 0);
+                ASSERT((result <= length) || ((result > length) && (partialRead == true)));
 
-                if(part1 < bufferLength){
-                    memcpy(buffer + part1, _realBuffer, bufferLength - part1);
-                }
+                //if does not allow partial read, we found a data, but it is too small to fit
+                if ((result <= length) || ((result > length) && (partialRead == true))) {
+                    uint32_t bufferLength = std::min(length, result);
 
-                // Add one round, but prevent overflow.
-                roundCount = (roundCount + 1) % _administration->_roundCountModulo;
-                uint32_t newTail = part2 + roundCount * (1 + _administration->_tailIndexMask);
-                if (!_administration->_tail.compare_exchange_weak(oldTail, newTail)) {
-                    foundData = false;
+                    offset += cursor.Offset();
+                    uint32_t roundCount = oldTail / (1 + _administration->_tailIndexMask);
+                    if ((offset + result) < _administration->_size) {
+                        memcpy(buffer, _realBuffer + offset, bufferLength);
+
+                        uint32_t newTail = offset + result + roundCount * (1 + _administration->_tailIndexMask);
+                        if (!_administration->_tail.compare_exchange_weak(oldTail, newTail)) {
+                            foundData = false;
+                        }
+                    } else {
+                        uint32_t part1 = 0;
+                        uint32_t part2 = 0;
+
+                        if (_administration->_size < offset) {
+                            part2 = result - (offset - _administration->_size);
+                        } else {
+                            part1 = _administration->_size - offset;
+                            part2 = result - part1;
+                        }
+
+                        memcpy(buffer, _realBuffer + offset, std::min(part1, bufferLength));
+
+                        if (part1 < bufferLength) {
+                            memcpy(buffer + part1, _realBuffer, bufferLength - part1);
+                        }
+
+                        // Add one round, but prevent overflow.
+                        roundCount = (roundCount + 1) % _administration->_roundCountModulo;
+                        uint32_t newTail = part2 + roundCount * (1 + _administration->_tailIndexMask);
+                        if (!_administration->_tail.compare_exchange_weak(oldTail, newTail)) {
+                            foundData = false;
+                        }
+                    }
                 }
             }
         }
 
-        return (result);
+         return (result);
     }
 
     uint32_t CyclicBuffer::Write(const uint8_t buffer[], const uint32_t length)


### PR DESCRIPTION
To avoid the reader not receiving the DataAvailable notification, after writing, a check on the tail position is performed. If the tail has moved during write, and the buffer is not empty (and the previous tail position indicated it is empty), a DataAvailable call is performed. 