### PR TITLE
RDKDEV-346: Plugin startup-order support

### DIFF
--- a/cmake/project.cmake.in
+++ b/cmake/project.cmake.in
@@ -137,6 +137,10 @@ macro(write_config)
                 map_append(${plugin_config} resumed ${resumed})
             endif()
 
+            if (NOT ${startuporder} STREQUAL "")
+                map_append(${plugin_config} startuporder ${startuporder})
+            endif()
+
             if (NOT ${configuration} STREQUAL "")
                 map_append(${plugin_config} configuration ${configuration})
             endif()


### PR DESCRIPTION
Reason for change: Adding plugin startup order support in write_config which will take from Plugin.config map. This is required for https://github.com/rdkcentral/rdkservices/pull/3185
Test Procedure: Please see ticket for details.
Risks: Medium
Source: Comcast
License: Inherited
Upstream-Status: Pending

Signed-off-by: Arun Madhavan <arun_madhavan@comcast.com>