### PR TITLE
RDKSEC-71 Build failure in wpeframework recipe while adding distro feature for DOBBY_CONTAINERS (#1095)

### DIFF
--- a/Source/processcontainers/CMakeLists.txt
+++ b/Source/processcontainers/CMakeLists.txt
@@ -106,9 +106,14 @@ elseif (PROCESSCONTAINERS_CRUN)
 elseif (PROCESSCONTAINERS_DOBBY)
         find_package(Dobby REQUIRED CONFIG)
 
+        find_library(SYSTEMD_LIBRARIES
+	        NAMES systemd
+        )
+
         target_link_libraries(${TARGET}
                 PRIVATE
                 DobbyClientLib
+                ${SYSTEMD_LIBRARIES}
         )
 elseif (PROCESSCONTAINERS_AWC)
         find_package(LXC REQUIRED)


### PR DESCRIPTION
RDKSEC-71 Build failure in wpeframework recipe while adding distro feature for DOBBY_CONTAINERS (#1095)