### PR TITLE
[Portability] Add define indicating Thunder version

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -762,4 +762,6 @@ namespace Core {
 #define BUILD_REFERENCE engineering_build_for_debug_purpose_only
 #endif
 
+#define THUNDER_VERSION 2
+
 #endif // __PORTABILITY_H


### PR DESCRIPTION
That definition may later be used in situations, where a different piece of code needs to be executed depending on the Thunder version.
This is backported PR of: https://github.com/rdkcentral/Thunder/pull/1013