### PR TITLE
RDKDEV-340: Thread: Fix handling of pthread_create() failures

### DIFF
--- a/Source/core/Thread.h
+++ b/Source/core/Thread.h
@@ -162,7 +162,8 @@ namespace Core {
             BLOCKED = 0x0008,
             STOPPED = 0x0010,
             INITIALIZED = 0x0020,
-            STOPPING = 0x0040
+            STOPPING = 0x0040,
+            FAILED = 0x0080
 
         } thread_state;
 
@@ -194,6 +195,10 @@ namespace Core {
         inline bool IsBlocked() const
         {
             return (m_enumState == BLOCKED);
+        }
+        inline bool IsFailed() const
+        {
+            return (m_enumState == FAILED);
         }
         int PriorityMin() const;
         int PriorityMax() const;


### PR DESCRIPTION
When pthread_create() fails, it returns a value different than zero, not
-1 as the current implementation was assuming. This was detected in a
use case where some threads were trying to be created with approximately
1GiB stack size and failing.

Additionally, when the thread creation fails, any waits or set states on
it must fail, otherwise the system may become deadlocked waiting for
some thread that could not even be created. For this, introduce a new
'FAILED' state and handle it accordingly.

Signed-off-by: Ricardo Silva <ricardo.josilva@parceiros.nos.pt>