### PR TITLE
RDKTV-16992: Synchronisation of container stop functionality

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -167,7 +167,7 @@ namespace RPC {
                     if (_process.Id() != 0) {
                         _process.Kill(false);
                     } else {
-                        _container->Stop(0);
+                        _container->Stop(3000);
                     }
                 }
                     nextinterval = 10000;
@@ -182,7 +182,7 @@ namespace RPC {
                     }
                 } break;
                 case 2:
-                    _container->Stop(0);
+                    _container->Stop(3000);
                     nextinterval = 5000;
                     break;
                 default:


### PR DESCRIPTION
Reason for change: Thunder expects containers to be stopped
asynchronously with a configurable timeout. Blocking inside
the DobbyContainer class does not work as Thunder expects
RPCs to be handled immediately. Starting threads inside the
DobbyContainer class to wait for the timeout is unreliable
as the class can be destroyed before any callback or timeout.
This change adopts the producer consumer pattern to queue
container stop requests and process them synchronously in a
persistent thread.

Test Procedure: Containers can be stopped and restarted successfully.

Risks: Medium

Signed-off-by: Will Tallentire <will.tallentire@sky.uk>