### PR TITLE
[WARNINGS] Mark Core::Format as printf-style

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -3704,7 +3704,7 @@ POP_WARNING()
                     }
                     string message;
                     _element->ToString(message);
-                    return (Core::Format(_T("{ \"type\": \"WS\", \"callsign\": \"%s\", \"message\": %s }"), Callsign(), message.c_str()));
+                    return (Core::Format(_T("{ \"type\": \"WS\", \"callsign\": \"%s\", \"message\": %s }"), Callsign().c_str(), message.c_str()));
                 }
 
             private:

--- a/Source/WPEFramework/WarningReportingCategories.h
+++ b/Source/WPEFramework/WarningReportingCategories.h
@@ -89,7 +89,7 @@ namespace WarningReporting {
             visitor = Core::Format(_T("It took suspiciously long to switch plugin [%s] to state [%s]"),
                 _callsign.c_str(),
                 StateAsString(_stateChange).c_str());
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 5000 };
@@ -209,7 +209,7 @@ namespace WarningReporting {
             visitor = Core::Format(_T("It took suspiciously long to handle an incoming message of type [%s] with content [%s]"),
                 TypeAsString(_type).c_str(),
                 (_content.c_str() == nullptr ? _T("<empty>") : _content.c_str()));
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 500 };

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -243,6 +243,7 @@ PUSH_WARNING( \
 #include <array>
 #include <thread>
 #include <stdarg.h> /* va_list, va_start, va_arg, va_end */
+#include <inttypes.h>
 
 #define AF_NETLINK 16
 #define AF_PACKET  17
@@ -378,6 +379,7 @@ typedef std::string string;
 #include <pthread.h>
 #include <sched.h>
 #include <signal.h>
+#include <inttypes.h>
 
 #include <sys/ioctl.h>
 #include <sys/resource.h>
@@ -506,14 +508,17 @@ inline void EXTERNAL SleepS(unsigned int a_Time)
 #define DEPRECATED __attribute__((deprecated))
 #define VARIABLE_IS_NOT_USED __attribute__((unused))
 #define WARNING_RESULT_NOT_USED __attribute__((warn_unused_result))
+#define PRINTF_FORMAT(fmt, ellipsis) __attribute__ ((format (printf, fmt, ellipsis)))
 #elif defined(_MSC_VER)
 #define DEPRECATED __declspec(deprecated)
 #define VARIABLE_IS_NOT_USED
 #define WARNING_RESULT_NOT_USED
+#define PRINTF_FORMAT(fmt, ellipsis)
 #else
 #define DEPRECATED
 #define VARIABLE_IS_NOT_USED
 #define WARNING_RESULT_NOT_USED
+#define PRINTF_FORMAT(fmt, ellipsis)
 #endif
 
 #if !defined(NDEBUG)
@@ -734,8 +739,8 @@ namespace Core {
         std::transform(inplace.begin(), inplace.end(), inplace.begin(), ::tolower);
     }
 
-    string EXTERNAL Format(const TCHAR formatter[], ...);
-    void EXTERNAL Format(string& dst, const TCHAR format[], ...);
+    string EXTERNAL Format(const TCHAR formatter[], ...) PRINTF_FORMAT(1, 2);
+    void EXTERNAL Format(string& dst, const TCHAR format[], ...) PRINTF_FORMAT(2, 3);
     void EXTERNAL Format(string& dst, const TCHAR format[], va_list ap);
 
     const uint32_t infinite = -1;

--- a/Source/core/WarningReportingCategories.h
+++ b/Source/core/WarningReportingCategories.h
@@ -46,7 +46,7 @@ namespace WarningReporting {
         void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
         {
             visitor = (_T("It took suspiciously long to acquire a critical section"));
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 1000 };
@@ -74,7 +74,7 @@ namespace WarningReporting {
         void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
         {
             visitor = (_T("A sink still holds a reference when it is being destructed"));
-            visitor += Core::Format(_T(", value %lld, max allowed %lld"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 ", max allowed %" PRId64), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 0 };
@@ -130,7 +130,7 @@ namespace WarningReporting {
         {
             visitor = _T("RPC call of method ");
             visitor += Core::Format(_T("[%d] on interface [%d] took to long"), _methodId, _interfaceId);
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 750 };
@@ -162,7 +162,7 @@ namespace WarningReporting {
         void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
         {
             visitor = (_T("Job took too long to finish"));
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 7500 };
@@ -190,7 +190,7 @@ namespace WarningReporting {
         void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
         {
             visitor = (_T("Job waiting in queue to be executed took too long"));
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 400 };
@@ -218,7 +218,7 @@ namespace WarningReporting {
         void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
         {
             visitor = (_T("Decrypt call took too long"));
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
 
         };
 
@@ -247,7 +247,7 @@ namespace WarningReporting {
         void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
         {
             visitor = (_T("Job is taking too long to complete the execution, a potentail deadlock issue.."));
-            visitor += Core::Format(_T(", value %lld [ms], max allowed %lld [ms]"), actualValue, maxValue);
+            visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
         };
 
         static constexpr uint32_t DefaultWarningBound = { 20000 };


### PR DESCRIPTION
Set the printf format attribute on Core::Format so the compiler can detect invalid printf-style format strings. Fix warnings generated