### PR TITLE
DELIA-56858: Enable Thunder Debug Logs

### DIFF
--- a/Source/core/Trace.h
+++ b/Source/core/Trace.h
@@ -43,16 +43,30 @@ namespace WPEFramework {
     }
 }
 
+
+
 #ifdef __WINDOWS__
 #define TRACE_PROCESS_ID ::GetCurrentProcessId()
+#define TRACE_THREAD_ID ::GetCurrentThreadId()
 #else
 #define TRACE_PROCESS_ID ::getpid()
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define TRACE_THREAD_ID syscall(SYS_gettid)
+#else
+#include <unistd.h>
+#define TRACE_THREAD_ID ::gettid()
+#endif
 #endif
 
-#define TRACE_FORMATTING(fmt, ...)                                                                                                        \
-    do {                                                                                                                                  \
-        fprintf(stderr, "\033[1;32m[%s:%d](%s)<%d>" fmt "\n\033[0m", &__FILE__[WPEFramework::Core::FileNameOffset(__FILE__)], __LINE__, __FUNCTION__, TRACE_PROCESS_ID, ##__VA_ARGS__);  \
-        fflush(stderr);                                                                                                                   \
+#define TRACE_LOG_FLAG  "/tmp/wpeframeworkTraceEnable"
+
+#define TRACE_FORMATTING(fmt, ...)                                                                                                   \
+    do {                                                                                                                             \
+        if(0 == access(TRACE_LOG_FLAG, F_OK)) {                                                                                      \
+            fprintf(stderr, "\033[1;32m[%s:%d](%s)<PID:%d><TID:%d>" fmt "\n\033[0m", &__FILE__[WPEFramework::Core::FileNameOffset(__FILE__)], __LINE__, __FUNCTION__, TRACE_PROCESS_ID, TRACE_THREAD_ID, ##__VA_ARGS__);  \
+            fflush(stderr);                                                                                                          \
+        }                                                                                                                            \
     } while (0)
 
 #ifdef __WINDOWS__


### PR DESCRIPTION
Reason for change: Runtime enabling/disabling of thunder debug logs
Risks: low
Signed-off-by: cmuhammedrafi <muhammed_rafi@comcast.com>