### PR TITLE
[Core] Removing memrcpy implementation and calling memmove instead

### DIFF
--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -191,19 +191,6 @@ uint32_t GetCallStack(const ThreadId threadId, void* addresses[], const uint32_t
 
 #endif // BACKTRACE
 
-void* memrcpy(void* _Dst, const void* _Src, size_t _MaxCount)
-{
-    unsigned char* destination = static_cast<unsigned char*>(_Dst) + _MaxCount - 1;
-    const unsigned char* source = static_cast<const unsigned char*>(_Src) + _MaxCount - 1;
-
-    while (_MaxCount) {
-        *destination-- = *source--;
-        --_MaxCount;
-    }
-
-    return (destination);
-}
-
 extern "C" {
 
 void DumpCallStack(const ThreadId threadId VARIABLE_IS_NOT_USED, std::list<WPEFramework::Core::callstack_info>& stackList VARIABLE_IS_NOT_USED)

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -568,7 +568,7 @@ struct TemplateIntToType {
 
 extern "C" {
 
-void* memrcpy(void* _Dst, const void* _Src, size_t _MaxCount)
+EXTERNAL void* memrcpy(void* _Dst, const void* _Src, size_t _MaxCount)
 {
     return (::memmove(_Dst, _Src, _MaxCount));
 }

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -568,7 +568,10 @@ struct TemplateIntToType {
 
 extern "C" {
 
-extern EXTERNAL void* memrcpy(void* _Dst, const void* _Src, size_t _MaxCount);
+void* memrcpy(void* _Dst, const void* _Src, size_t _MaxCount)
+{
+    return (::memmove(_Dst, _Src, _MaxCount));
+}
 
 #if defined(__LINUX__)
 uint64_t htonll(const uint64_t& value);


### PR DESCRIPTION
Benchmarking proved that memrcpy is about 5 times slower than both memmove and memcpy.