### PR TITLE
[SINGLETON/64BITS] Fixes for 64Bits build on linux (warning)

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -346,7 +346,7 @@ namespace PluginHost
                 State(PRECONDITION);
 
 #ifdef __CORE_MESSAGING__
-                if (TRACE_ENABLED(Activity) == true) {
+                if (WPEFramework::Messaging::LocalLifetimeType<Activity, &WPEFramework::Core::System::MODULE_NAME, WPEFramework::Core::Messaging::Metadata::type::TRACING>::IsEnabled() == true) {
                     string feedback;
                     uint8_t index = 1;
                     uint32_t delta(_precondition.Delta(_administrator.SubSystemInfo()));

--- a/Source/core/MessageStore.cpp
+++ b/Source/core/MessageStore.cpp
@@ -117,13 +117,13 @@ namespace Core {
                 Core::FrameType<0>::Reader frameReader(frame, 0);
 
                 _type = frameReader.Number<type>();
+
+                _category = frameReader.NullTerminatedText();
+                _module = frameReader.NullTerminatedText();
+
                 ASSERT(_type != Metadata::type::INVALID);
 
-                if (_type != type::INVALID) {
-                    _category = frameReader.NullTerminatedText();
-                    _module = frameReader.NullTerminatedText();
-                    length = (sizeof(_type) + (static_cast<uint16_t>(_category.size()) + 1) + (static_cast<uint16_t>(_module.size()) + 1));
-                }
+                length = std::min<uint16_t>(bufferSize, static_cast<uint16_t>(sizeof(_type) + (static_cast<uint16_t>(_category.size()) + 1) + (static_cast<uint16_t>(_module.size()) + 1)));
             }
 
             return (length);

--- a/Source/core/Singleton.h
+++ b/Source/core/Singleton.h
@@ -134,7 +134,11 @@ namespace Core {
         }
 
         inline static SINGLETON& Instance() {
-            return (GetObject(TemplateIntToType<available::value>()));
+            // As available does not see through friend clas/protected 
+            // declarations, we can not rely on the output of it.
+            // If this Instance method id called, assume it has a
+            // default constructor..
+            return (GetObject(TemplateIntToType<true>()));
         }
 
         // The Create() and Dispose() methods should only be used if the lifetime of 

--- a/Source/core/Trace.h
+++ b/Source/core/Trace.h
@@ -64,11 +64,20 @@ namespace WPEFramework {
         fflush(stderr);                                                                                                                 \
     } while (0)
 #else
+#if INTPTR_MAX == INT64_MAX
+#define TRACE_FORMATTING_IMPL(fmt, ...)                                                                                                     \
+    do {                                                                                                                                    \
+        ::fprintf(stderr, "\033[1;32m[%s:%d](%s)<PID:%d><TID:%ld>" fmt "\n\033[0m", &__FILE__[WPEFramework::Core::FileNameOffset(__FILE__)], __LINE__, __FUNCTION__, TRACE_PROCESS_ID, TRACE_THREAD_ID, ##__VA_ARGS__);  \
+        fflush(stderr);                                                                                                                     \
+    } while (0)
+#else
 #define TRACE_FORMATTING_IMPL(fmt, ...)                                                                                                     \
     do {                                                                                                                                    \
         ::fprintf(stderr, "\033[1;32m[%s:%d](%s)<PID:%d><TID:%d>" fmt "\n\033[0m", &__FILE__[WPEFramework::Core::FileNameOffset(__FILE__)], __LINE__, __FUNCTION__, TRACE_PROCESS_ID, TRACE_THREAD_ID, ##__VA_ARGS__);  \
-        fflush(stderr);                                                                                                                 \
+        fflush(stderr);                                                                                                                     \
     } while (0)
+#endif
+#
 #endif
 
 #if defined(CORE_TRACE_NOT_ALLOWED) && !defined(__WINDOWS__) 


### PR DESCRIPTION
is_default_constructible is behaving differently in the STL libraries of windows than it is on linux (and I think Windows is right here :-) . Temporary disabled the use of is_default_constructible in linux and windows.