### PR TITLE
Core: Remove unrightful ASSERT

### DIFF
--- a/Source/core/MessageDispatcher.h
+++ b/Source/core/MessageDispatcher.h
@@ -266,8 +266,6 @@ namespace Core {
          */
         uint32_t PopData(uint16_t& outLength, uint8_t* outValue)
         {
-            ASSERT(_dataBuffer.IsValid());
-
             _dataLock.Lock();
             uint32_t result = Core::ERROR_READ_ERROR;
 


### PR DESCRIPTION
This ASSERT is not valid as far as I can a see. In the [```Validate```](https://github.com/rdkcentral/Thunder/blob/master/Source/core/CyclicBuffer.cpp#L159-L164) the ```_administration``` is assigned if its a ```nullptr```. 