### PR TITLE
Logging: Add module name to logs

### DIFF
--- a/Source/tracing/Logging.cpp
+++ b/Source/tracing/Logging.cpp
@@ -65,11 +65,11 @@ namespace Logging {
 #ifndef __WINDOWS__
         if (_syslogging == true) {
             string time(now.ToRFC1123(true));
-            syslog(LOG_NOTICE, "[%s]:[%s:%d]: %s: %s\n", time.c_str(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
+            syslog(LOG_NOTICE, "[%s]:[%s]:[%s:%d]: %s: %s\n", time.c_str(), information->Module(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
         } else
 #endif
         {
-            printf("[%11ju us] %s\n", static_cast<uintmax_t>(now.Ticks() - _baseTime), information->Data());
+            printf("[%11ju us]:[%s]:[%s:%d]: %s: %s\n", static_cast<uintmax_t>(now.Ticks() - _baseTime), information->Module(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
         }
     }
 


### PR DESCRIPTION
The current implementation of the TraceControl plugin won't output the origin of the trace.

With this commit, the resulting log message will have the form: 

`[<time>]:[<module-name>]:[<file-name:line-number>] <log-category>: <data>`

This would allow for easier handling of log messages in a scenario where multiple plugins have their tracing flag enabled at the same time.

This change is targeting only the non-abbreviated form of the logs, as the understanding is that adding the module name would make it "less abbreviated".

To capture syslog messages for a given module, use `journalctl |grep <module-name>`.