### PR TITLE
Changed WorkerPool release() order in ~ProcessFlow().  Now the _engine (WorkerPool) is released after resetting the global instance. 

### DIFF
--- a/Source/WPEProcess/Process.cpp
+++ b/Source/WPEProcess/Process.cpp
@@ -434,13 +434,13 @@ public:
             _server.Release();
         }
 
-        if (_engine.IsValid() == true) {
-            _engine.Release();
-        }
-
         // We are going to tear down the stugg. Unregistere the Worker Pool
         Core::IWorkerPool::Assign(nullptr);
         PluginHost::IFactories::Assign(nullptr);
+
+        if (_engine.IsValid() == true) {
+            _engine.Release();
+        }
 
         Core::Singleton::Dispose();
         std::set_terminate(nullptr);


### PR DESCRIPTION
… singleton instance to nullptr