### PR TITLE
RDKTV-17127 : WPEFramework crash at std::terminate

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -183,8 +183,11 @@ namespace PluginHost {
         virtual uint32_t Worker() override
         {
 	    _adminLock.Lock();
-            CloseDown(_destructor);
+	    PluginHost::Server* destructor = _destructor;
+	    _destructor = nullptr;
 	    _adminLock.Unlock();
+		
+            CloseDown(destructor);
             Block();
             return (Core::infinite);
         }

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -182,7 +182,9 @@ namespace PluginHost {
     private:
         virtual uint32_t Worker() override
         {
+	    _adminLock.Lock();
             CloseDown(_destructor);
+	    _adminLock.Unlock();
             Block();
             return (Core::infinite);
         }
@@ -198,11 +200,18 @@ namespace PluginHost {
                 fflush(stderr);
             }
 
-            destructor->Close();
-            delete destructor;
-            delete _config;
-            _config = nullptr;
+	    if(destructor != nullptr)
+	    {
+            	destructor->Close();
+		delete destructor;
+		destructor = nullptr;
+	    }
 
+	    if(_config != nullptr)
+	    {
+            	delete _config;
+		_config = nullptr;
+	    }
 
 #ifndef __WINDOWS__
             closelog();

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -198,11 +198,18 @@ namespace PluginHost {
                 fflush(stderr);
             }
 
-            destructor->Close();
-            delete destructor;
-            delete _config;
-            _config = nullptr;
+	    if(destructor != nullptr)
+	    {
+            	destructor->Close();
+		delete destructor;
+		destructor = nullptr;
+	    }
 
+	    if(_config != nullptr)
+	    {
+            	delete _config;
+		_config = nullptr;
+	    }
 
 #ifndef __WINDOWS__
             closelog();


### PR DESCRIPTION
Reason for change: Setting unused pointer to null
Test Procedure: mentioned in the ticket.
Risks: None
Signed-off-by: Neeraj Sahu Neeraj_Sahu@comcast.com