### PR TITLE
[JSONRPC] Event as part of the designator. Cleaned up versioning.

### DIFF
--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -143,7 +143,7 @@ namespace PluginHost {
             void Event(JSONRPC& parent, const string event, const string& parameter, std::function<bool(const string&)>&& sendifmethod) {
                 for (const Destination& entry : _designators) {
                     if (!sendifmethod || sendifmethod(entry.second)) {
-                        parent.Notify(entry.first, entry.second, parameter);
+                        parent.Notify(entry.first, entry.second + '.' + event, parameter);
                     }
                 }
                 for (IDispatcher::ICallback*& callback : _callbacks) {


### PR DESCRIPTION
Removed the, by now, deprecated fullDesignator boolean parameter.