### PR TITLE
RDKTV-16992: Added timeout and synchronisation when stopping containers

### DIFF
--- a/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
+++ b/Source/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
@@ -371,15 +371,54 @@ namespace ProcessContainers {
 
     bool DobbyContainer::Stop(const uint32_t timeout /*ms*/)
     {
-        // TODO: add timeout support
         bool result = false;
+        bool stoppedSuccessfully = false;
         auto& admin = static_cast<DobbyContainerAdministrator&>(DobbyContainerAdministrator::Instance());
 
-        bool stoppedSuccessfully = admin.mDobbyProxy->stopContainer(_descriptor, false);
+        TRACE(Trace::Information, (_T("Stopping container. id: %s descriptor: %d timeout %d"), _name.c_str(), _descriptor, timeout));
+        if (timeout == 0)
+        {
+            stoppedSuccessfully = admin.mDobbyProxy->stopContainer(_descriptor, false);
+        }
+        else
+        {
+            std::mutex m;
+            std::condition_variable cv;
+            int temp_descriptor = _descriptor;
+            std::thread t([&cv, &stoppedSuccessfully, &admin, temp_descriptor]()
+            {
+                stoppedSuccessfully = admin.mDobbyProxy->stopContainer(temp_descriptor, false);
+                cv.notify_one();
+            });
 
-        if (!stoppedSuccessfully) {
-            TRACE(Trace::Error, (_T("Failed to stop container, internal Dobby error. id: %s descriptor: %d"), _name.c_str(), _descriptor));
-        } else {
+            t.detach();
+
+            std::unique_lock<std::mutex> tmp_lock(m);
+            if(cv.wait_for(tmp_lock, std::chrono::milliseconds(timeout)) == std::cv_status::timeout)
+            {
+                SYSLOG(Logging::Error, (_T("Timeout during container stop operation. id: %s descriptor: %d timeout %d"), _name.c_str(), _descriptor, timeout));
+                switch (static_cast<IDobbyProxyEvents::ContainerState>(admin.mDobbyProxy->getContainerState(_descriptor)))
+                {
+                case IDobbyProxyEvents::ContainerState::Invalid:
+                    stoppedSuccessfully = true;
+                    break;
+                case IDobbyProxyEvents::ContainerState::Stopped:
+                    stoppedSuccessfully = true;
+                break;
+                default:
+                    stoppedSuccessfully = false;
+                    break;
+                }
+            }
+        }
+
+        if (!stoppedSuccessfully)
+        {
+            SYSLOG(Logging::Error, (_T("Failed to stop container, internal Dobby error. id: %s descriptor: %d"), _name.c_str(), _descriptor));
+        }
+        else
+        {
+            TRACE(Trace::Information, (_T("Container stopped successfully. id: %s descriptor: %d"), _name.c_str(), _descriptor));
             result = true;
         }
 


### PR DESCRIPTION
Reason for change: It was possible for successive calls to DobbyContainer::Stop
to be made due to the WPEFramework not being notified quickly enough
that a container had stopped.

This change implements the missing timeout functionality
within that method to prevent the opportunity for quick multiple calls.
When the timeout is zero this method behaves as previous.

Test Procedure: Stop containers with zero and non-zero timeouts and
ensure there are no occurrences of containers being stopped multiple
times.

Risks: Low

Signed-off-by: Will Tallentire <will.tallentire@sky.uk>