### PR TITLE
RDKSEC-71 Build failure in wpeframework recipe while adding distro fe…

### DIFF
--- a/Source/processcontainers/CMakeLists.txt
+++ b/Source/processcontainers/CMakeLists.txt
@@ -106,9 +106,14 @@ elseif (PROCESSCONTAINERS_CRUN)
 elseif (PROCESSCONTAINERS_DOBBY)
         find_package(Dobby REQUIRED CONFIG)
 
+        find_library(SYSTEMD_LIBRARIES
+	        NAMES systemd
+        )
+
         target_link_libraries(${TARGET}
                 PRIVATE
                 DobbyClientLib
+                ${SYSTEMD_LIBRARIES}
         )
 elseif (PROCESSCONTAINERS_AWC)
         find_package(LXC REQUIRED)


### PR DESCRIPTION
…ature for DOBBY_CONTAINERS

(| Source/processcontainers/libWPEFrameworkProcessContainers.so.2.1.11: error: undefined reference to 'sd_bus_message_read_array' | Source/processcontainers/libWPEFrameworkProcessContainers.so.2.1.11: error: undefined reference to 'sd_bus_message_skip' | Source/processcontainers/libWPEFrameworkProcessContainers.so.2.1.11: error: undefined reference to 'sd_bus_message_peek_type' | Source/processcontainers/libWPEFrameworkProcessContainers.so.2.1.11: error: undefined reference to 'sd_bus_message_at_end' | Source/processcontainers/libWPEFrameworkProcessContainers.so.2.1.11: error: undefined reference to 'sd_bus_message_append_array)

Reason for change: Stable build
Test Procedure: None.
Risks: None.