### PR TITLE
cmake: move ConfigGenerator to plugins

### DIFF
--- a/Source/plugins/CMakeLists.txt
+++ b/Source/plugins/CMakeLists.txt
@@ -164,6 +164,7 @@ InstallPackageConfig(
         DESCRIPTION "Basic library to realize the glue between a proprietary plugin and the framework host.")
 
 InstallCMakeConfig(
+        EXTRA_DEPENDENCIES "ConfigGenerator"
         TARGETS ${TARGET})
 
 InstallCMakeConfig(TARGETS ${TARGET_PROXYSTUBS})

--- a/cmake/project.cmake.in
+++ b/cmake/project.cmake.in
@@ -215,5 +215,3 @@ function(print_target_properties tgt)
         endif()
     endforeach(prop)
 endfunction(print_target_properties)
-
-find_package(ConfigGenerator REQUIRED)


### PR DESCRIPTION
Fixes an configuration error when components only use e.g WPEFrameworkCore.