### PR TITLE
DELIA-56519: Force the compiler to generate template for all methods

### DIFF
--- a/Source/core/IIterator.h
+++ b/Source/core/IIterator.h
@@ -174,7 +174,7 @@ namespace Core {
 
         inline ELEMENT operator->()
         {
-            ASSERT(((m_Index > 0) && (m_Index <= Count())));
+            ASSERT(IsValid());
 
             return (*m_Iterator);
         }

--- a/Source/tracing/TraceUnit.cpp
+++ b/Source/tracing/TraceUnit.cpp
@@ -360,3 +360,6 @@ namespace Trace {
     }
 }
 } // namespace WPEFramework::Trace
+
+//Force the compiler to generate template for all methods
+template class WPEFramework::Core::IteratorType<WPEFramework::Trace::TraceUnit::TraceControlList, WPEFramework::Trace::ITraceControl*>;


### PR DESCRIPTION
Reason for change: To resolve linker error while enabling ASSERT

Test Procedure: Build and verify.
Risks: Low
Signed-off-by:Zameerun Rasheed M S <zmamoo711@cable.comcast.com>