### PR TITLE
Deleting double concatenation in number to string conversion

### DIFF
--- a/Source/core/ASN1.h
+++ b/Source/core/ASN1.h
@@ -318,7 +318,7 @@ namespace Core {
                     uint16_t value = index.Number();
 
                     while (value > 0) {
-                        textValue += static_cast<char>((value % 10) + '0') + textValue;
+                        textValue = static_cast<char>((value % 10) + '0') + textValue;
                         value /= 10;
                     }
 


### PR DESCRIPTION
Example:

1. string textValue = ""
uint16_t value = 13

2. textValue = "3"
value = 1

3. // now
textValue = "313"
// after the change
textValue = "13"
value = 0