### PR TITLE
[JSON] Parsing error incorrectly set on none quoted simple types.

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1847,7 +1847,7 @@ namespace Core {
                         else if ((_flagsAndCounters & 0x1F) == 0) {
                             // If we did not open an object, the only thing we allow are whitespaces as they can 
                             // always be dropped!
-                            finished = (((_flagsAndCounters & EscapeFoundBit) == 0) && ((current == ',') || (current == '}') || (current == ']')));
+                            finished = (((_flagsAndCounters & EscapeFoundBit) == 0) && ((current == ',') || (current == '}') || (current == ']') || (current = '\0')));
                         }
                         else if (current == '}') {
                             if (OutScope(ScopeBracket::CURLY_BRACKET) == false) {

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1847,7 +1847,7 @@ namespace Core {
                         else if ((_flagsAndCounters & 0x1F) == 0) {
                             // If we did not open an object, the only thing we allow are whitespaces as they can 
                             // always be dropped!
-                            finished = (((_flagsAndCounters & EscapeFoundBit) == 0) && ((current == ',') || (current == '}') || (current == ']') || (current = '\0')));
+                            finished = (((_flagsAndCounters & EscapeFoundBit) == 0) && ((current == ',') || (current == '}') || (current == ']') || (current == '\0')));
                         }
                         else if (current == '}') {
                             if (OutScope(ScopeBracket::CURLY_BRACKET) == false) {


### PR DESCRIPTION
In the JSONRPC message, one can return "result": 0 to indicate that the registartion request iver JSONRPC succeeded, erro code0. However before this fix, the result was expected to be quoted, an array or object. No we also assume that plain results are oke.