### PR TITLE
[Core] Fix socket shutdown

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -592,7 +592,7 @@ namespace WPEFramework {
 #ifdef __WINDOWS__
                         shutdown(m_Socket, SD_SEND);
 #else
-                        shutdown(m_Socket, SHUT_RD);
+                        shutdown(m_Socket, SHUT_RDWR);
 #endif
                     }
 


### PR DESCRIPTION
Needs to be RDWR in order to receive a HUP event, otherwise would also have to listen for RDHUP and then react accordingly.