### PR TITLE
Controller: Allow configuring if the UI is enabled or not

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -111,7 +111,11 @@ namespace Plugin {
 
         _service->Register(&_systemInfoReport);
 
-        _service->EnableWebServer(_T("UI"), EMPTY_STRING);
+        if ((config.Ui.IsSet() == true) && (config.Ui.Value() == true)) {
+            _service->EnableWebServer(_T("UI"), EMPTY_STRING);
+        } else {
+            _service->DisableWebServer();
+        }
 
         // On succes return a name as a Callsign to be used in the URL, after the "service"prefix
         return (_T(""));

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -142,10 +142,12 @@ namespace Plugin {
                 , Probe()
                 , Resumes()
                 , SubSystems()
+                , Ui(true)
             {
                 Add(_T("probe"), &Probe);
                 Add(_T("resumes"), &Resumes);
                 Add(_T("subsystems"), &SubSystems);
+                Add(_T("ui"), &Ui);
             }
             ~Config()
             {
@@ -155,6 +157,7 @@ namespace Plugin {
             ProbeConfig Probe;
             Core::JSON::ArrayType<Core::JSON::String> Resumes;
             Core::JSON::ArrayType<Core::JSON::EnumType<PluginHost::ISubSystem::subsystem>> SubSystems;
+            Core::JSON::Boolean Ui;
         };
 
     private:

--- a/Source/WPEFramework/GenericConfig.cmake
+++ b/Source/WPEFramework/GenericConfig.cmake
@@ -38,6 +38,9 @@ set(KEY_OUTPUT_DISABLED false CACHE STRING "New outputs on the VirtualInput will
 set(EXIT_REASONS "Failure;MemoryExceeded;WatchdogExpired" CACHE STRING "Process exit reason list for which the postmortem is required")
 set(ETHERNETCARD_NAME "" CACHE STRING "Ethernet Card name which has to be associated for the Raw Device Id creation")
 
+# Controller Plugin Settings.
+set(PLUGIN_CONTROLLER_UI_ENABLED true CACHE STRING "Enable the Controller's UI")
+
 map()
   key(plugins)
   key(tracing)
@@ -84,6 +87,7 @@ ans(PLUGIN_CONTROLLER)
 map()
     kv(subsystems)
     key(resumes)
+    kv(ui ${PLUGIN_CONTROLLER_UI_ENABLED})
 end()
 ans(PLUGIN_CONTROLLER_CONFIGURATION)
 


### PR DESCRIPTION
Currently, the Controller's UI, serving as base for the Thunder UI, is enabled by default, without allowing a configuration option to disable it.

Since having the Controller's UI enabled requires Web Servicing (accepting and responding to HTTP requests) and that might bring security concerns, and also considering that the UI is mostly for development/debug, add a way to configure the Controller to have the UI disabled.

This way, add a cmake boolean option (`PLUGIN_CONTROLLER_UI_ENABLED`) which, when set to `false`, disables the Controller's UI. Set the new option as `true` by default, enabling the UI by default, for keeping backwards compatibility.

Tested by:
* Confirming the JSON generation for the Controller plugin succeeds in both the cases of Thunder UI enabled and disabled.
* Confirming the Thunder UI is still enabled by default.
* Confirming that, when the Thunder UI is disabled, even though the web server still responds (it is expected), it never actually tries to serve a file by using gdb and confirming that `PluginHost::Server::Service::Evaluate()`, which is the method that processes the requests, will never call `PluginHost::Server::Service::FileToServe()` in this case, and this is the only method that could actually leak some file out.

RDKDEV-458