### PR TITLE
[DOWNLOADPATH] Add an additional path with the same sematics as the P…

### DIFF
--- a/Source/WPEFramework/Config.h
+++ b/Source/WPEFramework/Config.h
@@ -53,6 +53,9 @@ namespace PluginHost {
                 _variables.insert(std::make_pair("volatilepath", [](const Config& config, const Plugin::Config* info) {
                     return (info == nullptr ? config.VolatilePath() : info->VolatilePath(config.VolatilePath()));
                 }));
+                _variables.insert(std::make_pair("downloadpath", [](const Config& config, const Plugin::Config*) {
+                    return (config.DownloadPath());
+                }));
                 _variables.insert(std::make_pair("proxystubpath", [](const Config& config, const Plugin::Config*) {
                     return (config.ProxyStubPath());
                 }));
@@ -294,6 +297,7 @@ namespace PluginHost {
                 , Prefix(_T("Service"))
                 , JSONRPC(_T("jsonrpc"))
                 , PersistentPath()
+                , DownloadPath()
                 , DataPath()
                 , SystemPath()
 #ifdef __WINDOWS__
@@ -333,6 +337,7 @@ namespace PluginHost {
                 Add(_T("interface"), &Interface);
                 Add(_T("prefix"), &Prefix);
                 Add(_T("persistentpath"), &PersistentPath);
+                Add(_T("downloadpath"), &DownloadPath);
                 Add(_T("datapath"), &DataPath);
                 Add(_T("systempath"), &SystemPath);
                 Add(_T("volatilepath"), &VolatilePath);
@@ -368,6 +373,7 @@ namespace PluginHost {
             Core::JSON::String Prefix;
             Core::JSON::String JSONRPC;
             Core::JSON::String PersistentPath;
+            Core::JSON::String DownloadPath;
             Core::JSON::String DataPath;
             Core::JSON::String SystemPath;
             Core::JSON::String VolatilePath;
@@ -519,6 +525,7 @@ namespace PluginHost {
 #endif
                 _volatilePath = Core::Directory::Normalize(config.VolatilePath.Value());
                 _persistentPath = Core::Directory::Normalize(config.PersistentPath.Value());
+                _downloadPath = Core::Directory::Normalize(config.DownloadPath.Value());
                 _dataPath = Core::Directory::Normalize(config.DataPath.Value());
                 _systemPath = Core::Directory::Normalize(config.SystemPath.Value());
                 _configsPath = Core::Directory::Normalize(config.Configs.Value());
@@ -637,6 +644,10 @@ namespace PluginHost {
         inline const string& PersistentPath() const
         {
             return (_persistentPath);
+        }
+        inline const string& DownloadPath() const
+        {
+            return (_downloadPath);
         }
         inline const string& DataPath() const
         {
@@ -831,6 +842,7 @@ namespace PluginHost {
         string _JSONRPCPrefix;
         string _volatilePath;
         string _persistentPath;
+        string _downloadPath;
         string _dataPath;
         string _hashKey;
         string _appPath;

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -207,6 +207,7 @@ namespace RPC {
             : _connector()
             , _hostApplication()
             , _persistent()
+            , _download()
             , _system()
             , _data()
             , _volatile()
@@ -219,6 +220,7 @@ namespace RPC {
             const string& connector,
             const string& hostApplication,
             const string& persistentPath,
+            const string& downloadPath,
             const string& systemPath,
             const string& dataPath,
             const string& volatilePath,
@@ -228,6 +230,7 @@ namespace RPC {
             : _connector(connector)
             , _hostApplication(hostApplication)
             , _persistent(persistentPath)
+            , _download(downloadPath)
             , _system(systemPath)
             , _data(dataPath)
             , _volatile(volatilePath)
@@ -240,6 +243,7 @@ namespace RPC {
             : _connector(copy._connector)
             , _hostApplication(copy._hostApplication)
             , _persistent(copy._persistent)
+            , _download(copy._download)
             , _system(copy._system)
             , _data(copy._data)
             , _volatile(copy._volatile)
@@ -264,6 +268,10 @@ namespace RPC {
         inline const string& PersistentPath() const
         {
             return (_persistent);
+        }
+        inline const string& DownloadPath() const
+        {
+            return (_download);
         }
         inline const string& SystemPath() const
         {
@@ -295,6 +303,7 @@ namespace RPC {
         string _connector;
         string _hostApplication;
         string _persistent;
+        string _download;
         string _system;
         string _data;
         string _volatile;
@@ -335,6 +344,9 @@ namespace RPC {
             }
             if (config.PersistentPath().empty() == false) {
                 _options.Add(_T("-p")).Add('"' + config.PersistentPath() + '"');
+            }
+            if (config.DownloadPath().empty() == false) {
+                _options.Add(_T("-D")).Add('"' + config.DownloadPath() + '"');
             }
             if (config.SystemPath().empty() == false) {
                 _options.Add(_T("-s")).Add('"' + config.SystemPath() + '"');
@@ -604,10 +616,11 @@ namespace RPC {
             {
                 ProcessContainers::IContainerAdministrator& admin = ProcessContainers::IContainerAdministrator::Instance();
 
-                std::vector<string> searchpaths(3);
+                std::vector<string> searchpaths(4);
                 searchpaths[0] = baseConfig.VolatilePath();
-                searchpaths[1] = baseConfig.PersistentPath();
-                searchpaths[2] = baseConfig.DataPath();
+                searchpaths[1] = baseConfig.DownloadPath();
+                searchpaths[2] = baseConfig.PersistentPath();
+                searchpaths[3] = baseConfig.DataPath();
 
 #ifdef __DEBUG__
                 ContainerConfig config;

--- a/Source/plugins/Service.h
+++ b/Source/plugins/Service.h
@@ -38,11 +38,12 @@ namespace PluginHost {
             Config(const Config&) = delete;
             Config& operator=(const Config&) = delete;
 
-            Config(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& dataPath, const string& volatilePath)
+            Config(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& downloadPath, const string& dataPath, const string& volatilePath)
             {
                 const string& callSign(plugin.Callsign.Value());
 
                 _webPrefix = webPrefix + '/' + callSign;
+                _downloadPath = downloadPath + callSign + '/';
                 _persistentPath = plugin.PersistentPath(persistentPath);
                 _dataPath = plugin.DataPath(dataPath);
                 _volatilePath = plugin.VolatilePath(volatilePath);
@@ -85,6 +86,14 @@ namespace PluginHost {
             inline const string& PersistentPath() const
             {
                 return (_persistentPath);
+            }
+
+            // DownloadPath is a path to a location where the plugin instance can store data needed
+            // by the plugin instance, hence why the callSign is included. .
+            // This path is build up from: DownloadPath / callSign /
+            inline const string& DownloadPath() const
+            {
+                return (_downloadPath);
             }
 
             // VolatilePath is a path to a location where the plugin instance can store data needed
@@ -132,6 +141,7 @@ namespace PluginHost {
 
             string _webPrefix;
             string _persistentPath;
+            string _downloadPath;
             string _volatilePath;
             string _dataPath;
             string _accessor;
@@ -146,14 +156,14 @@ namespace PluginHost {
         Service(const Service&) = delete;
         Service& operator=(const Service&) = delete;
 
-        Service(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& dataPath, const string& volatilePath)
+        Service(const Plugin::Config& plugin, const string& webPrefix, const string& persistentPath, const string& downloadPath, const string& dataPath, const string& volatilePath)
             : _adminLock()
             #if THUNDER_RUNTIME_STATISTICS
             , _processedRequests(0)
             , _processedObjects(0)
             #endif
             , _state(DEACTIVATED)
-            , _config(plugin, webPrefix, persistentPath, dataPath, volatilePath)
+            , _config(plugin, webPrefix, persistentPath, downloadPath,  dataPath, volatilePath)
             #if THUNDER_RESTFULL_API
             , _notifiers()
             #endif
@@ -217,6 +227,10 @@ namespace PluginHost {
         string PersistentPath() const override
         {
             return (_config.PersistentPath());
+        }
+        string DownloadPath() const 
+        {
+            return (_config.DownloadPath());
         }
         string VolatilePath() const override
         {


### PR DESCRIPTION
…ersistentPath.

The new functionality from the Packager (downloadable plugins) requires that a new location should be serached for plugins (the plugin binary) as well for starting that later installed plugin. The DoenloadPath allows for this to be indicated. Set the DownloadPath ("downloadpath":) in the /etc/WPEFramework/config.json file to search this path for a potential plugin.