### PR TITLE
[VERSIONING] Resolve a conflicting virtual name usage.

### DIFF
--- a/Source/core/Services.cpp
+++ b/Source/core/Services.cpp
@@ -65,7 +65,7 @@ namespace Core {
         ServiceList::iterator index = _services.begin();
 
         while ((index != _services.end()) && (found == false)) {
-            const char* thisName = index->first->Name().c_str();
+            const char* thisName = index->first->ServiceName().c_str();
             found = ((strcmp(thisName, name) == 0) && ((version == static_cast<uint32_t>(~0)) || (version == ((index->first->Major() << 8) | index->first->Minor()))));
 
             if (found == false) {

--- a/Source/core/Services.h
+++ b/Source/core/Services.h
@@ -40,7 +40,7 @@ namespace Core {
     struct EXTERNAL IServiceMetadata {
         virtual ~IServiceMetadata() = default;
 
-        virtual const std::string& Name() const = 0;
+        virtual const std::string& ServiceName() const = 0;
         virtual const TCHAR* Module() const = 0;
         virtual uint8_t Major() const = 0;
         virtual uint8_t Minor() const = 0;
@@ -266,8 +266,8 @@ namespace Core {
             uint8_t Patch() const override {
                 return (_info->Patch());
             }
-            const std::string& Name() const override {
-                return (_info->Name());
+            const std::string& ServiceName() const override {
+                return (_info->ServiceName());
             }
             const TCHAR* Module() const override {
                 return (_info->Module());
@@ -300,7 +300,7 @@ namespace Core {
         uint8_t Patch() const override {
             return (static_cast<uint8_t>(_version & 0xFF));
         }
-        const std::string& Name() const override
+        const std::string& ServiceName() const override
         {
             return (_Id);
         }

--- a/Source/plugins/MetaData.h
+++ b/Source/plugins/MetaData.h
@@ -276,8 +276,8 @@ namespace Plugin {
             uint8_t Patch() const override {
                 return (_info->Patch());
             }
-            const std::string& Name() const override {
-                return (_info->Name());
+            const std::string& ServiceName() const override {
+                return (_info->ServiceName());
             }
             const TCHAR* Module() const override {
                 return (_info->Module());
@@ -334,7 +334,7 @@ namespace Plugin {
         uint8_t Patch() const override {
             return (static_cast<uint8_t>(_version & 0xFF));
         }
-        const std::string& Name() const override {
+        const std::string& ServiceName() const override {
             return (_Id);
         }
         const TCHAR* Module() const override {


### PR DESCRIPTION
The bluetooth plugin is using the Name() as a method on a interface implemented by the plugin. This was conflicting with the new functionality (metadat) on the Service. renamed Name->ServiceName.