### PR TITLE
RDKTV-19382 : Change QualifiedName() to HostAddress()

### DIFF
--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -180,11 +180,11 @@ namespace WPEFramework {
             }
             inline string LocalId() const
             {
-                return (m_LocalNode.QualifiedName());
+                return (m_LocalNode.HostAddress());
             }
             inline string RemoteId() const
             {
-                return (m_RemoteNode.QualifiedName());
+                return (m_RemoteNode.HostAddress());
             }
             inline const NodeId& ReceivedNode() const
             {


### PR DESCRIPTION
Reason for change: Avoiding WebProcess to become unresponsive due to getnameinfo timeout
Test Procedure: See Jira Ticket
Risks: Low
Signed-off-by: Karthick S karthick_s@comcast.com