### PR TITLE
[Actions] Generate preview documentation on PR

### DIFF
--- a/.github/workflows/Documentation Preview.yml
+++ b/.github/workflows/Documentation Preview.yml
@@ -1,0 +1,32 @@
+name: Preview Thunder Documentation
+
+# If a PR modifies the docs directory, then regenerate a preview of the github
+# pages site for easier review
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - 'docs/**'
+
+concurrency: preview-${{ github.ref }}
+
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -16,5 +16,9 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material
-
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: site
+          clean-exclude: pr-preview/


### PR DESCRIPTION
If a PR is opened that modifies the files in the `docs` directory, generate a preview version of the GitHub pages site for easy review.