### PR TITLE
[METROL-523]: Block Controller from serving too many files

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -606,7 +606,7 @@ namespace PluginHost {
                     result = _unavailableHandler;
                 } else if (IsWebServerRequest(request.Path) == true) {
                     result = IFactories::Instance().Response();
-                    FileToServe(request.Path, *result);
+                    FileToServe(request.Path, *result, false);
                 } else if (request.Verb == Web::Request::HTTP_OPTIONS) {
 
                     result = IFactories::Instance().Response();

--- a/Source/plugins/Service.cpp
+++ b/Source/plugins/Service.cpp
@@ -86,9 +86,8 @@ namespace PluginHost {
     }
 #endif
 
-    void Service::FileToServe(const string& webServiceRequest, Web::Response& response)
+    void Service::FileToServe(const string& webServiceRequest, Web::Response& response, bool allowUnsafePath)
     {
-        bool safePath = true;
         Web::MIMETypes result;
         Web::EncodingTypes encoding = Web::ENCODING_UNKNOWN;
         uint16_t offset = static_cast<uint16_t>(_config.WebPrefix().length()) + (_webURLPath.empty() ? 1 : static_cast<uint16_t>(_webURLPath.length()) + 2);
@@ -102,9 +101,10 @@ namespace PluginHost {
             response.Body<Web::FileBody>(fileBody);
         } else {
             ASSERT(fileToService.length() >= _webServerFilePath.length());
+            bool safePath = true;
             string normalizedPath = Core::File::Normalize(fileToService.substr(_webServerFilePath.length()), safePath);
 
-            if (safePath){
+            if (allowUnsafePath || safePath ) {
                 Core::ProxyType<Web::FileBody> fileBody(IFactories::Instance().FileBody());
                 *fileBody = fileToService;
                 response.ContentType = result;

--- a/Source/plugins/Service.h
+++ b/Source/plugins/Service.h
@@ -409,7 +409,7 @@ namespace PluginHost {
         }
         #endif
 
-        void FileToServe(const string& webServiceRequest, Web::Response& response);
+        void FileToServe(const string& webServiceRequest, Web::Response& response, bool allowUnsafePath);
 
     private:
         mutable Core::CriticalSection _adminLock;


### PR DESCRIPTION
Before serving the file we are normalizing the file to
webserver file path to avoid serving file beyond the
configured path.