### PR TITLE
[Actions] Repo owner can no longer be a parameter

### DIFF
--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -21,13 +21,13 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Thunder
-        repository: ${{github.repository_owner}}/Thunder
+        repository: rdkcentral/Thunder
 
     - name: Checkout ThunderTools
       uses: actions/checkout@v3
       with:
         path: ThunderTools
-        repository: ${{github.repository_owner}}/ThunderTools
+        repository: rdkcentral/ThunderTools
 
     - name: Install necessary packages
       uses: nick-fields/retry@v2


### PR DESCRIPTION
Referencing this action inside ThunderNanoServicesRDK breaks since the owner of this repo is different