### PR TITLE
[Portability] Add define indicating Thunder version

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -900,4 +900,6 @@ namespace std {
 #endif
 #endif
 
+#define THUNDER_VERSION 3
+
 #endif // __PORTABILITY_H


### PR DESCRIPTION
That definition may later be used in situations, where a different piece of code needs to be executed depending on the Thunder version. 