### PR TITLE
Controller: Allow configuring if the UI is enabled or not (#1179)

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -122,7 +122,12 @@ namespace Plugin {
         }
 
         _service->Register(&_systemInfoReport);
-        _service->EnableWebServer(_T("UI"), EMPTY_STRING);
+
+        if ((config.Ui.IsSet() == true) && (config.Ui.Value() == true)) {
+            _service->EnableWebServer(_T("UI"), EMPTY_STRING);
+        } else {
+            _service->DisableWebServer();
+        }
 
         Register(this);
         Exchange::IController::JConfiguration::Register(*this, this);

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -246,10 +246,12 @@ namespace Plugin {
                 , Probe()
                 , Resumes()
                 , SubSystems()
+                , Ui(true)
             {
                 Add(_T("probe"), &Probe);
                 Add(_T("resumes"), &Resumes);
                 Add(_T("subsystems"), &SubSystems);
+                Add(_T("ui"), &Ui);
             }
             ~Config()
             {
@@ -259,6 +261,7 @@ namespace Plugin {
             ProbeConfig Probe;
             Core::JSON::ArrayType<Core::JSON::String> Resumes;
             Core::JSON::ArrayType<Core::JSON::EnumType<PluginHost::ISubSystem::subsystem>> SubSystems;
+            Core::JSON::Boolean Ui;
         };
 
     private:

--- a/Source/WPEFramework/GenericConfig.cmake
+++ b/Source/WPEFramework/GenericConfig.cmake
@@ -44,7 +44,11 @@ set(GROUP "" CACHE STRING "Define which system group will be used")
 set(UMASK "" CACHE STRING "Set the permission mask for the creation of new files. e.g. 0760")
 
 # Controller Plugin Settings.
-set(PLUGIN_CONTROLLER_UI_ENABLED true CACHE STRING "Enable the Controller's UI")
+set(PLUGIN_CONTROLLER_UI_ENABLED "true" CACHE STRING "Enable the Controller's UI")
+
+if (PLUGIN_CONTROLLER_UI_ENABLED STREQUAL "false")
+    set (BINDING "127.0.0.1")
+endif()
 
 if(CMAKE_VERSION VERSION_LESS 3.20.0 AND LEGACY_CONFIG_GENERATOR)
 map()

--- a/Source/WPEFramework/GenericConfig.cmake
+++ b/Source/WPEFramework/GenericConfig.cmake
@@ -43,6 +43,9 @@ set(ETHERNETCARD_NAME "eth0" CACHE STRING "Ethernet Card name which has to be as
 set(GROUP "" CACHE STRING "Define which system group will be used")
 set(UMASK "" CACHE STRING "Set the permission mask for the creation of new files. e.g. 0760")
 
+# Controller Plugin Settings.
+set(PLUGIN_CONTROLLER_UI_ENABLED true CACHE STRING "Enable the Controller's UI")
+
 if(CMAKE_VERSION VERSION_LESS 3.20.0 AND LEGACY_CONFIG_GENERATOR)
 map()
   key(plugins)
@@ -134,6 +137,7 @@ ans(PLUGIN_CONTROLLER)
 map()
     kv(subsystems)
     key(resumes)
+    kv(ui ${PLUGIN_CONTROLLER_UI_ENABLED})
 end()
 ans(PLUGIN_CONTROLLER_CONFIGURATION)
 


### PR DESCRIPTION
Currently, the Controller's UI, serving as base for the Thunder UI, is enabled by default, without allowing a configuration option to disable it.

Since having the Controller's UI enabled requires Web Servicing (accepting and responding to HTTP requests) and that might bring security concerns, and also considering that the UI is mostly for development/debug, add a way to configure the Controller to have the UI disabled.

This way, add a cmake boolean option ('PLUGIN_CONTROLLER_UI_ENABLED') which, when set to 'false', disables the Controller's UI. Set the new option as 'true' by default, enabling the UI by default, for keeping backwards compatibility.