### PR TITLE
[POSTMORTEM] Enhance the dumping of information as required by the Th…

### DIFF
--- a/Source/WPEFramework/Controller.cpp
+++ b/Source/WPEFramework/Controller.cpp
@@ -55,12 +55,12 @@ namespace Plugin {
     static Core::ProxyPoolType<Web::JSONBodyType<PluginHost::MetaData>> jsonBodyMetaDataFactory(1);
     static Core::ProxyPoolType<Web::JSONBodyType<PluginHost::MetaData::Service>> jsonBodyServiceFactory(1);
     static Core::ProxyPoolType<Web::JSONBodyType<PluginHost::MetaData::Version>> jsonBodyVersionFactory(1);
-    static Core::ProxyPoolType<Web::JSONBodyType<Core::JSON::ArrayType<Controller::CallstackData>>> jsonBodyCallstackFactory(1);
+    static Core::ProxyPoolType<Web::JSONBodyType<Core::JSON::ArrayType<PluginHost::CallstackData>>> jsonBodyCallstackFactory(1);
     static Core::ProxyPoolType<Web::JSONBodyType<Core::JSON::ArrayType<PluginHost::MetaData::COMRPC>>> jsonBodyProxiesFactory(1);
 
     static Core::ProxyPoolType<Web::TextBody> jsonBodyTextFactory(2);
 
-    void Controller::Callstack(const ThreadId id, Core::JSON::ArrayType<CallstackData>& response) const {
+    void Controller::Callstack(const ThreadId id, Core::JSON::ArrayType<PluginHost::CallstackData>& response) const {
         std::list<Core::callstack_info> stackList;
 
         ::DumpCallStack(id, stackList);
@@ -453,13 +453,13 @@ namespace Plugin {
             else {
                 Core::NumberType<uint8_t> threadIndex(index.Current());
                 
-                Core::ProxyType<Web::JSONBodyType<Core::JSON::ArrayType<CallstackData>>> response = jsonBodyCallstackFactory.Element();
+                Core::ProxyType<Web::JSONBodyType<Core::JSON::ArrayType<PluginHost::CallstackData>>> response = jsonBodyCallstackFactory.Element();
                 Callstack(_pluginServer->WorkerPool().Id(threadIndex.Value()), *response);
                 result->Body(Core::ProxyType<Web::IBody>(response));
             }
         } else if (index.Current() == _T ("Monitor")) {
             Core::NumberType<uint8_t> threadIndex(index.Current());
-            Core::ProxyType<Web::JSONBodyType<Core::JSON::ArrayType<CallstackData>>> response = jsonBodyCallstackFactory.Element();
+            Core::ProxyType<Web::JSONBodyType<Core::JSON::ArrayType<PluginHost::CallstackData>>> response = jsonBodyCallstackFactory.Element();
             Callstack(Core::ResourceMonitor::Instance().Id(), *response);
             result->Body(Core::ProxyType<Web::IBody>(response));
         } else if (index.Current() == _T("Discovery")) {
@@ -1084,7 +1084,7 @@ namespace Plugin {
 
     Core::hresult Controller::CallStack(const string& index, string& callstack) const
     {
-        Core::JSON::ArrayType<CallstackData> jsonResponse;
+        Core::JSON::ArrayType<PluginHost::CallstackData> jsonResponse;
         Core::hresult result = Core::ERROR_UNKNOWN_KEY;
 
         if (index.empty() == true) {

--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -24,6 +24,7 @@
 #include "PluginServer.h"
 #include "Probe.h"
 #include "IController.h"
+#include "PostMortem.h"
 
 namespace WPEFramework {
 namespace Plugin {
@@ -39,73 +40,6 @@ namespace Plugin {
         , public Exchange::IController::ILifeTime
         , public Exchange::IController::ILifeTime::INotification {
     public:
-        class CallstackData : public Core::JSON::Container {
-        public:
-            CallstackData()
-                : Core::JSON::Container()
-                , Address()
-                , Function()
-                , Module()
-                , Line()
-            {
-                Add(_T("address"), &Address);
-                Add(_T("function"), &Function);
-                Add(_T("module"), &Module);
-                Add(_T("line"), &Line);
-            }
-            CallstackData(const Core::callstack_info source)
-                : Core::JSON::Container()
-                , Address()
-                , Function()
-                , Module()
-                , Line()
-            {
-                Add(_T("address"), &Address);
-                Add(_T("function"), &Function);
-                Add(_T("module"), &Module);
-                Add(_T("line"), &Line);
-
-                Address = reinterpret_cast<Core::instance_id>(source.address);
-                Function = source.function;
-                if (source.module.empty() == false) {
-                    Module = source.module;
-                }
-                if (source.line != static_cast<uint32_t>(~0)) {
-                    Line = source.line;
-                }
-            }
-            CallstackData(const CallstackData& copy)
-                : Core::JSON::Container()
-                , Address(copy.Address)
-                , Function(copy.Function)
-                , Module(copy.Module)
-                , Line(copy.Line)
-            {
-                Add(_T("address"), &Address);
-                Add(_T("function"), &Function);
-                Add(_T("module"), &Module);
-                Add(_T("line"), &Line);
-            }
-
-            ~CallstackData() = default;
-
-            CallstackData& operator=(const CallstackData& RHS)  {
-
-                Address = RHS.Address;
-                Function = RHS.Function;
-                Module = RHS.Module;
-                Line = RHS.Line;
-
-                return (*this);
-            }
-
-        public:
-            Core::JSON::Pointer   Address;
-            Core::JSON::String    Function;
-            Core::JSON::String    Module;
-            Core::JSON::DecUInt32 Line;
-        };
-
 	class SubsystemsData : public Core::JSON::Container {
         public:
             SubsystemsData()
@@ -450,7 +384,7 @@ namespace Plugin {
         void WorkerPoolMetaData(PluginHost::MetaData::Server& data) const {
             _pluginServer->WorkerPool().Snapshot(data);
         }
-        void Callstack(const ThreadId id, Core::JSON::ArrayType<CallstackData>& response) const;
+        void Callstack(const ThreadId id, Core::JSON::ArrayType<PluginHost::CallstackData>& response) const;
         void SubSystems();
         uint32_t Harakiri();
         uint32_t Storeconfig();

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -266,8 +266,11 @@ POP_WARNING()
 
     ExitHandler* ExitHandler::_instance = nullptr;
     Core::CriticalSection ExitHandler::_adminLock;
+    
+    #ifndef __WINDOWS__
     struct sigaction _originalSegmentationHandler;
     struct sigaction _originalAbortHandler;
+    #endif
 
     static string GetDeviceId(PluginHost::Server* dispatcher)
     {

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -266,6 +266,7 @@ POP_WARNING()
 
     ExitHandler* ExitHandler::_instance = nullptr;
     Core::CriticalSection ExitHandler::_adminLock;
+    struct sigaction _originalSegmentationHandler;
 
     static string GetDeviceId(PluginHost::Server* dispatcher)
     {
@@ -311,6 +312,24 @@ POP_WARNING()
                 syslog(LOG_NOTICE, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a SIGTERM or SIGQUIT signal. Regular shutdown");
             } else {
                 fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a SIGTERM or SIGQUIT signal. No regular shutdown.\nErrors to follow are collateral damage errors !!!!!!\n");
+                fflush(stderr);
+            }
+
+            ExitHandler::StartShutdown();
+        }
+        else if (signo == SIGSEGV) {
+
+            // From here on we do the best we can do. Have no clue what failed, try to log as much as possible and on
+            // a subsequent segmentation fault, just handle it the old fashion way. The root cause has been logged
+            // by than!
+            sigaction(SIGSEGV, &_originalSegmentationHandler, nullptr);
+
+            ExitHandler::DumpMetadata();
+
+            if (_background) {
+                syslog(LOG_NOTICE, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a segmentation fault. All relevant data dumped");
+            } else {
+                fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a segmentation fault. All relevant data dumped\n");
                 fflush(stderr);
             }
 
@@ -449,6 +468,8 @@ POP_WARNING()
             sigaction(SIGTERM, &sa, nullptr);
             sigaction(SIGQUIT, &sa, nullptr);
             sigaction(SIGUSR1, &sa, nullptr);
+            sigaction(SIGUSR1, &sa, nullptr);
+            sigaction(SIGSEGV, &sa, &_originalSegmentationHandler);
         }
 
         if (atexit(ForcedExit) != 0) {
@@ -831,7 +852,7 @@ POP_WARNING()
                         printf("Pending:     %d\n", static_cast<uint32_t>(metaData.Pending.size()));
                         printf("Poolruns:\n");
                         for (uint8_t index = 0; index < metaData.Slots; index++) {
-                           printf("  Thread%02d|0x%08X: %10d", (index + 1), (uint32_t) metaData.Slot[index].WorkerId, metaData.Slot[index].Runs);
+                           printf("  Thread%02d|0x%16lX: %10d", (index + 1), metaData.Slot[index].WorkerId, metaData.Slot[index].Runs);
                             if (metaData.Slot[index].Job.IsSet() == false) {
                                 printf("\n");
                             }

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -267,6 +267,7 @@ POP_WARNING()
     ExitHandler* ExitHandler::_instance = nullptr;
     Core::CriticalSection ExitHandler::_adminLock;
     struct sigaction _originalSegmentationHandler;
+    struct sigaction _originalAbortHandler;
 
     static string GetDeviceId(PluginHost::Server* dispatcher)
     {
@@ -317,12 +318,14 @@ POP_WARNING()
 
             ExitHandler::StartShutdown();
         }
-        else if (signo == SIGSEGV) {
+        else if ( (signo == SIGSEGV)  || (signo == SIGABRT) ) {
 
             // From here on we do the best we can do. Have no clue what failed, try to log as much as possible and on
             // a subsequent segmentation fault, just handle it the old fashion way. The root cause has been logged
             // by than!
             sigaction(SIGSEGV, &_originalSegmentationHandler, nullptr);
+            sigaction(SIGABRT, &_originalAbortHandler, nullptr);
+
 
             ExitHandler::DumpMetadata();
 
@@ -468,8 +471,8 @@ POP_WARNING()
             sigaction(SIGTERM, &sa, nullptr);
             sigaction(SIGQUIT, &sa, nullptr);
             sigaction(SIGUSR1, &sa, nullptr);
-            sigaction(SIGUSR1, &sa, nullptr);
             sigaction(SIGSEGV, &sa, &_originalSegmentationHandler);
+            sigaction(SIGABRT, &sa, &_originalAbortHandler);
         }
 
         if (atexit(ForcedExit) != 0) {

--- a/Source/WPEFramework/PostMortem.h
+++ b/Source/WPEFramework/PostMortem.h
@@ -72,7 +72,7 @@ namespace PluginHost {
             Add(_T("line"), &Line);
         }
 
-        ~CallstackData() = default;
+        ~CallstackData() override = default;
 
         CallstackData& operator=(const CallstackData& RHS)  {
 

--- a/Source/WPEFramework/PostMortem.h
+++ b/Source/WPEFramework/PostMortem.h
@@ -1,0 +1,152 @@
+ /*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace PluginHost {
+
+    class CallstackData : public Core::JSON::Container {
+    public:
+        CallstackData()
+            : Core::JSON::Container()
+            , Address()
+            , Function()
+            , Module()
+            , Line()
+        {
+            Add(_T("address"), &Address);
+            Add(_T("function"), &Function);
+            Add(_T("module"), &Module);
+            Add(_T("line"), &Line);
+        }
+        CallstackData(const Core::callstack_info& source)
+            : Core::JSON::Container()
+            , Address()
+            , Function()
+            , Module()
+            , Line()
+        {
+            Add(_T("address"), &Address);
+            Add(_T("function"), &Function);
+            Add(_T("module"), &Module);
+            Add(_T("line"), &Line);
+
+            Address = reinterpret_cast<Core::instance_id>(source.address);
+            Function = source.function;
+            if (source.module.empty() == false) {
+                Module = source.module;
+            }
+            if (source.line != static_cast<uint32_t>(~0)) {
+                Line = source.line;
+            }
+        }
+        CallstackData(const CallstackData& copy)
+            : Core::JSON::Container()
+            , Address(copy.Address)
+            , Function(copy.Function)
+            , Module(copy.Module)
+            , Line(copy.Line)
+        {
+            Add(_T("address"), &Address);
+            Add(_T("function"), &Function);
+            Add(_T("module"), &Module);
+            Add(_T("line"), &Line);
+        }
+
+        ~CallstackData() = default;
+
+        CallstackData& operator=(const CallstackData& RHS)  {
+
+            Address = RHS.Address;
+            Function = RHS.Function;
+            Module = RHS.Module;
+            Line = RHS.Line;
+
+            return (*this);
+        }
+
+    public:
+        Core::JSON::Pointer   Address;
+        Core::JSON::String    Function;
+        Core::JSON::String    Module;
+        Core::JSON::DecUInt32 Line;
+    };
+
+    
+    class PostMortemData : public Core::JSON::Container {
+    public:
+        class Callstack : public Core::JSON::Container {
+        public:
+            Callstack& operator=(const Callstack& copy) = delete;
+
+            Callstack() 
+                : Core::JSON::Container()
+                , Id(0)
+                , Data() {
+                Add(_T("id"), &Id);
+                Add(_T("stack"), &Data);
+            }
+            Callstack(Callstack&& move) 
+                : Core::JSON::Container()
+                , Id(move.Id)
+                , Data(move.Data) {
+                Add(_T("id"), &Id);
+                Add(_T("stack"), &Data);
+            }
+            Callstack(const Callstack& copy) 
+                : Core::JSON::Container()
+                , Id(copy.Id)
+                , Data(copy.Data) {
+                Add(_T("id"), &Id);
+                Add(_T("stack"), &Data);
+            }
+            ~Callstack() override = default;
+
+        public:
+            Core::JSON::Pointer                   Id;
+            Core::JSON::ArrayType<CallstackData>  Data;
+        };
+
+    public:
+        PostMortemData(PostMortemData&&) = delete;
+        PostMortemData(const PostMortemData&) = delete;
+        PostMortemData& operator= (const PostMortemData&) = delete;
+
+        PostMortemData()
+            : Core::JSON::Container()
+            , WorkerPool()
+            , Callstacks() {
+            Add(_T("workerpool"), &WorkerPool);
+            Add(_T("stacks"), &Callstacks);
+        }
+        ~PostMortemData() override = default;
+
+    public:
+        MetaData::Server WorkerPool;
+        Core::JSON::ArrayType<Callstack> Callstacks;
+    };
+
+} }
+
+
+ 
+

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -637,7 +637,7 @@ typedef std::string string;
 #ifdef __LINUX__
 typedef pthread_t ThreadId;
 #else
-typedef HANDLE ThreadId;
+typedef DWORD ThreadId;
 #endif
 
 #define QUOTE(str) #str

--- a/Source/core/Thread.cpp
+++ b/Source/core/Thread.cpp
@@ -129,7 +129,7 @@ namespace Core {
     {
 #ifdef __WINDOWS__
 PUSH_WARNING(DISABLE_WARNING_CONVERSION_TO_GREATERSIZE)
-        return (reinterpret_cast<::ThreadId>(::GetCurrentThreadId()));
+        return (::GetCurrentThreadId());
 POP_WARNING()
 #else
         return static_cast<::ThreadId>(pthread_self());

--- a/Source/core/Thread.cpp
+++ b/Source/core/Thread.cpp
@@ -100,7 +100,7 @@ namespace Core {
         err = pthread_attr_destroy(&attr);
         ASSERT(err == 0);
 
-        m_ThreadId = (uint32_t)(size_t)m_hThreadInstance;
+        m_ThreadId = m_hThreadInstance;
 #endif
 
         if (threadName != nullptr) {

--- a/Source/core/Thread.h
+++ b/Source/core/Thread.h
@@ -220,13 +220,7 @@ namespace Core {
         bool Priority(int priority);
         inline ::ThreadId Id() const
         {
-#if defined(__WINDOWS__) || defined(__APPLE__)
-PUSH_WARNING(DISABLE_WARNING_CONVERSION_TO_GREATERSIZE)
-            return (reinterpret_cast<const ::ThreadId>(m_ThreadId));
-POP_WARNING()
-#else
-            return (static_cast<::ThreadId>(m_ThreadId));
-#endif
+            return (m_ThreadId);
         }
         static ::ThreadId ThreadId();
 
@@ -280,15 +274,15 @@ POP_WARNING()
 #ifdef __POSIX__
         Event m_sigExit;
         pthread_t m_hThreadInstance;
-        uint32_t m_ThreadId;
 #endif
 
 #ifdef __WINDOWS__
         Event m_sigExit;
         thread_state m_enumSuspendedState;
         HANDLE m_hThreadInstance;
-        DWORD m_ThreadId;
 #endif
+
+        ::ThreadId m_ThreadId;
         static uint32_t _defaultStackSize;
 
 #ifdef __CORE_EXCEPTION_CATCHING__


### PR DESCRIPTION
…under Crash Handler POC [RDK-40121]

From a Thunder perspective this is a usefull part of this POC. Self-healing, as also explained in the meetings, is an undesirable feature as it break more than it solves. Recovering in a process is unwanted because:
1) Thunder has the concept of out-0of-process. This is for instable or security sensitive plugins.
   Use this feature if you cannot solve the root-cause, develop stable plugins. A process restart resolves all following objections that come with the described self-healing feature.

2) Attempting to self heal the WPEFramework process will push the cause untrackable issues later on because:
   - memory leakages will occure for objects that have been alllocated (but are not freed due to the self healing)
   - synchronisation object might casue deadlock later on (very hard to track the root-cause than) because the self-healing process can not revert locked synchronisation objects.
   - Files might get corrupted as they might have partially written, Self healing can not close these and recover these.
   - State changes on which other components might rely are never send and thus other components might assume the incorrect state as the change might have occured but the notification was not yet end.

Self healing might suggets fast recovery but as explained in the call, the deadlocking mutex might frustrate the end0user even more as the system becomes than irresponsive for a undefined time.

Fault finding with the spamming RDK Service plugins becomes a nightmare as you need to first check if a self-healing process occured to place the latest crash in the right perspective....

So self healing is a bad idea!