### PR TITLE
[STRESSTEST] Sending data on closed sockets terminates the WPEFramewo…

### DIFF
--- a/Source/core/Thread.cpp
+++ b/Source/core/Thread.cpp
@@ -150,6 +150,7 @@ POP_WARNING()
         sigset_t mask;
         sigemptyset(&mask);
         sigaddset(&mask, SIGTERM);
+        sigaddset(&mask, SIGPIPE);
         pthread_sigmask(SIG_BLOCK, &mask, nullptr);
 #endif
 


### PR DESCRIPTION
…rk process.

As we are strating to focus more and more on stress testing the system, it was observed that very rarly, if we are hard killing processes (out-of-process plugins), it was observed thet the WPEFrmework woiuld crash with a SIGPIPE. Code review and evaluation of the callstacks show that this can be caused by a race condition. If a process (out-of-process plugin) is killed using SIGTERM, the process might still have work "queued" in the WPEFrmework process for handling. Another process in WPEFrmework will detect that the child process is gone, and thus the COMRPC connection to it is closed as well. The work still queued might just after the close still try to send the data it produced, however this leads to a SIGPIPE signal and the write will return an error. The socketPort implementation is takiong care of the returned error (socket goed into an error state and will be closed) however the SIGPIPE was not handled. This commit will block the SIGPIPE, as the error result is handled, we are not interested in this signal.