### PR TITLE
Updating syslog of dynamic COMRPC/configs when disabled

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -2360,7 +2360,11 @@ namespace PluginHost {
                     }
 
                     if (_proxyStubObserver.IsValid() == false) {
-                        SYSLOG(Logging::Startup, (_T("Dynamic COMRPC failed. Can not observe: [%s]"), observableProxyStubPath.c_str()));
+                        if (observableProxyStubPath.empty() == true) {
+                            SYSLOG(Logging::Startup, (_T("Dynamic COMRPC disabled.")));
+                        } else {
+                            SYSLOG(Logging::Startup, (_T("Dynamic COMRPC failed. Can not observe: [%s]"), observableProxyStubPath.c_str()));
+                        }
                     }
                 }
                 virtual ~CommunicatorServer()
@@ -2779,7 +2783,11 @@ POP_WARNING()
                 , _compositPlugins()
             {
                 if (_configObserver.IsValid() == false) {
-                    SYSLOG(Logging::Startup, (_T("Dynamic configs failed. Can not observe: [%s]"), server._config.PluginConfigPath().c_str()));
+                    if (server._config.PluginConfigPath().empty() == true) {
+                        SYSLOG(Logging::Startup, (_T("Dynamic configs disabled.")));
+                    } else {
+                        SYSLOG(Logging::Startup, (_T("Dynamic configs failed. Can not observe: [%s]"), server._config.PluginConfigPath().c_str()));
+                    }
                 }
             }
             POP_WARNING();

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -2359,12 +2359,10 @@ namespace PluginHost {
                         RPC::Communicator::ForcedDestructionTimes(softKillCheckWaitTime, hardKillCheckWaitTime);
                     }
 
-                    if (_proxyStubObserver.IsValid() == false) {
-                        if (observableProxyStubPath.empty() == true) {
-                            SYSLOG(Logging::Startup, (_T("Dynamic COMRPC disabled.")));
-                        } else {
-                            SYSLOG(Logging::Startup, (_T("Dynamic COMRPC failed. Can not observe: [%s]"), observableProxyStubPath.c_str()));
-                        }
+                    if (observableProxyStubPath.empty() == true) {
+                        SYSLOG(Logging::Startup, (_T("Dynamic COMRPC disabled.")));
+                    } else if (_proxyStubObserver.IsValid() == false) {
+                        SYSLOG(Logging::Startup, (_T("Dynamic COMRPC failed. Can not observe: [%s]"), observableProxyStubPath.c_str()));
                     }
                 }
                 virtual ~CommunicatorServer()
@@ -2782,12 +2780,10 @@ POP_WARNING()
                 , _configObserver(*this, server._config.PluginConfigPath())
                 , _compositPlugins()
             {
-                if (_configObserver.IsValid() == false) {
-                    if (server._config.PluginConfigPath().empty() == true) {
-                        SYSLOG(Logging::Startup, (_T("Dynamic configs disabled.")));
-                    } else {
-                        SYSLOG(Logging::Startup, (_T("Dynamic configs failed. Can not observe: [%s]"), server._config.PluginConfigPath().c_str()));
-                    }
+                if (server._config.PluginConfigPath().empty() == true) {
+                    SYSLOG(Logging::Startup, (_T("Dynamic configs disabled.")));
+                } else if (_configObserver.IsValid() == false) {
+                    SYSLOG(Logging::Startup, (_T("Dynamic configs failed. Can not observe: [%s]"), server._config.PluginConfigPath().c_str()));
                 }
             }
             POP_WARNING();


### PR DESCRIPTION
It scared both me and Sebastian that something has failed, whereas in reality it is simply disabled (not configured), so let's not scare others trying to build and run Thunder after the upcoming readme update.