### PR TITLE
[SECURITY] Add a framework to enable a COMRPCServer per plugin.

### DIFF
--- a/Source/WPEFramework/Config.h
+++ b/Source/WPEFramework/Config.h
@@ -254,7 +254,6 @@ namespace PluginHost {
                 Core::JSON::Boolean OutputEnabled;
             };
 
-
             class Observables : public Core::JSON::Container {
             public:
                 Observables& operator= (const Observables&);

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -426,6 +426,13 @@ namespace PluginHost
                         _jsonrpc->Activate(this);
                     }
 
+                    if (_external.Connector().empty() == false) {
+                        uint32_t result = _external.Open(0);
+                        if ((result != Core::ERROR_NONE) && (result != Core::ERROR_INPROGRESS)) {
+                            TRACE(Trace::Error, (_T("Could not open the external connector for %s"), Callsign().c_str()));
+                        }
+                    }
+
                     SYSLOG(Logging::Startup, (_T("Activated plugin [%s]:[%s]"), className.c_str(), callSign.c_str()));
                     Lock();
                     State(ACTIVATED);
@@ -549,6 +556,9 @@ namespace PluginHost
 
                 if (_jsonrpc != nullptr) {
                     _jsonrpc->Deactivate();
+                }
+                if (_external.Connector().empty() == false) {
+                    _external.Close(0);
                 }
             }
 

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -933,6 +933,37 @@ namespace PluginHost {
             };
 
         private:
+            class ExternalAccess : public RPC::Communicator {
+            public:
+                ExternalAccess() = delete;
+                ExternalAccess(ExternalAccess&&) = delete;
+                ExternalAccess(const ExternalAccess&) = delete;
+                ExternalAccess& operator=(const ExternalAccess&) = delete;
+
+                ExternalAccess(
+                    const Core::NodeId& source,
+                    const string& proxyStubPath)
+                    : RPC::Communicator(source, proxyStubPath)
+                    , _plugin(nullptr)
+                {
+                    //engine->Announcements(Announcement());
+                }
+                ~ExternalAccess() override = default;
+
+            public:
+                void SetInterface(Core::IUnknown* plugin) {
+                    ASSERT((_plugin == nullptr) ^ (plugin == nullptr));
+                    _plugin = plugin;
+                }
+
+            private:
+                void* Acquire(const string& /* className */, const uint32_t interfaceId, const uint32_t /* versionId */) override {
+                    return (_plugin->QueryInterface(interfaceId));
+                }
+
+            private:
+                Core::IUnknown* _plugin;
+            };
             class Condition {
             private:
                 enum state : uint8_t {
@@ -1128,9 +1159,27 @@ namespace PluginHost {
                 std::vector<PluginHost::ISubSystem::subsystem> _control;
                 string _versionHash;
             };
+            static Core::NodeId PluginNodeId(const string& basePath, const Core::JSON::String& communicator) {
+                Core::NodeId result;
+                if (communicator.IsSet() == true) {
+                    if (strchr(communicator.Value().c_str(), '/') == nullptr) {
+                        result = Core::NodeId(communicator.Value().c_str());
+                    }
+                    else {
+                        uint8_t index = 0;
+                        string path = communicator.Value();
+                        while (path[index] == '/') {
+                            index++;
+                        }
+                        result = Core::NodeId((basePath + path.substr(index)).c_str());
+                    }
+                }
+                return (result);
+            }
 
         public:
             Service() = delete;
+            Service(Service&&) = delete;
             Service(const Service&) = delete;
             Service& operator=(const Service&) = delete;
 
@@ -1155,6 +1204,7 @@ namespace PluginHost {
                 , _lastId(0)
                 , _metadata()
                 , _library()
+                , _external(PluginNodeId(server.VolatilePath() + plugin.Callsign.Value() + '/', plugin.Communicator), server.ProxyStubPath())
                 , _administrator(administrator)
             {
             }
@@ -1912,6 +1962,8 @@ namespace PluginHost {
                     _precondition.Evaluate(events);
                     _termination.Evaluate(events);
 
+                    _external.SetInterface(newIF);
+
                     _pluginHandling.Unlock();
                 }
             }
@@ -1972,7 +2024,7 @@ namespace PluginHost {
                 _pluginHandling.Unlock();
 
                 if (currentIF != nullptr) {
-
+                    _external.SetInterface(nullptr);
                     currentIF->Release();
                 }
 
@@ -2004,6 +2056,7 @@ namespace PluginHost {
             ControlData _metadata;
             Core::Library _library;
             void* _hibernateStorage;
+            ExternalAccess _external;
             ServiceMap& _administrator;
             static Core::ProxyType<Web::Response> _unavailableHandler;
             static Core::ProxyType<Web::Response> _missingHandler;
@@ -4397,7 +4450,7 @@ POP_WARNING()
                 
                 std::list<Core::callstack_info> stackList;
 
-                ::DumpCallStack(index.Current().Id.Value(), stackList);
+                ::DumpCallStack(static_cast<ThreadId>(index.Current().Id.Value()), stackList);
 
                 PostMortemData::Callstack dump;
                 dump.Id = index.Current().Id.Value();

--- a/Source/core/IPCChannel.h
+++ b/Source/core/IPCChannel.h
@@ -202,8 +202,6 @@ namespace Core {
             , _connector()
             , _bufferSize(bufferSize)
         {
-            ASSERT(node.IsValid() == true);
-
             static_assert(INTERNALFACTORY == true, "This constructor can only be called if you specify an INTERNAL factory");
 
             if (node.IsValid() == true) {
@@ -225,8 +223,6 @@ namespace Core {
             , _connector()
             , _bufferSize(bufferSize)
         {
-            ASSERT(node.IsValid() == true);
-
             static_assert(INTERNALFACTORY == false, "This constructor can only be called if you specify an EXTERNAL factory");
 
             if (node.IsValid() == true) {
@@ -256,6 +252,13 @@ namespace Core {
         }
 
     public:
+        uint32_t Open(const uint32_t waitTime) {
+            ASSERT(_connector.empty() == false);
+            return (SocketListner::Open(waitTime));
+        }
+        uint32_t Close(const uint32_t waitTime) {
+            return (SocketListner::Close(waitTime));
+        }
         // void action(const Client& client)
         template<typename ACTION>
         void Visit(ACTION&& action) {

--- a/Source/extensions/localtracer/include/localtracer/localtracer.h
+++ b/Source/extensions/localtracer/include/localtracer/localtracer.h
@@ -11,7 +11,9 @@ namespace Messaging {
     class EXTERNAL LocalTracer {
     public:
         struct EXTERNAL ICallback {
-            virtual void Output(const Core::Messaging::IStore::Information& info, const Core::Messaging::IEvent* message) = 0;
+            virtual ~ICallback() = default;
+
+            virtual void Message(const Core::Messaging::Metadata& metadata, const string& message) = 0;
         };
 
     private:
@@ -67,7 +69,7 @@ namespace Messaging {
         LocalTracer(const LocalTracer&) = delete;
         LocalTracer& operator=(const LocalTracer&) = delete;
 
-        ~LocalTracer()
+        virtual ~LocalTracer()
         {
             _worker.Stop();
 
@@ -77,6 +79,10 @@ namespace Messaging {
 
         void Close()
         {
+            _adminLock.Lock();
+            _callback = nullptr;
+            _adminLock.Unlock();
+
             Messaging::MessageUnit::Instance().Close();
 
             Core::Directory(_path.c_str()).Destroy();
@@ -158,8 +164,8 @@ namespace Messaging {
         void Dispatch()
         {
             _client.WaitForUpdates(Core::infinite);
-            _client.PopMessagesAndCall([this](const Core::Messaging::IStore::Information& info, const Core::ProxyType<Core::Messaging::IEvent>& message) {
-                Output(info, message.Origin());
+            _client.PopMessagesAndCall([this](const Core::Messaging::Metadata& metadata, const Core::ProxyType<Core::Messaging::IEvent>& message) {
+                Message(metadata, message->Data());
             });
         }
 
@@ -173,12 +179,12 @@ namespace Messaging {
         }
 
     private:
-        void Output(const Core::Messaging::IStore::Information& info, const Core::Messaging::IEvent* message)
+        void Message(const Core::Messaging::Metadata& metadata, const string& message)
         {
             Core::SafeSyncType<Core::CriticalSection> scopedLock(_adminLock);
 
             if (_callback != nullptr) {
-                _callback->Output(info, message);
+                _callback->Message(metadata, message);
             }
         }
 
@@ -194,27 +200,6 @@ namespace Messaging {
     };
 
     class ConsolePrinter : public Messaging::LocalTracer::ICallback {
-    private:
-        class IosFlagSaver {
-        public:
-            explicit IosFlagSaver(std::ostream& _ios)
-                : ios(_ios)
-                , f(_ios.flags())
-            {
-            }
-            ~IosFlagSaver()
-            {
-                ios.flags(f);
-            }
-
-            IosFlagSaver(const IosFlagSaver&) = delete;
-            IosFlagSaver& operator=(const IosFlagSaver&) = delete;
-
-        private:
-            std::ostream& ios;
-            std::ios::fmtflags f;
-        };
-
     public:
         ConsolePrinter(const ConsolePrinter&) = delete;
         ConsolePrinter& operator=(const ConsolePrinter&) = delete;
@@ -225,30 +210,36 @@ namespace Messaging {
         }
         virtual ~ConsolePrinter() = default;
 
-        void Output(const Core::Messaging::IStore::Information& info, const Core::Messaging::IEvent* message) override
+        void Message(const Core::Messaging::Metadata& metadata, const string& message) override
         {
-            IosFlagSaver saveUs(std::cout);
+            string output;
 
-            std::ostringstream output;
+            ASSERT(metadata.Type() == Core::Messaging::Metadata::type::TRACING);
 
-            output.str("");
-            output.clear();
-
-            Core::Time now(info.TimeStamp());
+            ASSERT(dynamic_cast<const Core::Messaging::IStore::Tracing*>(&metadata) != nullptr);
+            const Core::Messaging::IStore::Tracing& trace = static_cast<const Core::Messaging::IStore::Tracing&>(metadata);
+            const Core::Time now(trace.TimeStamp());
 
             if (_abbreviated == true) {
-                std::string time(now.ToTimeOnly(true));
-                output << '[' << time.c_str() << ']'
-                       << '[' << info.Module() << "]"
-                       << '[' << info.Category() << "]: "
-                       << message->Data().c_str() << std::endl;
+                const string time(now.ToTimeOnly(true));
+                output = Core::Format("[%s]:[%s]:[%s]: %s",
+                    time.c_str(),
+                    metadata.Module().c_str(),
+                    metadata.Category().c_str(),
+                    message.c_str());
             } else {
-                std::string time(now.ToRFC1123(true));
-                output << '[' << time.c_str() << "]:[" << Core::FileNameOnly(info.FileName().c_str()) << ':' << info.LineNumber() << "] "
-                       << info.Category() << ": " << message->Data().c_str() << std::endl;
+                const string time(now.ToRFC1123(true));
+                output = Core::Format("[%s]:[%s]:[%s:%u]:[%s]:[%s]: %s",
+                    time.c_str(),
+                    metadata.Module().c_str(),
+                    Core::FileNameOnly(trace.FileName().c_str()),
+                    trace.LineNumber(),
+                    trace.ClassName().c_str(),
+                    metadata.Category().c_str(),
+                    message.c_str());
             }
-
-            std::cout << output.str() << std::flush;
+            std::cout << output << std::endl
+                      << std::flush;
         }
 
     private:

--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -216,6 +216,7 @@ namespace Plugin {
             , SystemRootPath()
             , StartupOrder(50)
             , Startup(PluginHost::IShell::startup::DEACTIVATED)
+            , Communicator()
         {
             Add(_T("callsign"), &Callsign);
             Add(_T("locator"), &Locator);
@@ -232,6 +233,7 @@ namespace Plugin {
             Add(_T("systemrootpath"), &SystemRootPath);
             Add(_T("startuporder"), &StartupOrder);
             Add(_T("startmode"), &Startup);
+            Add(_T("communicator"), &Communicator);
         }
         Config(const Config& copy)
             : Core::JSON::Container()
@@ -250,6 +252,7 @@ namespace Plugin {
             , SystemRootPath(copy.SystemRootPath)
             , StartupOrder(copy.StartupOrder)
             , Startup(copy.Startup)
+            , Communicator(copy.Communicator)
         {
             Add(_T("callsign"), &Callsign);
             Add(_T("locator"), &Locator);
@@ -266,6 +269,7 @@ namespace Plugin {
             Add(_T("systemrootpath"), &SystemRootPath);
             Add(_T("startuporder"), &StartupOrder);
             Add(_T("startmode"), &Startup);
+            Add(_T("communicator"), &Communicator);
         }
         ~Config() override = default;
 
@@ -286,6 +290,7 @@ namespace Plugin {
             SystemRootPath = RHS.SystemRootPath;
             StartupOrder = RHS.StartupOrder;
             Startup = RHS.Startup;
+            Communicator = RHS.Communicator;
 
             return (*this);
         }
@@ -318,6 +323,7 @@ namespace Plugin {
         Core::JSON::String SystemRootPath;
         Core::JSON::DecUInt32 StartupOrder;
         Core::JSON::EnumType<PluginHost::IShell::startup> Startup;
+        Core::JSON::String Communicator;
 
         static Core::NodeId IPV4UnicastNode(const string& ifname);
 


### PR DESCRIPTION
For security concerns, it is preferred to limit the access over COMRPC to the Thunder global communicator port. It is preferred to get a dedicated connector per plugin and in such a way limit the access to the plugins by limiting the access to only that plugin. This way, using containers, access in the container can be opened up to only a specific subsets of plugins. This can be done in conrainers, through domain sockets, file access/exposure of the domain socket in the container, or punching through a listening TCP socket using IPTables.

This feature is included in the Thunder framework and needs no dedicated support/alterations in the plugin or plugin code. If in the main section of the plugin configuration a field "communicator" (as for the main thunder app config) is declared, that will trigger the opening of a dedicated COMRPC socket for that connector.

If the field value of the "communicator" has a forward slash in the name, e.g. "/communicator|0777", Thunder will open a domain socket at <volatilepath>/<callsign>/communicator for listening for incoming COMRPC requests (Acquire) specific for this plugin (no programatical way to reach another plugin) If the field value of the "communicator" has no forward slash in the name, it will be interpreted as a TCP socket. The expectation is that the field is organised as "<IP Address>:<portnumber>", "localhost:<portnumber>" or "<hostname>:portnumber"

It goes without saying that this port is only open if the plugin is active. If it is deactivated the listening and all client sockets are closed!