### PR TITLE
Set pthread name on Linux

### DIFF
--- a/Source/core/Thread.cpp
+++ b/Source/core/Thread.cpp
@@ -438,6 +438,15 @@ POP_WARNING()
         } __except (EXCEPTION_EXECUTE_HANDLER) {
         }
 #endif // __DEBUG__
+#else
+        int rc = pthread_setname_np(m_hThreadInstance, threadName);
+        if (rc == ERANGE) {
+            // name too long - max 16 chars allowed
+            char truncName[16];
+            strncpy(truncName, threadName, sizeof(truncName));
+            truncName[15] = '\0';
+            pthread_setname_np(m_hThreadInstance, truncName);
+        }
 #endif // __WINDOWS__
     }
 


### PR DESCRIPTION
Set pthread_name for Linux threads to make tracking/debugging threads easier.

Annoyingly pthread names are limited to 16 chars so some thread names get truncated
```
  37269 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.01 WPEFramework                               
  37285 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 COMRPCTerminato                            
  37286 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 Monitor::IResou                            
  37287 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 WorkerPool::Thr                            
  37288 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 WorkerPool::Thr                            
  37289 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 WorkerPool::Thr                            
  37290 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 WorkerPool::Thr                            
  37291 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 WorkerPoolType:                            
  37313 stephen+  20   0  460888  11628  10396 S   0.0   0.1   0:00.00 WPEFramework 
```