### PR TITLE
RDKTV-15347: Add PluginActivator utility for systemd integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(ENABLE_STRICT_COMPILER_SETTINGS
 option(LEGACY_CONFIG_GENERATOR
     "Use the legacy config generator and all its needed CMake sub-components. 
      If switched OFF, plugins need to use the new python-based templates. (*.conf.in)" ON) 
+option(BUILD_PLUGIN_ACTIVATOR
+     "Build the standalone plugin activator utility to activate plugins using systemd" OFF) 
 
 if (BUILD_REFERENCE)
     add_definitions (-DBUILD_REFERENCE=${BUILD_REFERENCE})
@@ -137,3 +139,7 @@ endif()
 add_subdirectory(Source)
 
 add_subdirectory(Tests)
+
+if (BUILD_PLUGIN_ACTIVATOR)
+  add_subdirectory(Utils/PluginActivator)
+endif()

--- a/Utils/PluginActivator/CMakeLists.txt
+++ b/Utils/PluginActivator/CMakeLists.txt
@@ -20,8 +20,7 @@ cmake_minimum_required(VERSION 3.10.3)
 
 project( PluginActivator )
 
-set( CMAKE_CXX_STANDARD 14 )
-set( CMAKE_CXX_STANDARD_REQUIRED ON )
+set( CMAKE_CXX_STANDARD 11 )
 
 add_executable(${PROJECT_NAME}
     source/Module.cpp
@@ -29,13 +28,9 @@ add_executable(${PROJECT_NAME}
     source/COMRPCStarter.cpp
 )
 
-target_compile_options(${PROJECT_NAME}
-    PRIVATE
-    -Wall
-)
-
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
+    CompileSettingsDebug::CompileSettingsDebug
     ${NAMESPACE}Core::${NAMESPACE}Core
     ${NAMESPACE}COM::${NAMESPACE}COM
     ${NAMESPACE}Plugins::${NAMESPACE}Plugins

--- a/Utils/PluginActivator/CMakeLists.txt
+++ b/Utils/PluginActivator/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10.3)
+
+project( PluginActivator )
+
+set( CMAKE_CXX_STANDARD 14 )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
+
+add_executable(${PROJECT_NAME}
+    source/Module.cpp
+    source/main.cpp
+    source/COMRPCStarter.cpp
+)
+
+target_compile_options(${PROJECT_NAME}
+    PRIVATE
+    -Wall
+)
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    ${NAMESPACE}Core::${NAMESPACE}Core
+    ${NAMESPACE}COM::${NAMESPACE}COM
+    ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION bin
+)

--- a/Utils/PluginActivator/CMakeLists.txt
+++ b/Utils/PluginActivator/CMakeLists.txt
@@ -1,3 +1,21 @@
+
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 Metrological
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.10.3)
 
 project( PluginActivator )

--- a/Utils/PluginActivator/README.md
+++ b/Utils/PluginActivator/README.md
@@ -1,0 +1,18 @@
+# Plugin Activator
+A command-line tool to activate a specified Thunder plugin.
+
+Will automatically retry activation mutliple times if the plugin does not successfully activate.
+
+Designed to be used with systemd where each plugin becomes a standalone systemd service, activated with this tool.
+
+## Usage
+```
+Usage: PluginActivator <option(s)> [callsign]
+    Utility that starts a given thunder plugin
+
+    -h, --help          Print this help and exit
+    -r, --retries       Maximum amount of retries to attempt to start the plugin before giving up
+    -d, --delay         Delay (in ms) between each attempt to start the plugin if it fails
+
+    [callsign]          Callsign of the plugin to activate (Required)
+```

--- a/Utils/PluginActivator/source/COMRPCStarter.cpp
+++ b/Utils/PluginActivator/source/COMRPCStarter.cpp
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "COMRPCStarter.h"
 
 #include "Log.h"

--- a/Utils/PluginActivator/source/COMRPCStarter.cpp
+++ b/Utils/PluginActivator/source/COMRPCStarter.cpp
@@ -1,0 +1,143 @@
+#include "COMRPCStarter.h"
+
+#include "Log.h"
+
+#include <chrono>
+#include <thread>
+
+COMRPCStarter::COMRPCStarter(const std::string &pluginName)
+    : mPluginName(pluginName),
+      mEngine(Core::ProxyType<RPC::InvokeServerType<1, 0, 4>>::Create()),
+      mClient(Core::ProxyType<RPC::CommunicatorClient>::Create(getConnectionEndpoint(),
+                                                               Core::ProxyType<Core::IIPCServer>(mEngine)))
+{
+    // Announce our arrival
+    mEngine->Announcements(mClient->Announcement());
+
+    if (!mClient.IsValid())
+    {
+        LOG_ERROR(pluginName.c_str(), "Failed to create valid COM-RPC client");
+    }
+}
+
+COMRPCStarter::~COMRPCStarter()
+{
+    // Disconnect from Thunder and clean up
+    mClient->Close(RPC::CommunicationTimeOut);
+    if (mClient.IsValid())
+    {
+        mClient.Release();
+    }
+
+    Core::Singleton::Dispose();
+}
+
+/**
+ * @brief Attempt to activate the plugin and automatically retry on failure
+ *
+ * @param[in]   maxRetries      Maximum amount of times to retry activation if it fails
+ * @param[in]   retryDelayMs    Delay in ms between retry attempts
+ *
+ * @return True if plugin successfully activated, false if failed to activate
+ */
+bool COMRPCStarter::activatePlugin(const int maxRetries, const int retryDelayMs)
+{
+    // Attempt to open the plugin shell
+    bool success = false;
+    int currentRetry = 1;
+
+    PluginHost::IShell *shell = nullptr;
+
+    while (!success && currentRetry <= maxRetries)
+    {
+        LOG_INF(mPluginName.c_str(), "Attempting to activate plugin - attempt %d/%d", currentRetry, maxRetries);
+
+        auto start = std::chrono::steady_clock::now();
+
+        if (!shell)
+        {
+            shell = mClient->Open<PluginHost::IShell>(_T(mPluginName), ~0, RPC::CommunicationTimeOut);
+        }
+
+        // We could not open IShell for some reason - Thunder doesn't give an error about why this might have failed
+        // Normally this is because either:
+        //  a) Thunder isn't running or we can't connect to /tmp/communicator
+        //  b) A plugin with the specified callsign does not exist
+        if (!shell)
+        {
+            LOG_ERROR(mPluginName.c_str(), "Failed to open IShell interface for %s", mPluginName.c_str());
+            currentRetry++;
+
+            // Must close the connection before we retry, since even if shell is null the underlying
+            // connection will still have been opened
+            mClient->Close(RPC::CommunicationTimeOut);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
+            continue;
+        };
+
+        // Connected to Thunder successfully and got the plugin shell
+        if (shell->State() == PluginHost::IShell::ACTIVATED)
+        {
+            LOG_INF(mPluginName.c_str(), "Plugin is already activated - nothing to do");
+            shell->Release();
+            return true;
+        }
+
+        // Will block until plugin is activated
+        uint32_t result = shell->Activate(PluginHost::IShell::REQUESTED);
+
+        auto end = std::chrono::steady_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+        if (result != Core::ERROR_NONE)
+        {
+            if (result == Core::ERROR_PENDING_CONDITIONS)
+            {
+                // Ideally we'd print out which preconditions are un-met for debugging, but that data is not exposed through the IShell interface
+                LOG_ERROR(mPluginName.c_str(), "Failed to activate plugin due to unmet preconditions after %ldms", duration.count());
+            }
+            else
+            {
+                LOG_ERROR(mPluginName.c_str(), "Failed to activate plugin with error %u (%s) after %ldms", result, Core::ErrorToString(result), duration.count());
+            }
+            currentRetry++;
+            std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
+            continue;
+        }
+        else
+        {
+            // Our work here is done!
+            LOG_INF(mPluginName.c_str(), "Successfully activated plugin after %ldms", duration.count());
+            shell->Release();
+            return true;
+        }
+    }
+
+    // If we got to this point, we've not managed to activate the plugin after X retries
+    LOG_ERROR(mPluginName.c_str(), "Max retries hit - giving up activating the plugin");
+    if (shell)
+    {
+        shell->Release();
+    }
+
+    return false;
+}
+
+/**
+ * Retrieves the socket we will communicate over for COM-RPC
+ */
+Core::NodeId COMRPCStarter::getConnectionEndpoint() const
+{
+    std::string communicatorPath;
+    Core::SystemInfo::GetEnvironment(_T("COMMUNICATOR_PATH"), communicatorPath);
+
+    // On linux, Thunder defaults to /tmp/communicator for the generic COM-RPC
+    // interface
+    if (communicatorPath.empty())
+    {
+        communicatorPath = "/tmp/communicator";
+    }
+
+    return Core::NodeId(communicatorPath.c_str());
+}

--- a/Utils/PluginActivator/source/COMRPCStarter.cpp
+++ b/Utils/PluginActivator/source/COMRPCStarter.cpp
@@ -119,15 +119,14 @@ bool COMRPCStarter::activatePlugin(const int maxRetries, const int retryDelayMs)
             }
         }
     }
+
     if (!success) {
         LOG_ERROR(mPluginName.c_str(), "Max retries hit - giving up activating the plugin");
     }
 
-    if (shell)
-    {
+    if (shell) {
         shell->Release();
     }
-
 
     return success;
 }

--- a/Utils/PluginActivator/source/COMRPCStarter.h
+++ b/Utils/PluginActivator/source/COMRPCStarter.h
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include "Module.h"
 

--- a/Utils/PluginActivator/source/COMRPCStarter.h
+++ b/Utils/PluginActivator/source/COMRPCStarter.h
@@ -29,10 +29,9 @@ using namespace WPEFramework;
  *
  * Connects to Thunder over COM-RPC and attempts to start a given plugin
  */
-class COMRPCStarter : public IPluginStarter
-{
+class COMRPCStarter : public IPluginStarter {
 public:
-    explicit COMRPCStarter(const std::string& pluginName);
+    explicit COMRPCStarter(const string& pluginName);
     ~COMRPCStarter() override;
 
     bool activatePlugin(const int maxRetries, const int retryDelayMs) final;
@@ -41,7 +40,7 @@ private:
     Core::NodeId getConnectionEndpoint() const;
 
 private:
-    const std::string mPluginName;
+    const string mPluginName;
 
     Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> mEngine;
     Core::ProxyType<RPC::CommunicatorClient> mClient;

--- a/Utils/PluginActivator/source/COMRPCStarter.h
+++ b/Utils/PluginActivator/source/COMRPCStarter.h
@@ -34,14 +34,14 @@ public:
     explicit COMRPCStarter(const string& pluginName);
     ~COMRPCStarter() override;
 
-    bool activatePlugin(const int maxRetries, const int retryDelayMs) final;
+    bool activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) override;
 
 private:
     Core::NodeId getConnectionEndpoint() const;
 
 private:
-    const string mPluginName;
+    const string _pluginName;
 
-    Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> mEngine;
-    Core::ProxyType<RPC::CommunicatorClient> mClient;
+    Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> _engine;
+    Core::ProxyType<RPC::CommunicatorClient> _client;
 };

--- a/Utils/PluginActivator/source/COMRPCStarter.h
+++ b/Utils/PluginActivator/source/COMRPCStarter.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "Module.h"
+
+#include "IPluginStarter.h"
+
+using namespace WPEFramework;
+
+/**
+ * @brief COM-RPC implementation of a plugin starter
+ *
+ * Connects to Thunder over COM-RPC and attempts to start a given plugin
+ */
+class COMRPCStarter : public IPluginStarter
+{
+public:
+    explicit COMRPCStarter(const std::string& pluginName);
+    ~COMRPCStarter() override;
+
+    bool activatePlugin(const int maxRetries, const int retryDelayMs) final;
+
+private:
+    Core::NodeId getConnectionEndpoint() const;
+
+private:
+    const std::string mPluginName;
+
+    Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> mEngine;
+    Core::ProxyType<RPC::CommunicatorClient> mClient;
+};

--- a/Utils/PluginActivator/source/IPluginStarter.h
+++ b/Utils/PluginActivator/source/IPluginStarter.h
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <string>

--- a/Utils/PluginActivator/source/IPluginStarter.h
+++ b/Utils/PluginActivator/source/IPluginStarter.h
@@ -26,10 +26,9 @@
  *
  * Could be implemented with JSON-RPC or COM-RPC
  */
-class IPluginStarter
-{
+class IPluginStarter {
 public:
-    virtual ~IPluginStarter() {};
+    virtual ~IPluginStarter(){};
 
     /**
      * @brief Activate a Thunder plugin

--- a/Utils/PluginActivator/source/IPluginStarter.h
+++ b/Utils/PluginActivator/source/IPluginStarter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+/**
+ * Interface to start a specified plugin
+ *
+ * Could be implemented with JSON-RPC or COM-RPC
+ */
+class IPluginStarter
+{
+public:
+    virtual ~IPluginStarter() {};
+
+    /**
+     * @brief Activate a Thunder plugin
+     *
+     * Will block until either the Thunder plugin has activated or until the maximum amount of retires has occurred
+     *
+     * @param[in]   maxRetries          Maximum amount of attempts to activate the plugin - if plugin is not activated within the amount of retries
+     *                                  this method will return false
+     * @param[in]   retryDelayMs        Amount of time to wait after a failed activation before retrying again
+     */
+    virtual bool activatePlugin(const int maxRetries, const int retryDelayMs) = 0;
+};

--- a/Utils/PluginActivator/source/IPluginStarter.h
+++ b/Utils/PluginActivator/source/IPluginStarter.h
@@ -28,7 +28,7 @@
  */
 class IPluginStarter {
 public:
-    virtual ~IPluginStarter(){};
+    virtual ~IPluginStarter() = default;
 
     /**
      * @brief Activate a Thunder plugin
@@ -39,5 +39,5 @@ public:
      *                                  this method will return false
      * @param[in]   retryDelayMs        Amount of time to wait after a failed activation before retrying again
      */
-    virtual bool activatePlugin(const int maxRetries, const int retryDelayMs) = 0;
+    virtual bool activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) = 0;
 };

--- a/Utils/PluginActivator/source/Log.h
+++ b/Utils/PluginActivator/source/Log.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdio.h>
+#include <string.h>
+
+#define LOG_LEVEL 3
+
+#ifndef __FILENAME__
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LEVEL_DEBUG 3
+#define LEVEL_INFO 2
+#define LEVEL_WARN 1
+#define LEVEL_ERROR 0
+
+
+#define LOG_DBG(plugin, fmt, ...) \
+    __LOG(LEVEL_DEBUG, plugin, fmt, ##__VA_ARGS__)
+
+#define LOG_INF(plugin, fmt, ...) \
+    __LOG(LEVEL_INFO, plugin, fmt, ##__VA_ARGS__)
+
+#define LOG_WARN(plugin, fmt, ...) \
+    __LOG(LEVEL_WARN, plugin, fmt, ##__VA_ARGS__)
+
+#define LOG_ERROR(plugin, fmt, ...) \
+    __LOG(LEVEL_ERROR, plugin, fmt, ##__VA_ARGS__)
+
+#define __LOG(level, plugin, fmt, ...)                                                                                                         \
+    do                                                                                                                                         \
+    {                                                                                                                                          \
+        if (__builtin_expect(((level) <= LOG_LEVEL), 0))                                                                                       \
+            fprintf(stderr, "%s[%s:%d][%s] (%s) " fmt "\n", getLogLevel(level), __FILENAME__, __LINE__, __FUNCTION__, plugin, ##__VA_ARGS__); \
+    } while (0)
+
+inline const char *getLogLevel(int level)
+{
+    switch (level)
+    {
+    case LEVEL_DEBUG:
+        return "[DBG]";
+    case LEVEL_INFO:
+        return "[NFO]";
+    case LEVEL_WARN:
+        return "[WRN]";
+    case LEVEL_ERROR:
+        return "[ERR]";
+    default:
+        return "";
+    }
+}

--- a/Utils/PluginActivator/source/Log.h
+++ b/Utils/PluginActivator/source/Log.h
@@ -33,7 +33,6 @@
 #define LEVEL_WARN 1
 #define LEVEL_ERROR 0
 
-
 #define LOG_DBG(plugin, fmt, ...) \
     __LOG(LEVEL_DEBUG, plugin, fmt, ##__VA_ARGS__)
 
@@ -46,17 +45,15 @@
 #define LOG_ERROR(plugin, fmt, ...) \
     __LOG(LEVEL_ERROR, plugin, fmt, ##__VA_ARGS__)
 
-#define __LOG(level, plugin, fmt, ...)                                                                                                         \
-    do                                                                                                                                         \
-    {                                                                                                                                          \
-        if (__builtin_expect(((level) <= LOG_LEVEL), 0))                                                                                       \
+#define __LOG(level, plugin, fmt, ...)                                                                                                        \
+    do {                                                                                                                                      \
+        if (__builtin_expect(((level) <= LOG_LEVEL), 0))                                                                                      \
             fprintf(stderr, "%s[%s:%d][%s] (%s) " fmt "\n", getLogLevel(level), __FILENAME__, __LINE__, __FUNCTION__, plugin, ##__VA_ARGS__); \
     } while (0)
 
-inline const char *getLogLevel(int level)
+inline const char* getLogLevel(int level)
 {
-    switch (level)
-    {
+    switch (level) {
     case LEVEL_DEBUG:
         return "[DBG]";
     case LEVEL_INFO:

--- a/Utils/PluginActivator/source/Log.h
+++ b/Utils/PluginActivator/source/Log.h
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <stdio.h>

--- a/Utils/PluginActivator/source/Module.cpp
+++ b/Utils/PluginActivator/source/Module.cpp
@@ -1,0 +1,24 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2022 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+
+#include "Module.h"
+
+// If not set in CMake flags, BUILD_REFERENCE defaults to "engineering_build_for_debug_purpose_only"
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/Utils/PluginActivator/source/Module.cpp
+++ b/Utils/PluginActivator/source/Module.cpp
@@ -1,22 +1,21 @@
-/**
-* If not stated otherwise in this file or this component's LICENSE
-* file the following copyright and licenses apply:
-*
-* Copyright 2022 RDK Management
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "Module.h"
 

--- a/Utils/PluginActivator/source/Module.h
+++ b/Utils/PluginActivator/source/Module.h
@@ -23,10 +23,10 @@
 #define MODULE_NAME PluginStarter
 #endif
 
-#include <core/core.h>
 #include <com/com.h>
-#include <plugins/IShell.h>
+#include <core/core.h>
 #include <plugins/Configuration.h>
+#include <plugins/IShell.h>
 
 #undef EXTERNAL
 #define EXTERNAL

--- a/Utils/PluginActivator/source/Module.h
+++ b/Utils/PluginActivator/source/Module.h
@@ -1,0 +1,33 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2022 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME PluginStarter
+#endif
+
+#include <core/core.h>
+#include <com/com.h>
+#include <plugins/IShell.h>
+#include <plugins/Configuration.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/Utils/PluginActivator/source/Module.h
+++ b/Utils/PluginActivator/source/Module.h
@@ -25,8 +25,7 @@
 
 #include <com/com.h>
 #include <core/core.h>
-#include <plugins/Configuration.h>
-#include <plugins/IShell.h>
+#include <plugins/plugins.h>
 
 #undef EXTERNAL
 #define EXTERNAL

--- a/Utils/PluginActivator/source/Module.h
+++ b/Utils/PluginActivator/source/Module.h
@@ -1,22 +1,21 @@
-/**
-* If not stated otherwise in this file or this component's LICENSE
-* file the following copyright and licenses apply:
-*
-* Copyright 2022 RDK Management
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/Utils/PluginActivator/source/main.cpp
+++ b/Utils/PluginActivator/source/main.cpp
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-#include "Module.h"
 #include "COMRPCStarter.h"
+#include "Module.h"
 
 #include <memory>
 
 static int gRetryCount = 100;
 static int gRetryDelayMs = 500;
-static std::string gPluginName;
+static string gPluginName;
 
 /**
  * @brief Display a help message for the tool
@@ -46,46 +46,41 @@ static void displayUsage()
  * Must be given the name of the plugin to activate, everything else
  * is optional and will fallback to sane defaults
  */
-static void parseArgs(const int argc, char **argv)
+static void parseArgs(const int argc, char** argv)
 {
-    if (argc == 1)
-    {
+    if (argc == 1) {
         displayUsage();
         exit(EXIT_SUCCESS);
     }
 
-    struct option longopts[] =
-        {
-            {"help", no_argument, nullptr, (int)'h'},
-            {"retries", required_argument, nullptr, (int)'r'},
-            {"delay", required_argument, nullptr, (int)'d'},
-            {nullptr, 0, nullptr, 0}};
+    struct option longopts[] = {
+        { "help", no_argument, nullptr, (int)'h' },
+        { "retries", required_argument, nullptr, (int)'r' },
+        { "delay", required_argument, nullptr, (int)'d' },
+        { nullptr, 0, nullptr, 0 }
+    };
 
     opterr = 0;
 
     int c;
     int longindex;
 
-    while ((c = getopt_long(argc, argv, "hr:d:", longopts, &longindex)) != -1)
-    {
-        switch (c)
-        {
+    while ((c = getopt_long(argc, argv, "hr:d:", longopts, &longindex)) != -1) {
+        switch (c) {
         case 'h':
             displayUsage();
             exit(EXIT_SUCCESS);
             break;
         case 'r':
             gRetryCount = std::atoi(optarg);
-            if (gRetryCount < 0)
-            {
+            if (gRetryCount < 0) {
                 fprintf(stderr, "Error: Retry count must be > 0\n");
                 exit(EXIT_FAILURE);
             }
             break;
         case 'd':
             gRetryDelayMs = std::atoi(optarg);
-            if (gRetryDelayMs < 0)
-            {
+            if (gRetryDelayMs < 0) {
                 fprintf(stderr, "Error: Delay ms must be > 0\n");
                 exit(EXIT_FAILURE);
             }
@@ -106,8 +101,7 @@ static void parseArgs(const int argc, char **argv)
         }
     }
 
-    if (optind == argc)
-    {
+    if (optind == argc) {
         fprintf(stderr, "Error: Must provide plugin name to activate\n");
         exit(EXIT_FAILURE);
     }
@@ -115,25 +109,20 @@ static void parseArgs(const int argc, char **argv)
     gPluginName = argv[optind];
 
     optind++;
-    for (int i = optind; i < argc; i++)
-    {
+    for (int i = optind; i < argc; i++) {
         printf("Warning: Non-option argument %s ignored\n", argv[i]);
     }
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     parseArgs(argc, argv);
 
     // For now, we only implement the starter in COM-RPC but could do a JSON-RPC version
     // in the future
+    bool success;
     std::unique_ptr<IPluginStarter> starter = std::make_unique<COMRPCStarter>(gPluginName);
-    if (starter->activatePlugin(gRetryCount, gRetryDelayMs))
-    {
-        return EXIT_SUCCESS;
-    }
-    else
-    {
-        return EXIT_FAILURE;
-    }
+    success = starter->activatePlugin(gRetryCount, gRetryDelayMs);
+
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/Utils/PluginActivator/source/main.cpp
+++ b/Utils/PluginActivator/source/main.cpp
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "Module.h"
 #include "COMRPCStarter.h"
 

--- a/Utils/PluginActivator/source/main.cpp
+++ b/Utils/PluginActivator/source/main.cpp
@@ -62,11 +62,11 @@ static void parseArgs(const int argc, char** argv)
 
     opterr = 0;
 
-    int c;
+    int option;
     int longindex;
 
-    while ((c = getopt_long(argc, argv, "hr:d:", longopts, &longindex)) != -1) {
-        switch (c) {
+    while ((option = getopt_long(argc, argv, "hr:d:", longopts, &longindex)) != -1) {
+        switch (option) {
         case 'h':
             displayUsage();
             exit(EXIT_SUCCESS);
@@ -121,8 +121,12 @@ int main(int argc, char* argv[])
     // For now, we only implement the starter in COM-RPC but could do a JSON-RPC version
     // in the future
     bool success;
-    std::unique_ptr<IPluginStarter> starter = std::make_unique<COMRPCStarter>(gPluginName);
+    std::unique_ptr<IPluginStarter> starter(new COMRPCStarter(gPluginName));
     success = starter->activatePlugin(gRetryCount, gRetryDelayMs);
+
+    // Destruct the COM-RPC starter so it cleans up after itself before we dispose WPEFramework singletons
+    starter.reset();
+    Core::Singleton::Dispose();
 
     return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/Utils/PluginActivator/source/main.cpp
+++ b/Utils/PluginActivator/source/main.cpp
@@ -1,0 +1,120 @@
+#include "Module.h"
+#include "COMRPCStarter.h"
+
+#include <memory>
+
+static int gRetryCount = 100;
+static int gRetryDelayMs = 500;
+static std::string gPluginName;
+
+/**
+ * @brief Display a help message for the tool
+ */
+static void displayUsage()
+{
+    printf("Usage: PluginActivator <option(s)> [callsign]\n");
+    printf("    Utility that starts a given thunder plugin\n\n");
+    printf("    -h, --help          Print this help and exit\n");
+    printf("    -r, --retries       Maximum amount of retries to attempt to start the plugin before giving up\n");
+    printf("    -d, --delay         Delay (in ms) between each attempt to start the plugin if it fails\n");
+    printf("\n");
+    printf("    [callsign]          Callsign of the plugin to activate (Required)\n");
+}
+
+/**
+ * @brief Parse the provided command line arguments
+ *
+ * Must be given the name of the plugin to activate, everything else
+ * is optional and will fallback to sane defaults
+ */
+static void parseArgs(const int argc, char **argv)
+{
+    if (argc == 1)
+    {
+        displayUsage();
+        exit(EXIT_SUCCESS);
+    }
+
+    struct option longopts[] =
+        {
+            {"help", no_argument, nullptr, (int)'h'},
+            {"retries", required_argument, nullptr, (int)'r'},
+            {"delay", required_argument, nullptr, (int)'d'},
+            {nullptr, 0, nullptr, 0}};
+
+    opterr = 0;
+
+    int c;
+    int longindex;
+
+    while ((c = getopt_long(argc, argv, "hr:d:", longopts, &longindex)) != -1)
+    {
+        switch (c)
+        {
+        case 'h':
+            displayUsage();
+            exit(EXIT_SUCCESS);
+            break;
+        case 'r':
+            gRetryCount = std::atoi(optarg);
+            if (gRetryCount < 0)
+            {
+                fprintf(stderr, "Error: Retry count must be > 0\n");
+                exit(EXIT_FAILURE);
+            }
+            break;
+        case 'd':
+            gRetryDelayMs = std::atoi(optarg);
+            if (gRetryDelayMs < 0)
+            {
+                fprintf(stderr, "Error: Delay ms must be > 0\n");
+                exit(EXIT_FAILURE);
+            }
+            break;
+        case '?':
+            if (optopt == 'c')
+                fprintf(stderr, "Warning: Option -%c requires an argument.\n", optopt);
+            else if (isprint(optopt))
+                fprintf(stderr, "Warning: Unknown option `-%c'.\n", optopt);
+            else
+                fprintf(stderr, "Warning: Unknown option character `\\x%x'.\n", optopt);
+
+            exit(EXIT_FAILURE);
+            break;
+        default:
+            exit(EXIT_FAILURE);
+            break;
+        }
+    }
+
+    if (optind == argc)
+    {
+        fprintf(stderr, "Error: Must provide plugin name to activate\n");
+        exit(EXIT_FAILURE);
+    }
+
+    gPluginName = argv[optind];
+
+    optind++;
+    for (int i = optind; i < argc; i++)
+    {
+        printf("Warning: Non-option argument %s ignored\n", argv[i]);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    parseArgs(argc, argv);
+
+    // For now, we only implement the starter in COM-RPC but could do a JSON-RPC version
+    // in the future
+    std::unique_ptr<IPluginStarter> starter = std::make_unique<COMRPCStarter>(gPluginName);
+    if (starter->activatePlugin(gRetryCount, gRetryDelayMs))
+    {
+        return EXIT_SUCCESS;
+    }
+    else
+    {
+        return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
Add a new utility tool to activate Thunder plugins from the command line.

Designed to allow integration with systemd to allow systemd services to activate plugins. Will automatically retry plugin activation if it fails with configurable retry count and delay between retries.

Not built by default - can be build by setting the `-DBUILD_PLUGIN_ACTIVATOR=ON` cmake flag