### PR TITLE
XIONE-8644 : [Rack][Xione UK][CUSTOM Test] : AV struck in blue screen…

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3198,13 +3198,7 @@ namespace Core {
 
             void Reset()
             {
-                JSONElementList::const_iterator index = _data.begin();
-
-                // As long as we did not find a set element, continue..
-                while (index != _data.end()) {
-                    index->second->Clear();
-                    index = _data.erase(index);
-                }
+                _data.clear();
             }
 
             void Add(const TCHAR label[], IElement* element)
@@ -4182,6 +4176,7 @@ namespace Core {
             void Clear()
             {
                 Reset();
+                _elements.clear();
             }
             string GetDebugString(int indent = 0) const;
 


### PR DESCRIPTION
… during continuos channel changes

Reason for change: Map wasn't clear correctly. It clear resource but doesn't clear itself. Now it correclty dealocate nodes and clear.
Test Procedure: Test if ThunderCall work properly and response is parsed
correclty
Risks: MID

Signed-off-by: mateusz.adamski <mateusz.adamski2@sky.uk>