### PR TITLE
cmake: keep core compile flags private

### DIFF
--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -211,9 +211,8 @@ if(BUILD_TESTS)
 endif()
 
 target_link_libraries(${TARGET}
-        PUBLIC
-          CompileSettings::CompileSettings
         PRIVATE
+          CompileSettings::CompileSettings
           CompileSettingsDebug::CompileSettingsDebug
           ${CMAKE_DL_LIBS}
           Threads::Threads


### PR DESCRIPTION
We forced some flags like ```-fno-execptions``` to all components that link to core.