### PR TITLE
[REVERT] Reverting the uint24_t being packed on the wire as 3 bytes.

### DIFF
--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -184,7 +184,7 @@ namespace RPC {
                 if (result == true) {
                     TRACE_L3("Validated instance 0x%08x by administration", impl);
                 } else {
-                    TRACE_L1("Failed to validate instance 0x%08x of interface 0x%08x", impl, id);
+                    TRACE_L1("Failed to validate instance 0x%08llx of interface 0x%08x", impl, id);
                 }
             }
         }

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -655,7 +655,8 @@ namespace Core {
     private:
         template <typename TYPENAME>
         static constexpr uint8_t RealSize() {
-            return(std::is_same<TYPENAME, uint24_t>::value ? 3 : sizeof(TYPENAME));
+            const uint8_t response(std::is_same<TYPENAME, uint24_t>::value ? 3 : sizeof(TYPENAME));
+            return(sizeof(TYPENAME));
         }
 
         template <typename TYPENAME>
@@ -695,7 +696,7 @@ namespace Core {
         SIZE_CONTEXT SetNumber(const SIZE_CONTEXT offset, const TYPENAME number, const TemplateIntToType<false>&)
         {
             if ((offset + RealSize<TYPENAME>()) >= _size) {
-                Size(offset + sizeof(TYPENAME));
+                Size(offset + RealSize<TYPENAME>());
             }
 
             if (BIG_ENDIAN_ORDERING == true) {

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -655,7 +655,6 @@ namespace Core {
     private:
         template <typename TYPENAME>
         static constexpr uint8_t RealSize() {
-            const uint8_t response(std::is_same<TYPENAME, uint24_t>::value ? 3 : sizeof(TYPENAME));
             return(sizeof(TYPENAME));
         }
 


### PR DESCRIPTION
Seen in the debugger, that although the uint24_t is not actively used yet, the template fired with 3 bytes of length to be send over the wire. Needs further investigation but as this currently breaks some functionality lets roll back this saving of 1 byte on the wire until we are aware of what is causing this issue..