### PR TITLE
[WORKERPOOL] Next to the running jobs, export the queued jobs.

### DIFF
--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -381,18 +381,9 @@ namespace Plugin {
 
             return (service);
         }
-	void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const
-	{
-            const Core::WorkerPool::Metadata& snapshot = Core::WorkerPool::Instance().Snapshot();
-
-            data.PendingRequests = snapshot.Pending;
-
-            for (uint8_t teller = 0; teller < snapshot.Slots; teller++) {
-                // Example of why copy-constructor and assignment constructor should be equal...
-                Core::JSON::DecUInt32 newElement;
-                data.ThreadPoolRuns.Add() = snapshot.Slot[teller];
-            }
-	}
+        void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const {
+            _pluginServer->WorkerPool().Snapshot(data);
+        }
         void Callstack(const ThreadId id, Core::JSON::ArrayType<CallstackData>& response) const;
         void SubSystems();
         Core::ProxyType<Web::Response> GetMethod(Core::TextSegmentIterator& index) const;

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -160,7 +160,13 @@ POP_WARNING()
             Stop();
             Wait(Core::Thread::STOPPED, Core::infinite);
         }
-
+        static void DumpMetadata() {
+            _adminLock.Lock();
+            if (_dispatcher != nullptr) {
+                _dispatcher->DumpMetadata();
+            }
+            _adminLock.Unlock();
+        }
         static void StartShutdown() {
             _adminLock.Lock();
             if ((_dispatcher != nullptr) && (_instance == nullptr)) {
@@ -320,6 +326,10 @@ POP_WARNING()
         }
     }
 
+    void DumpMetadataHandler(int /* signo */) {
+        ExitHandler::DumpMetadata();
+    }
+
 #endif
 
     void LoadPlugins(const string& name, PluginHost::Config& config)
@@ -449,6 +459,10 @@ POP_WARNING()
             sigaction(SIGINT, &sa, nullptr);
             sigaction(SIGTERM, &sa, nullptr);
             sigaction(SIGQUIT, &sa, nullptr);
+
+            sa.sa_handler = DumpMetadataHandler;
+
+            sigaction(SIGUSR1, &sa, nullptr);
         }
 
         if (atexit(ForcedExit) != 0) {

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -820,7 +820,7 @@ POP_WARNING()
                             printf("SystemState: UNKNOWN\n");
                             printf("------------------------------------------------------------\n");
                         }
-                        printf("Pending:     %d\n", metaData.Pending);
+                        printf("Pending:     %d\n", static_cast<uint32_t>(metaData.Pending.size()));
                         printf("Poolruns:\n");
                         for (uint8_t index = 0; index < metaData.Slots; index++) {
                            printf("  Thread%02d|0x%08X: %10d", (index + 1), (uint32_t) metaData.Slot[index].WorkerId, metaData.Slot[index].Runs);

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -50,7 +50,6 @@ namespace Core {
 
 namespace Plugin {
     class Controller;
-
 }
 
 namespace PluginHost {
@@ -136,6 +135,20 @@ namespace PluginHost {
             void Idle() {
                 // Could be that we can now drop the dynamic library...
                 Core::ServiceAdministrator::Instance().FlushLibraries();
+            }
+            void Snapshot(PluginHost::MetaData::Server& data) const
+            {
+                const Core::WorkerPool::Metadata& snapshot = Core::WorkerPool::Snapshot();
+
+                for (const string& jobInfo : snapshot.Pending) {
+                    data.PendingRequests.Add() = jobInfo;
+                }
+
+                for (uint8_t teller = 0; teller < snapshot.Slots; teller++) {
+                    // Example of why copy-constructor and assignment constructor should be equal...
+                    Core::JSON::DecUInt32 newElement;
+                    data.ThreadPoolRuns.Add() = snapshot.Slot[teller];
+                }
             }
 
         private:
@@ -3366,7 +3379,16 @@ POP_WARNING()
                     
                 }
                 string Identifier() const override {
-                    return(_T("PluginServer::Channel::WebRequestJob::") + Callsign());
+                    string identifier;
+                    if (_jsonrpc == false) {
+                        identifier = _T("{ \"type\": \"JSON\",  }");
+                    }
+                    else {
+                        Core::ProxyType<Core::JSONRPC::Message> message(_request->Body<Core::JSONRPC::Message>());
+
+                        identifier = Core::Format(_T("{ \"type\": \"JSONRPC\", \"id\": %d, \"method\": \"%s\", \"parameters\": %s }"), message->Id.Value(), message->Designator.Value(), message->Parameters.Value());
+                    }
+                    return (identifier);
                 }
 
             private:
@@ -4114,6 +4136,16 @@ POP_WARNING()
         {
             return (_connections);
         }
+        inline void DumpMetadata() {
+            MetaData::Server data;
+            _dispatcher.Snapshot(data);
+
+            // Drop the workerpool info (wht is currently running and what is pending) to a file..
+            Core::File dumpFile(_config.PostMortemPath() + "ThunderInternals.json");
+            if (dumpFile.Create(false) == true) {
+                data.IElement::ToFile(dumpFile);
+            }
+        }
         inline ServiceMap& Services()
         {
             return (_services);
@@ -4134,7 +4166,6 @@ POP_WARNING()
         {
             _dispatcher.Revoke(job);
         }
-
         inline PluginHost::Config& Configuration()
         {
             return (_config);

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -312,11 +312,11 @@ namespace RPC {
         string Identifier() const override {
             string identifier;
             Core::ProxyType<InvokeMessage> message(_message);
-            if (message.IsValid() == true) {
-                identifier = _T("COMRPC::Unknown::Request");
+            if (message.IsValid() == false) {
+                identifier = _T("{ \"type\": \"COMRPC\" }");
             }
             else {
-                identifier = Core::Format(_T("COMRPC::Interface[%d]::Method[%d]"), message->Parameters().InterfaceId(), message->Parameters().MethodId());
+                identifier = Core::Format(_T("{ \"type\": \"COMRPC\", \"interface\": %d, \"method\": %d }"), message->Parameters().InterfaceId(), message->Parameters().MethodId());
             }
             return (identifier);
         }

--- a/Source/core/Queue.h
+++ b/Source/core/Queue.h
@@ -263,23 +263,32 @@ namespace Core {
             _adminLock.Unlock();
         }
 
-        inline void FreeSlot() const
+        void FreeSlot() const
         {
             _state.WaitState(false, DISABLED | ENTRIES | EMPTY, Core::infinite);
         }
-        inline bool IsEmpty() const
+        bool IsEmpty() const
         {
             return (_queue.empty());
         }
-        inline bool IsFull() const
+        bool IsFull() const
         {
             return (_queue.size() >= _maxSlots);
         }
-        inline uint32_t Length() const
+        uint32_t Length() const
         {
             return (static_cast<uint32_t>(_queue.size()));
         }
-        inline bool HasEntry(const CONTEXT& element) const {
+        // void action(const CONTEXT& element)
+        template<typename ACTION>
+        void Visit(ACTION&& action) const {
+            _adminLock.Lock();
+            for (const CONTEXT& entry : _queue) {
+                action(entry);
+            }
+            _adminLock.Unlock();
+        }
+        bool HasEntry(const CONTEXT& element) const {
 
             // This needs to be atomic. Make sure it is.
             _adminLock.Lock();
@@ -298,10 +307,10 @@ namespace Core {
 
             return (found);
         }
-        void Lock() {
+        void Lock() const {
             _adminLock.Lock();
         }
-        void Unlock() {
+        void Unlock() const {
             _adminLock.Unlock();
         }
 

--- a/Source/core/Timer.h
+++ b/Source/core/Timer.h
@@ -325,7 +325,7 @@ namespace Core {
 
         uint32_t Pending() const
         {
-            return (_pendingQueue.size());
+            return (static_cast<uint32_t>(_pendingQueue.size()));
         }
 
         ::ThreadId ThreadId() const

--- a/Source/core/WorkerPool.h
+++ b/Source/core/WorkerPool.h
@@ -93,7 +93,7 @@ namespace Core {
         };
 
         struct Metadata {
-            uint32_t Pending;
+            std::vector<string> Pending;
             uint8_t Slots;
             ThreadPool::Metadata* Slot;
         };
@@ -317,10 +317,10 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             , _joined(0)
             #ifdef __CORE_WARNING_REPORTING__
             , _dispatchedJobMonitor(*this, static_cast<uint32_t>(DispatchedJobMonitor::DefaultScheduleIntervalInMilliSeconds))
-            #endif
+            #endif 
         {
-            _metadata.Slots = threadCount + 1;
-            _metadata.Slot = new Core::ThreadPool::Metadata[threadCount + 1];
+            _metadata.Slots = threadCount + 2;
+            _metadata.Slot = new Core::ThreadPool::Metadata[threadCount + 2];
         }
 POP_WARNING()
 
@@ -394,14 +394,14 @@ POP_WARNING()
 
             return (result);
         }
-        virtual const Metadata& Snapshot() const
+        const Metadata& Snapshot() const
         {
-            _metadata.Pending = _threadPool.Pending();
-            _external.Info(_metadata.Slot[0]);
-            _metadata.Slot[0].WorkerId = _joined;
-
-            _threadPool.Info(_threadPool.Count(), &(_metadata.Slot[1]));
-
+            _metadata.Slot[0].WorkerId = _timer.ThreadId();
+            _metadata.Slot[0].Runs = _timer.Pending();
+            _metadata.Slot[0].Job = string(_T("WorkerPool::Timer"));
+            _external.Info(_metadata.Slot[1]);
+            _threadPool.Snapshot(_threadPool.Count(), &(_metadata.Slot[2]), _metadata.Pending);
+            _metadata.Slot[1].WorkerId = _joined;
             return (_metadata);
         }
         void Run()

--- a/Source/plugins/MetaData.h
+++ b/Source/plugins/MetaData.h
@@ -185,11 +185,12 @@ namespace PluginHost {
             inline void Clear()
             {
                 ThreadPoolRuns.Clear();
+                PendingRequests.Clear();
             }
 
         public:
             Core::JSON::ArrayType<Minion> ThreadPoolRuns;
-            Core::JSON::DecUInt32 PendingRequests;
+            Core::JSON::ArrayType<Core::JSON::String> PendingRequests;
         };
 
         class EXTERNAL SubSystem : public Core::JSON::Container {


### PR DESCRIPTION
If the Thunder system seems stop procesing requests it is interesting to know what is actually running, what is deadlocking in the workerpool. Each Job already had a method to return an Identifier() for the job. For COMRPC and JSONRPC, some elements of the job were already made part of this identifier, so that for PostMortem analyses one could deduce the type of job running (which interface, which method etc). This functionality has now been extended by also reporting what is in the queue (waiting jobs for the workerpool).
Also if the Workerpool seems/is deadlocked, this information can not be retrieved through calls that are handled in the workerpool hence why the reporting functionality is now also exposed through a signal handler on Thuner. If a SIGUSR1 is send all relevant internal Thunder information (like the WorkerPool jobs) are dumped to <PostMortemPath>/ThunderInternals.json.

This functionality was triggered by Madana Gopal Thirumalai, this pull-request is extending his implementation beyond the JSONRPC jobs.