### PR TITLE
[DOWNLOADPATH] Add an additional path with the same sematics as the P…

### DIFF
--- a/Source/WPEFramework/Config.h
+++ b/Source/WPEFramework/Config.h
@@ -54,6 +54,9 @@ namespace PluginHost {
                 _variables.insert(std::make_pair("volatilepath", [](const Config& config, const Plugin::Config* info) {
                     return (info == nullptr ? config.VolatilePath() : info->VolatilePath(config.VolatilePath()));
                 }));
+                _variables.insert(std::make_pair("downloadpath", [](const Config& config, const Plugin::Config*) {
+                    return (config.DownloadPath());
+                }));
                 _variables.insert(std::make_pair("proxystubpath", [](const Config& config, const Plugin::Config*) {
                     return (config.ProxyStubPath());
                 }));
@@ -295,6 +298,7 @@ namespace PluginHost {
                 , Prefix(_T("Service"))
                 , JSONRPC(_T("jsonrpc"))
                 , PersistentPath()
+                , DownloadPath()
                 , DataPath()
                 , SystemPath()
 #ifdef __WINDOWS__
@@ -339,6 +343,7 @@ namespace PluginHost {
                 Add(_T("interface"), &Interface);
                 Add(_T("prefix"), &Prefix);
                 Add(_T("persistentpath"), &PersistentPath);
+                Add(_T("downloadpath"), &DownloadPath);
                 Add(_T("datapath"), &DataPath);
                 Add(_T("systempath"), &SystemPath);
                 Add(_T("volatilepath"), &VolatilePath);
@@ -383,6 +388,7 @@ namespace PluginHost {
             Core::JSON::String Prefix;
             Core::JSON::String JSONRPC;
             Core::JSON::String PersistentPath;
+            Core::JSON::String DownloadPath;
             Core::JSON::String DataPath;
             Core::JSON::String SystemPath;
             Core::JSON::String VolatilePath;
@@ -529,6 +535,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             , _JSONRPCPrefix()
             , _volatilePath()
             , _persistentPath()
+            , _downloadPath()
             , _dataPath()
             , _hashKey()
             , _appPath()
@@ -583,6 +590,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
 #endif
                 _volatilePath = Core::Directory::Normalize(config.VolatilePath.Value());
                 _persistentPath = Core::Directory::Normalize(config.PersistentPath.Value());
+                _downloadPath = Core::Directory::Normalize(config.DownloadPath.Value());
                 _dataPath = Core::Directory::Normalize(config.DataPath.Value());
                 _systemPath = Core::Directory::Normalize(config.SystemPath.Value());
                 _configsPath = Core::Directory::Normalize(config.Configs.Value());
@@ -720,6 +728,10 @@ POP_WARNING()
         inline const string& PersistentPath() const
         {
             return (_persistentPath);
+        }
+        inline const string& DownloadPath() const
+        {
+            return (_downloadPath);
         }
         inline const string& DataPath() const
         {
@@ -959,6 +971,7 @@ POP_WARNING()
         string _JSONRPCPrefix;
         string _volatilePath;
         string _persistentPath;
+        string _downloadPath;
         string _dataPath;
         string _hashKey;
         string _appPath;

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -554,7 +554,7 @@ namespace PluginHost {
 
         public:
             Service(const PluginHost::Config& server, const Plugin::Config& plugin, ServiceMap& administrator)
-                : PluginHost::Service(plugin, server.WebPrefix(), server.PersistentPath(), server.DataPath(), server.VolatilePath())
+                : PluginHost::Service(plugin, server.WebPrefix(), server.PersistentPath(), server.DownloadPath(), server.DataPath(), server.VolatilePath())
                 , _pluginHandling()
                 , _handler(nullptr)
                 , _extended(nullptr)
@@ -992,7 +992,7 @@ namespace PluginHost {
             {
                 ASSERT(_connection == nullptr);
 
-                void* result(_administrator.Instantiate(object, waitTime, sessionId, DataPath(), PersistentPath(), VolatilePath()));
+                void* result(_administrator.Instantiate(object, waitTime, sessionId, DataPath(), PersistentPath(), DownloadPath(), VolatilePath()));
 
                 _connection = _administrator.RemoteConnection(sessionId);
 
@@ -1079,6 +1079,7 @@ namespace PluginHost {
                     string className = PluginHost::Service::Configuration().ClassName.Value() + _T("/");
                     // system configured paths
                     all_paths.push_back(DataPath() + locator);
+                    all_paths.push_back(DownloadPath() + locator);
                     all_paths.push_back(PersistentPath() + locator);
                     all_paths.push_back(SystemPath() + locator);
                     all_paths.push_back(PluginPath() + locator);
@@ -1550,6 +1551,7 @@ namespace PluginHost {
                     ServiceMap& parent,
                     const Core::NodeId& node,
                     const string& persistentPath,
+                    const string& downloadPath,
                     const string& systemPath,
                     const string& dataPath,
                     const string& volatilePath,
@@ -1562,6 +1564,7 @@ namespace PluginHost {
                     : RPC::Communicator(node, proxyStubPath.empty() == false ? Core::Directory::Normalize(proxyStubPath) : proxyStubPath, Core::ProxyType<Core::IIPCServer>(handler))
                     , _parent(parent)
                     , _persistentPath(persistentPath.empty() == false ? Core::Directory::Normalize(persistentPath) : persistentPath)
+                    , _downloadPath(downloadPath.empty() == false ? Core::Directory::Normalize(downloadPath) : downloadPath)
                     , _systemPath(systemPath.empty() == false ? Core::Directory::Normalize(systemPath) : systemPath)
                     , _dataPath(dataPath.empty() == false ? Core::Directory::Normalize(dataPath) : dataPath)
                     , _volatilePath(volatilePath.empty() == false ? Core::Directory::Normalize(volatilePath) : volatilePath)
@@ -1597,13 +1600,17 @@ namespace PluginHost {
                 }
 
             public:
-                void* Create(uint32_t& connectionId, const RPC::Object& instance, const uint32_t waitTime, const string& dataPath, const string& persistentPath, const string& volatilePath)
+                void* Create(uint32_t& connectionId, const RPC::Object& instance, const uint32_t waitTime, const string& dataPath, const string& persistentPath, const string& downloadPath, const string& volatilePath)
                 {
-                    return (RPC::Communicator::Create(connectionId, instance, RPC::Config(RPC::Communicator::Connector(), _application, persistentPath, _systemPath, dataPath, volatilePath, _appPath, _proxyStubPath, _postMortemPath), waitTime));
+                    return (RPC::Communicator::Create(connectionId, instance, RPC::Config(RPC::Communicator::Connector(), _application, persistentPath, downloadPath, _systemPath, dataPath, volatilePath, _appPath, _proxyStubPath, _postMortemPath), waitTime));
                 }
                 const string& PersistentPath() const
                 {
                     return (_persistentPath);
+                }
+                const string& DownloadPath() const
+                {
+                    return (_downloadPath);
                 }
                 const string& SystemPath() const
                 {
@@ -1735,6 +1742,7 @@ namespace PluginHost {
             private:
                 ServiceMap& _parent;
                 const string _persistentPath;
+                const string _downloadPath;
                 const string _systemPath;
                 const string _dataPath;
                 const string _volatilePath;
@@ -1802,17 +1810,19 @@ namespace PluginHost {
                     const string configuration) override
                 {
                     string persistentPath(_comms.PersistentPath());
+                    string downloadPath(_comms.DownloadPath());
                     string dataPath(_comms.DataPath());
                     string volatilePath(_comms.VolatilePath());
 
                     if (callsign.empty() == false) {
                         dataPath += callsign + '/';
                         persistentPath += callsign + '/';
+                        downloadPath += callsign + '/';
                         volatilePath += callsign + '/';
                     }
 
                     uint32_t id;
-                    RPC::Config config(_connector, _comms.Application(), persistentPath, _comms.SystemPath(), dataPath, volatilePath, _comms.AppPath(), _comms.ProxyStubPath(), _comms.PostMortemPath());
+                    RPC::Config config(_connector, _comms.Application(), persistentPath, downloadPath, _comms.SystemPath(), dataPath, volatilePath, _comms.AppPath(), _comms.ProxyStubPath(), _comms.PostMortemPath());
                     RPC::Object instance(libraryName, className, callsign, interfaceId, version, user, group, threads, priority, RPC::Object::HostType::LOCAL, linkLoaderPath, _T(""), configuration);
 
                     RPC::Process process(requestId, config, instance);
@@ -1926,6 +1936,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
                     *this, 
                     config.Communicator(), 
                     config.PersistentPath(), 
+                    config.DownloadPath(), 
                     config.SystemPath(), 
                     config.DataPath(), 
                     config.VolatilePath(), 
@@ -2091,9 +2102,9 @@ POP_WARNING()
                 return (result);
             }
 
-            void* Instantiate(const RPC::Object& object, const uint32_t waitTime, uint32_t& sessionId, const string& dataPath, const string& persistentPath, const string& volatilePath)
+            void* Instantiate(const RPC::Object& object, const uint32_t waitTime, uint32_t& sessionId, const string& dataPath, const string& persistentPath, const string& downloadPath, const string& volatilePath)
             {
-                return (_processAdministrator.Create(sessionId, object, waitTime, dataPath, persistentPath, volatilePath));
+                return (_processAdministrator.Create(sessionId, object, waitTime, dataPath, persistentPath, downloadPath, volatilePath));
             }
             void Destroy(const uint32_t id) {
                 _processAdministrator.Destroy(id);

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -217,6 +217,7 @@ namespace RPC {
             : _connector()
             , _hostApplication()
             , _persistent()
+            , _download()
             , _system()
             , _data()
             , _volatile()
@@ -229,6 +230,7 @@ namespace RPC {
             const string& connector,
             const string& hostApplication,
             const string& persistentPath,
+            const string& downloadPath,
             const string& systemPath,
             const string& dataPath,
             const string& volatilePath,
@@ -238,6 +240,7 @@ namespace RPC {
             : _connector(connector)
             , _hostApplication(hostApplication)
             , _persistent(persistentPath)
+            , _download(downloadPath)
             , _system(systemPath)
             , _data(dataPath)
             , _volatile(volatilePath)
@@ -250,6 +253,7 @@ namespace RPC {
             : _connector(copy._connector)
             , _hostApplication(copy._hostApplication)
             , _persistent(copy._persistent)
+            , _download(copy._download)
             , _system(copy._system)
             , _data(copy._data)
             , _volatile(copy._volatile)
@@ -274,6 +278,10 @@ namespace RPC {
         inline const string& PersistentPath() const
         {
             return (_persistent);
+        }
+        inline const string& DownloadPath() const
+        {
+            return (_download);
         }
         inline const string& SystemPath() const
         {
@@ -304,6 +312,7 @@ namespace RPC {
         string _connector;
         string _hostApplication;
         string _persistent;
+        string _download;
         string _system;
         string _data;
         string _volatile;
@@ -343,6 +352,9 @@ namespace RPC {
             }
             if (config.PersistentPath().empty() == false) {
                 _options.Add(_T("-p")).Add('"' + config.PersistentPath() + '"');
+            }
+            if (config.DownloadPath().empty() == false) {
+                _options.Add(_T("-D")).Add('"' + config.DownloadPath() + '"');
             }
             if (config.SystemPath().empty() == false) {
                 _options.Add(_T("-s")).Add('"' + config.SystemPath() + '"');
@@ -612,10 +624,11 @@ namespace RPC {
             {
                 ProcessContainers::IContainerAdministrator& admin = ProcessContainers::IContainerAdministrator::Instance();
 
-                std::vector<string> searchpaths(3);
+                std::vector<string> searchpaths(4);
                 searchpaths[0] = baseConfig.VolatilePath();
-                searchpaths[1] = baseConfig.PersistentPath();
-                searchpaths[2] = baseConfig.DataPath();
+                searchpaths[1] = baseConfig.DownloadPath();
+                searchpaths[2] = baseConfig.PersistentPath();
+                searchpaths[3] = baseConfig.DataPath();
 
 #ifdef __DEBUG__
                 ContainerConfig config;

--- a/Source/plugins/Service.h
+++ b/Source/plugins/Service.h
@@ -38,11 +38,12 @@ namespace PluginHost {
             Config(const Config&) = delete;
             Config& operator=(const Config&) = delete;
 
-            Config(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& dataPath, const string& volatilePath)
+            Config(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& downloadPath, const string& dataPath, const string& volatilePath)
             {
                 const string& callSign(plugin.Callsign.Value());
 
                 _webPrefix = webPrefix + '/' + callSign;
+                _downloadPath = downloadPath + callSign + '/';
                 _persistentPath = plugin.PersistentPath(persistentPath);
                 _dataPath = plugin.DataPath(dataPath);
                 _volatilePath = plugin.VolatilePath(volatilePath);
@@ -85,6 +86,14 @@ namespace PluginHost {
             inline const string& PersistentPath() const
             {
                 return (_persistentPath);
+            }
+
+            // DownloadPath is a path to a location where the plugin instance can store data needed
+            // by the plugin instance, hence why the callSign is included. .
+            // This path is build up from: DownloadPath / callSign /
+            inline const string& DownloadPath() const
+            {
+                return (_downloadPath);
             }
 
             // VolatilePath is a path to a location where the plugin instance can store data needed
@@ -132,6 +141,7 @@ namespace PluginHost {
 
             string _webPrefix;
             string _persistentPath;
+            string _downloadPath;
             string _volatilePath;
             string _dataPath;
             string _accessor;
@@ -146,14 +156,14 @@ namespace PluginHost {
         Service(const Service&) = delete;
         Service& operator=(const Service&) = delete;
 
-        Service(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& dataPath, const string& volatilePath)
+        Service(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& downloadPath, const string& dataPath, const string& volatilePath)
             : _adminLock()
             #if THUNDER_RUNTIME_STATISTICS
             , _processedRequests(0)
             , _processedObjects(0)
             #endif
             , _state(DEACTIVATED)
-            , _config(plugin, webPrefix, persistentPath, dataPath, volatilePath)
+            , _config(plugin, webPrefix, persistentPath, downloadPath,  dataPath, volatilePath)
             #if THUNDER_RESTFULL_API
             , _notifiers()
             #endif
@@ -213,6 +223,10 @@ namespace PluginHost {
         string PersistentPath() const override
         {
             return (_config.PersistentPath());
+        }
+        string DownloadPath() const 
+        {
+            return (_config.DownloadPath());
         }
         string VolatilePath() const override
         {


### PR DESCRIPTION
…ersistentPath.

The new functionality from the Packager (downloadable plugins) requires that a new location should be serached for plugins (the plugin binary) as well for starting that later installed plugin. The DoenloadPath allows for this to be indicated. Set the DownloadPath ("downloadpath":) in the /etc/WPEFramework/config.json file to search this path for a potential plugin.