### PR TITLE
[SMARTLINKTYPE] Avoid a double registration of the Notification from …

### DIFF
--- a/Source/websocket/WebSocketLink.h
+++ b/Source/websocket/WebSocketLink.h
@@ -1168,7 +1168,7 @@ POP_WARNING()
         }
         bool IsOpen() const
         {
-            return (_channel.IsOpen());
+            return ( (_channel.IsOpen()) && (_channel.IsWebSocket()) );
         }
         bool IsClosed() const
         {


### PR DESCRIPTION
…the SmartClient.

As the WebSocket consists of two phase process (HTTPSocket -> [UPGRADE] -> WebSocket) we got two opens, which triggered two times the Open call on the Opened. This patch will only report Open if it is "really" open (a fullfledged WebSocket).