### PR TITLE
RDKTV-15803 : WPEFramework crash at signature malloc_printerr

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -376,6 +376,7 @@ namespace Core {
         ASSERT(m_Socket == INVALID_SOCKET);
 
         ::free(m_SendBuffer);
+	m_SendBuffer = nullptr;
     }
 
     //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reason for change: Setting unused pointer to null
Test Procedure: mentioned in the ticket.
Risks: None
Signed-off-by: Neeraj Sahu Neeraj_Sahu@comcast.com