### PR TITLE
Thunder Debug Logs __ERRORRESULT__ not defined error fix

### DIFF
--- a/Source/core/Netlink.cpp
+++ b/Source/core/Netlink.cpp
@@ -22,6 +22,14 @@
 #include "Netlink.h"
 #include "Sync.h"
 
+#ifdef __WINDOWS__
+#include <Winsock2.h>
+#include <ws2tcpip.h>
+#define __ERRORRESULT__ ::WSAGetLastError()
+#else
+#define __ERRORRESULT__ errno
+#endif
+
 // #define DEBUG_FRAMES 1
 
 namespace WPEFramework {


### PR DESCRIPTION
Reason for change: This change is part of DELIA-56858: Enable Thunder Debug Logs (#1035)
Build error found in Jenkins build