### PR TITLE
RDKTV-16258: WPEWebProcess crash due to WPEFramework lambda signature

### DIFF
--- a/Tools/ProxyStubGenerator/StubGenerator.py
+++ b/Tools/ProxyStubGenerator/StubGenerator.py
@@ -827,6 +827,8 @@ def GenerateStubs(output_file, source_file, includePaths = [], defaults="", scan
                               ((" ".join(m.qualifiers) + " " + iface_name).strip(),  (" ".join(m.qualifiers) + " " + iface_name).strip()))
                     emit.Line("ASSERT((implementation != %s) && \"Null %s implementation pointer\");" %
                               (NULLPTR, iface_name))
+                    emit.Line("if (implementation != %s) {" % (NULLPTR))
+                    emit.IndentInc()
                     call = ""
                     if retval.has_output:
                         call += "%s %s = " % (retval.str_noref, retval.name)
@@ -924,6 +926,8 @@ def GenerateStubs(output_file, source_file, includePaths = [], defaults="", scan
                                     p.name)
                                 emit.IndentDec()
                                 emit.Line("}")
+                    emit.IndentDec()
+                    emit.Line("}")
 
                 else:
                     log.Print("stubbed method %s" % m.full_name, source_file)


### PR DESCRIPTION
Reason for change: wpeframework lambda fuction crash issue fix
Test Procedure: Verify in Hisense TV
Risks: low

Signed-off-by: cmuhammedrafi <muhammed_rafi@comcast.com>