### PR TITLE
[LEAKS] Add  notification if a potential leak (dengling proxy) is det…

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -215,7 +215,7 @@ namespace PluginHost
     {
         _adminLock.Lock();
 
-        std::map<const string, Core::ProxyType<Service>>::iterator index(_services.begin());
+        ServiceContainer::iterator index(_services.begin());
         std::list< Core::ProxyType<Service> > deactivationList;
 
         // First, move them all to deactivated except Controller

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -1534,17 +1534,18 @@ namespace PluginHost {
                 private:
                     friend class Core::Service<RemoteHost>;
 
+                public:
+                    RemoteHost(RemoteHost&&) = delete;
                     RemoteHost(const RemoteHost&) = delete;
                     RemoteHost& operator=(const RemoteHost&) = delete;
 
-                public:
                     RemoteHost(const RPC::Object& instance, const RPC::Config& config)
                         : RemoteConnection()
                         , _object(instance)
                         , _config(config)
                     {
                     }
-                    virtual ~RemoteHost()
+                    ~RemoteHost() override
                     {
                         TRACE_L1("Destructor for RemoteHost process for %d", Id());
                     }
@@ -1802,15 +1803,17 @@ namespace PluginHost {
                     return (_parent.Acquire(interfaceId, className, version));
                 }
 
-                void Cleanup(const Core::IUnknown* source, const uint32_t interfaceId) override
+                void Dangling(const Core::IUnknown* source, const uint32_t interfaceId) override
                 {
                     _adminLock.Lock();
 
                     for (auto& observer : _requestObservers) {
-                        observer->CleanedUp(source, interfaceId);
+                        observer->Dangling(source, interfaceId);
                     }
 
                     _adminLock.Unlock();
+
+                    TRACE(Activity, (T("Dangling resource cleanup of interface: 0x%X"), interfaceId));
                 }
 
                 void Revoke(const Core::IUnknown* remote, const uint32_t interfaceId) override

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -1522,13 +1522,15 @@ namespace PluginHost {
 
         class ServiceMap {
         public:
-            using Iterator = Core::IteratorMapType<std::map<const string, Core::ProxyType<Service>>, Core::ProxyType<Service>, const string&>;
+            using ServiceContainer = std::map<const string, Core::ProxyType<Service>>;
+            using Notifiers = std::vector<PluginHost::IPlugin::INotification*>;
+            using Iterator = Core::IteratorMapType<ServiceContainer, Core::ProxyType<Service>, const string&>;
             using RemoteInstantiators = std::map<const string, IRemoteInstantiation*>;
 
         private:
             class CommunicatorServer : public RPC::Communicator {
             private:
-                using ObserverList = std::list<IShell::ICOMLink::INotification*>;
+                using Observers = std::vector<IShell::ICOMLink::INotification*>;
 
                 class RemoteHost : public RPC::Communicator::RemoteConnection {
                 private:
@@ -1672,10 +1674,12 @@ namespace PluginHost {
                 virtual ~CommunicatorServer()
                 {
                     ASSERT(_requestObservers.size() == 0 && "Sink for ICOMLink::INotifications not unregistered!");
-                    while (_requestObservers.size() != 0) {
-                        _requestObservers.front()->Release();
-                        _requestObservers.pop_front();
+                    Observers::iterator index(_requestObservers.begin());
+                    while (index != _requestObservers.end()) {
+                        (*index)->Release();
+                        index++;
                     }
+                    _requestObservers.clear();
                 }
 
             public:
@@ -1731,7 +1735,7 @@ namespace PluginHost {
 
                         _adminLock.Lock();
 
-                        ObserverList::iterator index = std::find(_requestObservers.begin(), _requestObservers.end(), sink);
+                        Observers::iterator index = std::find(_requestObservers.begin(), _requestObservers.end(), sink);
 
                         ASSERT(index == _requestObservers.end());
 
@@ -1751,7 +1755,7 @@ namespace PluginHost {
 
                         _adminLock.Lock();
 
-                        ObserverList::iterator index = std::find(_requestObservers.begin(), _requestObservers.end(), sink);
+                        Observers::iterator index = std::find(_requestObservers.begin(), _requestObservers.end(), sink);
 
                         ASSERT(index != _requestObservers.end());
 
@@ -1813,7 +1817,7 @@ namespace PluginHost {
 
                     _adminLock.Unlock();
 
-                    TRACE(Activity, (T("Dangling resource cleanup of interface: 0x%X"), interfaceId));
+                    TRACE(Activity, (_T("Dangling resource cleanup of interface: 0x%X"), interfaceId));
                 }
 
                 void Revoke(const Core::IUnknown* remote, const uint32_t interfaceId) override
@@ -1847,7 +1851,7 @@ namespace PluginHost {
                 const string _postMortemPath;
                 const string _application;
                 mutable Core::CriticalSection _adminLock;
-                ObserverList _requestObservers;
+                Observers _requestObservers;
                 ProxyStubObserver _proxyStubObserver;
             };
             class RemoteInstantiation : public IRemoteInstantiation {
@@ -2130,11 +2134,11 @@ POP_WARNING()
             {
                 _notificationLock.Lock();
 
-                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+                Notifiers::iterator index(_notifiers.begin());
 
-                while (currentlist.size()) {
-                    currentlist.front()->Initialize(callsign, entry);
-                    currentlist.pop_front();
+                while (index != _notifiers.end()) {
+                    (*index)->Initialize(callsign, entry);
+                    index++;
                 }
 
                 _notificationLock.Unlock();
@@ -2143,11 +2147,11 @@ POP_WARNING()
             {
                 _notificationLock.Lock();
 
-                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+                Notifiers::iterator index(_notifiers.begin());
 
-                while (currentlist.size()) {
-                    currentlist.front()->Activated(callsign, entry);
-                    currentlist.pop_front();
+                while (index != _notifiers.end()) {
+                    (*index)->Activated(callsign, entry);
+                    index++;
                 }
 
                 _notificationLock.Unlock();
@@ -2157,11 +2161,11 @@ POP_WARNING()
             {
                 _notificationLock.Lock();
 
-                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+                Notifiers::iterator index(_notifiers.begin());
 
-                while (currentlist.size()) {
-                    currentlist.front()->Deactivated(callsign, entry);
-                    currentlist.pop_front();
+                while (index != _notifiers.end()) {
+                    (*index)->Deactivated(callsign, entry);
+                    index++;
                 }
 
                 _notificationLock.Unlock();
@@ -2171,11 +2175,11 @@ POP_WARNING()
             {
                 _notificationLock.Lock();
 
-                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+                Notifiers::iterator index(_notifiers.begin());
 
-                while (currentlist.size()) {
-                    currentlist.front()->Deinitialized(callsign, entry);
-                    currentlist.pop_front();
+                while (index != _notifiers.end()) {
+                    (*index)->Deinitialized(callsign, entry);
+                    index++;
                 }
 
                 _notificationLock.Unlock();
@@ -2185,11 +2189,11 @@ POP_WARNING()
             {
                 _notificationLock.Lock();
 
-                std::list<PluginHost::IPlugin::INotification*> currentlist(_notifiers);
+                Notifiers::iterator index(_notifiers.begin());
 
-                while (currentlist.size()) {
-                    currentlist.front()->Unavailable(callsign, entry);
-                    currentlist.pop_front();
+                while (index != _notifiers.end()) {
+                    (*index)->Unavailable(callsign, entry);
+                    index++;
                 }
 
                 _notificationLock.Unlock();
@@ -2204,7 +2208,7 @@ POP_WARNING()
                 _notifiers.push_back(sink);
 
                 // Tell this "new" sink all our actived plugins..
-                std::map<const string, Core::ProxyType<Service>>::iterator index(_services.begin());
+                ServiceContainer::iterator index(_services.begin());
 
                 // Notifty all plugins that we have sofar..
                 while (index != _services.end()) {
@@ -2227,7 +2231,7 @@ POP_WARNING()
             {
                 _notificationLock.Lock();
 
-                std::list<PluginHost::IPlugin::INotification*>::iterator index(std::find(_notifiers.begin(), _notifiers.end(), sink));
+                Notifiers::iterator index(std::find(_notifiers.begin(), _notifiers.end(), sink));
 
                 if (index != _notifiers.end()) {
                     (*index)->Release();
@@ -2284,7 +2288,7 @@ POP_WARNING()
                 _adminLock.Lock();
 
                 // First stop all services running ...
-                std::map<const string, Core::ProxyType<Service>>::iterator index(_services.begin());
+                ServiceContainer::iterator index(_services.begin());
 
                 while (index != _services.end()) {
                     index->second->Closed(id);
@@ -2343,7 +2347,7 @@ POP_WARNING()
                 _adminLock.Lock();
 
                 // First stop all services running ...
-                std::map<const string, Core::ProxyType<Service>>::iterator index(_services.find(callSign));
+                ServiceContainer::iterator index(_services.find(callSign));
 
                 if (index != _services.end()) {
                     index->second->Destroy();
@@ -2371,7 +2375,7 @@ POP_WARNING()
                 _adminLock.Lock();
 
                 std::list<Core::ProxyType<Service>> duplicates;
-                std::map<const string, Core::ProxyType<Service>>::const_iterator index(_services.begin());
+                ServiceContainer::const_iterator index(_services.begin());
 
                 while (index != _services.end()) {
                     duplicates.push_back(index->second);
@@ -2506,7 +2510,7 @@ POP_WARNING()
 
                 return (result);
             }
-            void RecursiveNotification(std::map<const string, Core::ProxyType<Service>>::iterator& index)
+            void RecursiveNotification(ServiceContainer::iterator& index)
             {
                 if (index != _services.end()) {
                     Core::ProxyType<Service> element(index->second);
@@ -2522,7 +2526,7 @@ POP_WARNING()
                 _adminLock.Lock();
 
                 // First stop all services running ...
-                std::map<const string, Core::ProxyType<Service>>::iterator index(_services.begin());
+                ServiceContainer::iterator index(_services.begin());
 
                 RecursiveNotification(index);
             }
@@ -2535,9 +2539,9 @@ POP_WARNING()
             Config& _webbridgeConfig;
             mutable Core::CriticalSection _adminLock;
             Core::CriticalSection _notificationLock;
-            std::map<const string, Core::ProxyType<Service>> _services;
+            ServiceContainer _services;
             mutable RemoteInstantiators _instantiators;
-            std::list<IPlugin::INotification*> _notifiers;
+            Notifiers _notifiers;
             Core::ProxyType<RPC::InvokeServer> _engine;
             CommunicatorServer _processAdministrator;
             Server& _server;

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -98,18 +98,15 @@ namespace RPC {
 
         template <typename PROXY>
         class ProxyType : public IMetadata {
-        private:
-            ProxyType(const ProxyType<PROXY>& copy) = delete;
-            ProxyType<PROXY>& operator=(const ProxyType<PROXY>& copy) = delete;
-
         public:
-            ProxyType()
-            {
-            }
+            ProxyType(ProxyType<PROXY>&& ) = delete;
+            ProxyType(const ProxyType<PROXY>&) = delete;
+            ProxyType<PROXY>& operator=(const ProxyType<PROXY>&) = delete;
+
+            ProxyType() = default;
             ~ProxyType() override = default;
 
-        private:
-            virtual ProxyStub::UnknownProxy* CreateProxy(const Core::ProxyType<Core::IPCChannel>& channel, const Core::instance_id& implementation, const bool remoteRefCounted)
+            ProxyStub::UnknownProxy* CreateProxy(const Core::ProxyType<Core::IPCChannel>& channel, const Core::instance_id& implementation, const bool remoteRefCounted) override
             {
                 return (new PROXY(channel, implementation, remoteRefCounted))->Administration();
             }

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1390,7 +1390,7 @@ POP_WARNING()
 
             std::list<ProxyStub::UnknownProxy*>::const_iterator loop(deadProxies.begin());
             while (loop != deadProxies.end()) {
-                Revoke((*loop)->Parent(), (*loop)->InterfaceId());
+                Dangling((*loop)->Parent(), (*loop)->InterfaceId());
 
                 // To avoid race conditions, the creation of the deadProxies took a reference
                 // on the interfaces, we presented here. Do not forget to release this reference.
@@ -1405,15 +1405,11 @@ POP_WARNING()
         {
             return (nullptr);
         }
-        virtual void Offer(Core::IUnknown* /* remote */, const uint32_t /* interfaceId */)
-        {
+        virtual void Offer(Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
-        // note: do NOT do a QueryInterface on the IUnknown pointer (or any other method for that matter), the object it points to might already be destroyed
-        virtual void Revoke(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */)
-        {
+        virtual void Revoke(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
-        virtual void Cleanup(const Core::IUnknown* /* source */, const uint32_t /* interfaceid */)
-        {
+        virtual void Dangling(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
 
     private:

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -380,7 +380,7 @@ namespace ProxyStub {
     class UnknownProxyType : public INTERFACE {
     public:
         using BaseClass = UnknownProxyType<INTERFACE>;
-        using IPCMessgae = Core::ProxyType<RPC::InvokeMessage>;
+        using IPCMessage = Core::ProxyType<RPC::InvokeMessage>;
 
     public:
         UnknownProxyType(const UnknownProxyType<INTERFACE>&) = delete;

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -44,7 +44,7 @@ namespace PluginHost {
 
             struct INotification : virtual public Core::IUnknown {
                 virtual ~INotification() = default;
-                virtual void CleanedUp(const Core::IUnknown* source, const uint32_t interfaceId) = 0;
+                virtual void Dangling(const Core::IUnknown* source, const uint32_t interfaceId) = 0;
                 virtual void Revoked(const Core::IUnknown* remote, const uint32_t interfaceId) = 0;
             };
 
@@ -368,18 +368,20 @@ namespace PluginHost {
             Core::File path(storagePath);
 
             if (path.IsDirectory() == false) {
-                if (Core::Directory(PersistentPath().c_str()).Create() != true) {
+                if (Core::Directory(storagePath.c_str()).Create() != true) {
                     result = Core::ERROR_BAD_REQUEST;
                 }
             }
-            if (permission) {
-                path.Permission(permission);
-            }
-            if (user.empty() != true) {
-                path.User(user);
-            }
-            if (group.empty() != true) {
-                path.Group(group);
+            if (result == Core::ERROR_NONE) {
+                if (permission) {
+                    path.Permission(permission);
+                }
+                if (user.empty() != true) {
+                    path.User(user);
+                }
+                if (group.empty() != true) {
+                    path.Group(group);
+                }
             }
 
             return (result);


### PR DESCRIPTION
…ected.

Going through the code, it was observed that in the non-happy day scenario, proxies of processes that close abnormally mght never be released by the crashing process. Examples of these are notification sinks that are registered by the out-of-process part in the plugin (the Thudner main process).
In such  case, the proxy created in the Thunder process, on behalf of the sink offered for registration by the out-of-process part, is never cleared (maintains a refcount of 1 and thus would leak.
Now if the Trace::Activity in the application, is turned on these "potential" leaks are sned to the trace output. If observed, please check if they can properly destructed if not lready done.