### PR TITLE
RDKTV-15390 : WPEFramework Crash  in Core::ResourceMonitorType

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -373,7 +373,11 @@ namespace Core {
 
         // Make sure the socket is closed before you destruct. Otherwise
         // the virtuals might be called, which are destructed at this point !!!!
-        ASSERT(m_Socket == INVALID_SOCKET);
+        ASSERT((m_Socket == INVALID_SOCKET) || (IsClosed()));
+
+        if (m_Socket != INVALID_SOCKET) {
+	    DestroySocket(m_Socket);
+        }
 
         ::free(m_SendBuffer);
 	m_SendBuffer = nullptr;

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -261,7 +261,7 @@ namespace Core {
         enumType m_SocketType;
         SOCKET m_Socket;
         mutable CriticalSection m_syncAdmin;
-        volatile uint16_t m_State;
+	std::atomic<uint16_t> m_State;
         NodeId m_ReceivedNode;
         uint8_t* m_SendBuffer;
         uint8_t* m_ReceiveBuffer;


### PR DESCRIPTION
Reason for change: closing the Socket
Test Procedure: mentioned in the ticket.
Risks: None
Signed-off-by: Neeraj Sahu Neeraj_Sahu@comcast.com