### PR TITLE
RDKDEV-345i: Crypto: Random: Prefer the OpenSSL RNG if 'SECURESOCKETS…

### DIFF
--- a/Source/cryptalgo/Random.cpp
+++ b/Source/cryptalgo/Random.cpp
@@ -38,27 +38,30 @@ namespace Crypto {
     // --------------------------------------------------------------------------------------------
     void Reseed()
     {
+#ifdef __LINUX__
 #if defined(SECURESOCKETS_ENABLED)
         if (RAND_poll() == 1) {
             return;
         }
-        // RAND_poll() failed, fallback to legacy random.
 #endif // SECURESOCKETS_ENABLED
+        // RAND_poll() failed, fallback to legacy random.
+        srandom(static_cast<unsigned int>(time(nullptr)));
+#endif // __LINUX__
 #ifdef __WINDOWS__
         srand(static_cast<unsigned int>(time(nullptr)));
 #endif // __WINDOWS__
-#ifdef __LINUX__
-        srandom(static_cast<unsigned int>(time(nullptr)));
-#endif // __LINUX__
+
     }
 
     void Random(uint8_t& value)
     {
 #if defined(SECURESOCKETS_ENABLED)
+#ifdef __LINUX__
         if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
             return;
         }
         // RAND_bytes() failed, fallback to legacy random.
+#endif // __LINUX__
 #endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFF
 #ifdef __WINDOWS__
@@ -75,10 +78,12 @@ namespace Crypto {
     void Random(uint16_t& value)
     {
 #if defined(SECURESOCKETS_ENABLED)
+#ifdef __LINUX__
         if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
             return;
         }
         // RAND_bytes() failed, fallback to legacy random.
+#endif // __LINUX__
 #endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFFFF
 #ifdef __WINDOWS__
@@ -105,10 +110,12 @@ namespace Crypto {
     void Random(uint32_t& value)
     {
 #if defined(SECURESOCKETS_ENABLED)
+#ifdef __LINUX__
         if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
             return;
         }
         // RAND_bytes() failed, fallback to legacy random.
+#endif // __LINUX__
 #endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFFFFFFFF
 #ifdef __WINDOWS__
@@ -149,10 +156,12 @@ namespace Crypto {
     void Random(uint64_t& value)
     {
 #if defined(SECURESOCKETS_ENABLED)
+#ifdef __LINUX__
         if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
             return;
         }
         // RAND_bytes() failed, fallback to legacy random.
+#endif // __LINUX__
 #endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFFFFFFFF
 #ifdef __WINDOWS__

--- a/Source/cryptalgo/Random.cpp
+++ b/Source/cryptalgo/Random.cpp
@@ -27,6 +27,10 @@
 #include "Winsock2.h"
 #endif // __WINDOWS__
 
+#if defined(SECURESOCKETS_ENABLED)
+#include <openssl/rand.h>
+#endif // SECURESOCKETS_ENABLED
+
 namespace WPEFramework {
 namespace Crypto {
     // --------------------------------------------------------------------------------------------
@@ -34,6 +38,12 @@ namespace Crypto {
     // --------------------------------------------------------------------------------------------
     void Reseed()
     {
+#if defined(SECURESOCKETS_ENABLED)
+        if (RAND_poll() == 1) {
+            return;
+        }
+        // RAND_poll() failed, fallback to legacy random.
+#endif // SECURESOCKETS_ENABLED
 #ifdef __WINDOWS__
         srand(static_cast<unsigned int>(time(nullptr)));
 #endif // __WINDOWS__
@@ -44,6 +54,12 @@ namespace Crypto {
 
     void Random(uint8_t& value)
     {
+#if defined(SECURESOCKETS_ENABLED)
+        if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
+            return;
+        }
+        // RAND_bytes() failed, fallback to legacy random.
+#endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFF
 #ifdef __WINDOWS__
         value = static_cast<uint8_t>(rand() & 0xFF);
@@ -58,6 +74,12 @@ namespace Crypto {
 
     void Random(uint16_t& value)
     {
+#if defined(SECURESOCKETS_ENABLED)
+        if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
+            return;
+        }
+        // RAND_bytes() failed, fallback to legacy random.
+#endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFFFF
 #ifdef __WINDOWS__
         value = static_cast<uint16_t>(rand() & 0xFFFF);
@@ -82,6 +104,12 @@ namespace Crypto {
 
     void Random(uint32_t& value)
     {
+#if defined(SECURESOCKETS_ENABLED)
+        if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
+            return;
+        }
+        // RAND_bytes() failed, fallback to legacy random.
+#endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFFFFFFFF
 #ifdef __WINDOWS__
         value = static_cast<uint32_t>(rand() & 0xFFFFFFFF);
@@ -120,6 +148,12 @@ namespace Crypto {
 
     void Random(uint64_t& value)
     {
+#if defined(SECURESOCKETS_ENABLED)
+        if (RAND_bytes(reinterpret_cast<unsigned char*>(&value), sizeof(value)) == 1) {
+            return;
+        }
+        // RAND_bytes() failed, fallback to legacy random.
+#endif // SECURESOCKETS_ENABLED
 #if RAND_MAX >= 0xFFFFFFFF
 #ifdef __WINDOWS__
         value = static_cast<uint32_t>(rand() & 0xFFFFFFFF);


### PR DESCRIPTION
…_ENABLED' is set (#1049)

Prefer the Random Number Generator (RNG) feature from OpenSSL to the C library's one when OpenSSL is enabled ('SECURESOCKETS_ENABLED' is set), both for seeding (Crypto::Reseed()) and random number generation (the several Crypto::Random() overrides).

With OpenSSL, seeding is done using RAND_poll() and random number generation with RAND_bytes().

The OpenSSL RNG is a Cryptographically Secure Pseudo Random Number Generator (CSPRNG), which provides a better and more secure RNG than the C library's one, so it should be preferred when available. In fact, with tests around the SecurityAgent plugin and the tokens generated by it (which use these Crypto::Random functions), it was observed that for a given payload, the tokens generated where always the same across different devices and reboots. This happens precisely because the C library's RNG is always returning the same random numbers. Even though this can be mitigated by forcing a Reseed() before requesting the random numbers, still this Reseeding() is based on the current time, which is not the best source of entropy for seeding. With OpenSSL RNG, this issue with the tokens is not happening, even without the re-seeding.

Still falling back to the C library's implementations when OpenSSL is not enabled, or when it's enabled but for some reason their RAND functions fail.