### PR TITLE
Creating GitHub Action for building Thunder

### DIFF
--- a/.github/workflows/Build Thunder.yml
+++ b/.github/workflows/Build Thunder.yml
@@ -1,0 +1,47 @@
+name: CMake Thunder
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        build_type: [Debug, Release, MinSizeRel]
+    
+    name: Build type - ${{matrix.build_type}}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install necessary packages
+      run: |
+        sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev python3-pip
+        pip install jsonref
+        
+    - name: Install generators
+      run: |
+        cmake -G Ninja -S Tools -B build/tools -DCMAKE_INSTALL_PREFIX=install/usr
+        cmake --build build/tools --target install
+        
+    - name: Build Thunder
+      run: |
+        cmake -G Ninja -S . -B build/thunder \
+        -DBINDING="127.0.0.1" \
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+        -DCMAKE_INSTALL_PREFIX="install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/install/usr/include/WPEFramework/Modules" \
+        -DDATA_PATH="${PWD}/install/usr/share/WPEFramework" \
+        -DMESSAGING=ON \
+        -DPERSISTENT_PATH="${PWD}/install/var/wpeframework" \
+        -DPORT="55555" \
+        -DPROXYSTUB_PATH="${PWD}/install/usr/lib/wpeframework/proxystubs" \
+        -DSYSTEM_PATH="${PWD}/install/usr/lib/wpeframework/plugins" \
+        -DTRACING=OFF \
+        -DVOLATILE_PATH="/tmp"
+        cmake --build build/thunder --target install


### PR DESCRIPTION
Automatically building Thunder in Debug, Release and MinSizeRel (Production) versions when anyone creates a PR or tries to push into master. The whole process is done concurrently and takes about 2 minutes in total. If the build is unsuccessful, there will be a notification just like in case of other checks (e.g. license/cla).