### PR TITLE
RDKTV-15395: Dobby processcontainer improvements

### DIFF
--- a/Source/processcontainers/CMakeLists.txt
+++ b/Source/processcontainers/CMakeLists.txt
@@ -106,37 +106,9 @@ elseif (PROCESSCONTAINERS_CRUN)
 elseif (PROCESSCONTAINERS_DOBBY)
         find_package(Dobby REQUIRED CONFIG)
 
-        # We need libsystemd since we're using their dbus library (sd-bus)
-        # There's probably a better way of doing this...
-        find_path(SYSTEMD_INCLUDE_DIRS
-                NAMES systemd/sd-bus.h
-        )
-
-        find_library(SYSTEMD_LIBRARIES
-                NAMES systemd
-        )
-
-        add_definitions( -DRDK )
-
-        include(FindPackageHandleStandardArgs)
-        find_package_handle_standard_args(
-                LIBSYSTEMD
-                SYSTEMD_LIBRARIES SYSTEMD_INCLUDE_DIRS
-        )
         target_link_libraries(${TARGET}
                 PRIVATE
-                # Dobby libraries
                 DobbyClientLib
-                IpcService
-                AppInfraCommon
-                AppInfraLogging
-
-                ${SYSTEMD_LIBRARIES}
-                )
-
-        target_include_directories( ${TARGET}
-                PRIVATE
-                ${JSONCPP_INCLUDE_DIRS}
         )
 elseif (PROCESSCONTAINERS_AWC)
         find_package(LXC REQUIRED)

--- a/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
+++ b/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
@@ -42,10 +42,10 @@ namespace ProcessContainers {
             auto path = searchpaths.Current();
 
             Core::File configFile(path + "/Container" + CONFIG_NAME);
-            TRACE_L1("searching %s container at %s", id.c_str(), configFile.Name().c_str());
+            TRACE(ProcessContainers::ProcessContainerization, (_T("searching %s container at %s"), id.c_str(), configFile.Name().c_str()));
 
             if (configFile.Exists()) {
-                TRACE_L1("Found %s container!", id.c_str());
+                TRACE(ProcessContainers::ProcessContainerization, (_T("Found %s container!"), id.c_str()));
                 // Make sure no leftover will interfere...
                 if (ContainerNameTaken(id)) {
                     DestroyContainer(id);
@@ -59,7 +59,7 @@ namespace ProcessContainers {
             }
         }
 
-        TRACE_L1("Could not find suitable container config for %s in any search path", id.c_str());
+        TRACE(Trace::Error, (_T("Could not find suitable container config for %s in any search path"), id.c_str()));
 
         return nullptr;
     }
@@ -70,7 +70,7 @@ namespace ProcessContainers {
         mIpcService = AI_IPC::createIpcService("unix:path=/var/run/dbus/system_bus_socket", "org.rdk.dobby.processcontainers");
 
         if (!mIpcService) {
-            TRACE_L1("Failed to create IPC service");
+            TRACE(Trace::Error, (_T("Failed to create Dobby IPC service")));
             return;
         } else {
             // Start the IPCService which kicks off the event dispatcher thread
@@ -101,7 +101,7 @@ namespace ProcessContainers {
             for (const std::pair<int32_t, std::string>& c : runningContainers) {
                 if (c.second == name) {
                     // found the container, now try stopping it...
-                    TRACE_L1("destroying container: %s ", name.c_str());
+                    TRACE(ProcessContainers::ProcessContainerization, (_T("destroying container: %s "), name.c_str()));
 
                     // Dobby stop is async - block until we get the notification the container
                     // has actually stopped
@@ -118,12 +118,13 @@ namespace ProcessContainers {
                     std::future<void> future = _stopPromise.get_future();
                     bool stoppedSuccessfully = mDobbyProxy->stopContainer(c.first, true);
                     if (!stoppedSuccessfully) {
-                        TRACE_L1("Failed to destroy container, internal Dobby error. id: %s descriptor: %d", name.c_str(), c.first);
+                        TRACE(Trace::Warning, (_T("Failed to destroy container, internal Dobby error. id: %s descriptor: %d"), name.c_str(), c.first));
                     }
                     else
                     {
                         // Block here until container has stopped
                         future.wait();
+                        TRACE(ProcessContainers::ProcessContainerization, (_T("Container %s has stopped"), name.c_str()));
                     }
 
                     this->InternalUnlock();
@@ -149,7 +150,7 @@ namespace ProcessContainers {
         if (!runningContainers.empty()) {
             for (const std::pair<int32_t, std::string>& c : runningContainers) {
                 if (c.second == name) {
-                    TRACE_L1("container %s already running...", name.c_str());
+                    TRACE(ProcessContainers::ProcessContainerization, (_T("container %s already running..."), name.c_str()));
                     result = true;
                     break;
                 }
@@ -167,7 +168,6 @@ namespace ProcessContainers {
 
         // Interested in stop events only
         if (state == IDobbyProxyEvents::ContainerState::Stopped && containerId == *id) {
-            TRACE_L1("Container %s has stopped", containerId.c_str());
             this->InternalLock();
             _stopPromise.set_value();
             this->InternalUnlock();
@@ -211,13 +211,13 @@ namespace ProcessContainers {
             std::string containerInfoString = admin.mDobbyProxy->getContainerInfo(_descriptor);
 
             if (containerInfoString.empty()) {
-                TRACE_L1("Failed to get info for container %s", _name.c_str());
+                TRACE(Trace::Warning, (_T("Failed to get info for container %s"), _name.c_str()));
             } else {
                 // Dobby returns the container info as JSON, so parse it
                 JsonObject containerInfoJson;
                 WPEFramework::Core::OptionalType<WPEFramework::Core::JSON::Error> error;
                 if (!WPEFramework::Core::JSON::IElement::FromString(containerInfoString, containerInfoJson, error)) {
-                    TRACE_L1("Failed to parse Dobby Spec JSON due to: %s", WPEFramework::Core::JSON::ErrorDisplayMessage(error).c_str());
+                    TRACE(Trace::Warning, (_T("Failed to parse Dobby container info JSON due to: %s"), WPEFramework::Core::JSON::ErrorDisplayMessage(error).c_str()));
                 } else {
                     JsonArray pids = containerInfoJson["pids"].Array();
 
@@ -334,10 +334,10 @@ namespace ProcessContainers {
 
         // startContainer returns -1 on failure
         if (_descriptor <= 0) {
-            TRACE_L1("Failed to start container - internal Dobby error.");
+            TRACE(Trace::Error, (_T("Failed to start container %s - internal Dobby error."), _name.c_str()));
             result = false;
         } else {
-            TRACE_L1("started %s container! descriptor: %d", _name.c_str(), _descriptor);
+            TRACE(ProcessContainers::ProcessContainerization, (_T("started %s container! descriptor: %d"), _name.c_str(), _descriptor));
             result = true;
         }
         return result;
@@ -352,7 +352,7 @@ namespace ProcessContainers {
         bool stoppedSuccessfully = admin.mDobbyProxy->stopContainer(_descriptor, false);
 
         if (!stoppedSuccessfully) {
-            TRACE_L1("Failed to stop container, internal Dobby error. id: %s descriptor: %d", _name.c_str(), _descriptor);
+            TRACE(Trace::Error, (_T("Failed to stop container, internal Dobby error. id: %s descriptor: %d"), _name.c_str(), _descriptor));
         } else {
             result = true;
         }

--- a/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
+++ b/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
@@ -26,8 +26,10 @@
 #include "processcontainers/common/Lockable.h"
 #include "processcontainers/common/NetworkInfoUnimplemented.h"
 
-#include <Dobby/Public/Dobby/IDobbyProxy.h>
 #include <Dobby/DobbyProtocol.h>
+#include <Dobby/Public/Dobby/IDobbyProxy.h>
+
+#include <future>
 
 namespace WPEFramework {
 namespace ProcessContainers {
@@ -59,7 +61,7 @@ namespace ProcessContainers {
         string _name;
         string _path;
         string _logPath;
-        int    _descriptor;
+        int _descriptor;
         mutable Core::OptionalType<uint32_t> _pid;
     };
 
@@ -71,7 +73,6 @@ namespace ProcessContainers {
         DobbyContainerAdministrator();
         DobbyContainerAdministrator(const DobbyContainerAdministrator&) = delete;
         DobbyContainerAdministrator& operator=(const DobbyContainerAdministrator&) = delete;
-
 
         std::shared_ptr<AI_IPC::IIpcService> mIpcService; // Ipc Service instance
         std::shared_ptr<IDobbyProxy> mDobbyProxy; // DobbyProxy instance
@@ -87,9 +88,14 @@ namespace ProcessContainers {
         void Logging(const string& logDir, const string& loggingOptions) override;
 
     protected:
-
         void DestroyContainer(const string& name); // make sure that no leftovers from previous launch will cause crash
         bool ContainerNameTaken(const string& name);
+        void containerStopCallback(int32_t cd, const std::string& containerId,
+            IDobbyProxyEvents::ContainerState state,
+            const void* params);
+
+    private:
+        std::promise<void> _stopPromise;
     };
 }
 }

--- a/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
+++ b/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
@@ -26,6 +26,8 @@
 #include "processcontainers/common/Lockable.h"
 #include "processcontainers/common/NetworkInfoUnimplemented.h"
 
+#include "Tracing.h"
+
 #include <Dobby/DobbyProtocol.h>
 #include <Dobby/Public/Dobby/IDobbyProxy.h>
 


### PR DESCRIPTION
When stopping a container that is already running, Thunder should block until the container has stopped. 

The Dobby stop command is async, so wait for the container stop event from Dobby.

Also take the opportunity to move from TRACE_L1 to TRACE logging and clean up the CMakeLists.txt file