### PR TITLE
DELIA-58171: use CLOCK_MONOTONIC for sem_clockwait

### DIFF
--- a/Source/core/SharedBuffer.cpp
+++ b/Source/core/SharedBuffer.cpp
@@ -103,7 +103,11 @@ namespace Core {
 
         struct timespec structTime;
 
+#if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+        clock_gettime(CLOCK_MONOTONIC, &structTime);
+#else
         clock_gettime(CLOCK_REALTIME, &structTime);
+#endif
         structTime.tv_nsec += ((waitTime % 1000) * 1000 * 1000); /* remainder, milliseconds to nanoseconds */
         structTime.tv_sec += (waitTime / 1000) + (structTime.tv_nsec / 1000000000); /* milliseconds to seconds */
         structTime.tv_nsec = structTime.tv_nsec % 1000000000;
@@ -111,7 +115,11 @@ namespace Core {
         // MF2018 please note: sem_timedwait is not compatible with CLOCK_MONOTONIC.
         //                     When used with CLOCK_REALTIME do not use this when the system time can make large jumps (so when Time subsystem is not yet up)
         do {
+#if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+            if (sem_clockwait(_semaphore, CLOCK_MONOTONIC, &structTime) == 0) {
+#else
             if (sem_timedwait(_semaphore, &structTime) == 0) {
+#endif
                 result = Core::ERROR_NONE;
             }
             else if ( errno == EINTR ) {


### PR DESCRIPTION
Reason for change: use CLOCK_MONOTONIC for sem_clockwait
sem_clockwait is only available from glibc 2.30 and above.  Hence added glibc version checking.
arris-xg1v3 & pace-xg1v3 are with glibc 2.24
Test Procedure: Build and verify.
Risks: low
Signed-off-by:Zameerun Rasheed M S <zmamoo711@cable.comcast.com>