### PR TITLE
[JSONRPCLINK] Make sure all resources are cleared at destruction.

### DIFF
--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -792,7 +792,12 @@ POP_WARNING()
                 // And did we succeed ?
                 return (l_Index != PROXY_LIST_ERROR);
             }
-
+            void Clear() {
+                for (unsigned int teller = 0; teller != m_Current; teller++) {
+                    m_List[teller]->Release();
+                }
+                m_Current = 0;
+            }
             void Clear(const unsigned int a_Start, const unsigned int a_Count)
             {
                 ASSERT((a_Start + a_Count) <= m_Current);

--- a/Source/core/StreamJSON.h
+++ b/Source/core/StreamJSON.h
@@ -46,6 +46,7 @@ namespace Core {
             }
             ~SerializerImpl()
             {
+                _sendQueue.Clear();
             }
 
         public:
@@ -149,7 +150,6 @@ namespace Core {
                 return (loaded);
             }
 
-
         private:
             inline uint16_t Deserialize(const Core::ProxyType<Core::JSON::IElement>& source, const uint8_t* stream, const uint16_t length) {
                 return(source->Deserialize(reinterpret_cast<const char*>(stream), length, _offset));
@@ -234,8 +234,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
         }
 POP_WARNING()
 
-        virtual ~StreamJSONType()
-        {
+        virtual ~StreamJSONType() {
             _channel.Close(Core::infinite);
         }
 

--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -498,6 +498,10 @@ namespace WPEFramework {
 			virtual ~LinkType()
 			{
 				_channel->Unregister(*this);
+
+				for (auto& element : _pendingQueue) {
+					element.second.Abort(element.first);
+				}
 			}
 
 		public:


### PR DESCRIPTION
And while testing we ran into a deadlock (abba) resolved it by moving status retrieval through atomic reporting. This locking was part of the Helgrind fixes (by locking) now moving to the atomic.