### PR TITLE
[MessageExchange] Fix deadlock during flushing

### DIFF
--- a/Source/core/StreamTypeLengthValue.h
+++ b/Source/core/StreamTypeLengthValue.h
@@ -355,9 +355,10 @@ POP_WARNING()
         }
         inline uint32_t Flush()
         {
+            _channel.Flush();
+
             _responses.Lock();
 
-            _channel.Flush();
             _responses.Flush();
             _buffer.Flush();
 


### PR DESCRIPTION
It has been observed that ocassionally write on serial port can lock up with flush. This hangs BluetoothControl and thus Thunder startup.

SerialPort::Write takes SerialPort mutex (A), waits on MessageExchange mutex (B) via SendData
MessageExchange::Flush takes MessageExchange mutex (B), waits on SerialPort mutex (A) via SocketPort::Flush
