### PR TITLE
[CONNECTIONID] Expose the ConnectionId on the COMRPC connection classes.

### DIFF
--- a/Source/com/ConnectorType.h
+++ b/Source/com/ConnectorType.h
@@ -143,8 +143,8 @@ namespace RPC {
 
             return (result);
         }
-        Core::ProxyType<CommunicatorClient> Communicator(const Core::NodeId& nodeId){
-            return _comChannels.Find(nodeId);
+        Core::ProxyType<CommunicatorClient> Communicator(const Core::NodeId& nodeId) {
+            return (Core::ProxyType<CommunicatorClient>(_comChannels.Find(nodeId)));
         }
         RPC::IIPCServer& Engine()
         {

--- a/Source/messaging/MessageUnit.cpp
+++ b/Source/messaging/MessageUnit.cpp
@@ -183,22 +183,24 @@ namespace WPEFramework {
 
             ASSERT(_dispatcher == nullptr);
 
-            _settings.Load();
+            if (instanceId != static_cast<uint32_t>(~0)) {
+                _settings.Load();
 
-            _dispatcher.reset(new MessageDispatcher(*this, _settings.Identifier(), instanceId, _settings.BasePath(), _settings.SocketPort()));
-            ASSERT(_dispatcher != nullptr);
+                _dispatcher.reset(new MessageDispatcher(*this, _settings.Identifier(), instanceId, _settings.BasePath(), _settings.SocketPort()));
+                ASSERT(_dispatcher != nullptr);
 
-            if ( (_dispatcher != nullptr) && (_dispatcher->IsValid() == true) ) {
+                if ((_dispatcher != nullptr) && (_dispatcher->IsValid() == true)) {
 
-                _direct.Mode(_settings.IsBackground(), _settings.IsAbbreviated());
+                    _direct.Mode(_settings.IsBackground(), _settings.IsAbbreviated());
 
-                Core::Messaging::IStore::Set(this);
+                    Core::Messaging::IStore::Set(this);
 
-                // according to received config,
-                // let all announced controls know, whether they should push messages
-                Update();
+                    // according to received config,
+                    // let all announced controls know, whether they should push messages
+                    Update();
 
-                result = Core::ERROR_NONE;
+                    result = Core::ERROR_NONE;
+                }
             }
 
             return (result);
@@ -219,12 +221,14 @@ namespace WPEFramework {
                 }
             } handler;
 
-            Core::Messaging::IStore::Set(nullptr);
-            Core::Messaging::IControl::Iterate(handler);
+            if (_dispatcher != nullptr) {
+                Core::Messaging::IStore::Set(nullptr);
+                Core::Messaging::IControl::Iterate(handler);
 
-            _adminLock.Lock();
-            _dispatcher.reset(nullptr);
-            _adminLock.Unlock();
+                _adminLock.Lock();
+                _dispatcher.reset(nullptr);
+                _adminLock.Unlock();
+            }
         }
 
         /* virtual */ bool MessageUnit::Default(const Core::Messaging::Metadata& control) const

--- a/Source/plugins/Types.h
+++ b/Source/plugins/Types.h
@@ -249,6 +249,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             : _controller(nullptr)
             , _administrator()
             , _monitor(*this)
+            , _connectionId(~0)
         {
         }
 POP_WARNING()
@@ -258,6 +259,9 @@ POP_WARNING()
         }
 
     public:
+        uint32_t ConnectionId() const {
+            return (_connectionId);
+        }
         bool IsOperational() const
         {
             return (_monitor.IsOperational());
@@ -278,6 +282,10 @@ POP_WARNING()
             }
             if (_controller != nullptr) {
                 _monitor.Register(_controller, callsign);
+                Core::ProxyType<CommunicatorClient> channel(_administrator.Communicator(node));
+                if (channel.IsValid() == true) {
+                    _connectionId = channel->ConnectionId();
+                }
             }
 
             return (_controller != nullptr ? Core::ERROR_NONE : Core::ERROR_UNAVAILABLE);
@@ -351,6 +359,7 @@ POP_WARNING()
         PluginHost::IShell* _controller;
         ConnectorType<ENGINE> _administrator;
         Monitor _monitor;
+        uint32_t _connectionId;
     };
 }
 }


### PR DESCRIPTION
In case an external entity (clientlibrary) want to setup a connection with a plugin, and the application want to open up a message transfer (Tracing/Logging/WarningReporting streams) bewtween the process and the ThunderFramework, the application needs to have a connection Id (uniqie number) for which it should open up the MessageTransfer.
This commit allows, after instantiating a COMRPC channel with Thunder, to request the used Conenction Id from where the host of this library can than open op the messaging for use within this process..