### PR TITLE
[MEMORYLEAKS] Dangling pointer cleanup.

### DIFF
--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -844,7 +844,7 @@ namespace RPC {
                     _adminLock.Unlock();
                 }
             }
-            inline void Unregister(RPC::IRemoteConnection::INotification* sink)
+            inline void Unregister(const RPC::IRemoteConnection::INotification* sink)
             {
                 ASSERT(sink != nullptr);
 
@@ -1360,7 +1360,7 @@ POP_WARNING()
         {
             _connectionMap.Register(sink);
         }
-        inline void Unregister(RPC::IRemoteConnection::INotification* sink)
+        inline void Unregister(const RPC::IRemoteConnection::INotification* sink)
         {
             _connectionMap.Unregister(sink);
         }

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -193,7 +193,7 @@ if(NOT WCHAR_SUPPORT)
 endif()
 
 if (INSTANCE_ID_BITS)
-    target_compile_definitions(${TARGET} PUBLIC INSTANCE_ID_BITS=${INSTANCE_ID_BITS})
+    target_compile_definitions(${TARGET} PUBLIC __CORE_INSTANCE_BITS__=${INSTANCE_ID_BITS})
     message(STATUS "COMRPC instanceid defined as ${INSTANCE_ID_BITS} bits.")
 endif()
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -650,14 +650,14 @@ namespace WPEFramework {
 
 namespace Core {
 
-    #if defined(INSTANCE_ID_BITS) && (INSTANCE_ID_BITS != 0)
-    #if INSTANCE_ID_BITS <= 8
+    #if defined(__CORE_INSTANCE_BITS__) && (__CORE_INSTANCE_BITS__ != 0)
+    #if __CORE_INSTANCE_BITS__ <= 8
     typedef uint8_t instance_id;
-    #elif INSTANCE_ID_BITS <= 16
+    #elif __CORE_INSTANCE_BITS__ <= 16
     typedef uint16_t instance_id;
-    #elif INSTANCE_ID_BITS <= 32 
+    #elif __CORE_INSTANCE_BITS__ <= 32 
     typedef uint32_t instance_id;
-    #elif INSTANCE_ID_BITS <= 64
+    #elif __CORE_INSTANCE_BITS__ <= 64
     typedef uint64_t instance_id;
     #endif
     #else

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -782,12 +782,12 @@ namespace Core {
         }
 
         template <typename REQUESTEDINTERFACE>
-        REQUESTEDINTERFACE* QueryInterface() const
+        const REQUESTEDINTERFACE* QueryInterface() const
         {
             const void* baseInterface(const_cast<IUnknown*>(this)->QueryInterface(REQUESTEDINTERFACE::ID));
 
             if (baseInterface != nullptr) {
-                return (reinterpret_cast<REQUESTEDINTERFACE*>(baseInterface));
+                return (reinterpret_cast<const REQUESTEDINTERFACE*>(baseInterface));
             }
 
             return (nullptr);

--- a/Source/core/Services.h
+++ b/Source/core/Services.h
@@ -199,6 +199,7 @@ namespace Core {
     template <typename ACTUALSINK>
     class Sink : public ACTUALSINK {
     private:
+        Sink(Sink<ACTUALSINK>&&) = delete;
         Sink(const Sink<ACTUALSINK>&) = delete;
         Sink<ACTUALSINK> operator=(const Sink<ACTUALSINK>&) = delete;
 

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -50,7 +50,7 @@ namespace PluginHost {
 
             virtual ~ICOMLink() = default;
             virtual void Register(RPC::IRemoteConnection::INotification* sink) = 0;
-            virtual void Unregister(RPC::IRemoteConnection::INotification* sink) = 0;
+            virtual void Unregister(const RPC::IRemoteConnection::INotification* sink) = 0;
 
             virtual void Register(INotification* sink) = 0;
             virtual void Unregister(INotification* sink) = 0;
@@ -286,7 +286,7 @@ namespace PluginHost {
                 handler->Register(sink);
             }
         }
-        inline void Unregister(RPC::IRemoteConnection::INotification* sink)
+        inline void Unregister(const RPC::IRemoteConnection::INotification* sink)
         {
             ICOMLink* handler(COMLink());
 

--- a/cmake/project.cmake.in
+++ b/cmake/project.cmake.in
@@ -78,12 +78,6 @@ endif()
 
 set(CMAKE_BUILD_TYPE @CMAKE_BUILD_TYPE@ CACHE INTERNAL "" FORCE)
 
-if(INSTANCE_ID_BITS)
-    add_definitions("-DINSTANCE_ID_BITS=@INSTANCE_ID_BITS@")
-else()
-    add_definitions("-DINSTANCE_ID_BITS=0")
-endif()
-
 # FIX_ME: Disable fortify source.
 #         https://jira.rdkcentral.com/jira/browse/METROL-483
 #         Enabled in upstream buildroot, generates a lot of warnings, caused by missing optimalisation flags.


### PR DESCRIPTION
If the WPEFramework server receives a dangling pointer (A dropped sink from another process) make sure it gets removed from its internal administration (drop proxy)