### PR TITLE
[ARRISEOS-42363] Don't flush libraries in Dispatch

### DIFF
--- a/Source/WPEProcess/Process.cpp
+++ b/Source/WPEProcess/Process.cpp
@@ -75,8 +75,6 @@ namespace Process {
 
         public:
             void Dispatch() {
-                Core::ServiceAdministrator::Instance().FlushLibraries();
-
                 uint32_t instances = Core::ServiceAdministrator::Instance().Instances();
 
                 if (instances != 0) {


### PR DESCRIPTION
When flush of libWPEFrameworkWebKitBrowserImpl.so library happens in Dispatch() there are cases where the other thread is still using it which leads to core dump of WPEProcess.