### PR TITLE
RDKTV-15442, RDKTV-15390, DELIA-55298 : WPEFramework Crash in Core::ResourceMonitorType

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1124,6 +1124,7 @@ namespace Core {
             result = false;
         } else {
             DestroySocket(m_Socket);
+	    ResourceMonitor::Instance().Unregister(*this);
             // Remove socket descriptor for UNIX domain datagram socket.
             if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) && 
                 ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM)) &&


### PR DESCRIPTION
Reason for change: Call ResourceMonitor::Unregister explicitly during the socket close/destruction sequence
Test Procedure: mentioned in the ticket.
Risks: None
Signed-off-by: Neeraj Sahu Neeraj_Sahu@comcast.com