### PR TITLE
RDK-41134: Improve Thunder crash logging.

### DIFF
--- a/Source/WPEFramework/PluginHost.h
+++ b/Source/WPEFramework/PluginHost.h
@@ -1,0 +1,12 @@
+#ifndef __PLUGINHOST_H
+#define __PLUGINHOST_H
+
+namespace WPEFramework {
+    namespace PluginHost {
+        extern "C" {
+
+        void SetupCrashHandler(void);
+        }
+    }
+}
+#endif // __PLUGINHOST_H

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -19,6 +19,7 @@
 
 #include "PluginServer.h"
 #include "Controller.h"
+#include "PluginHost.h"
 
 #ifndef __WINDOWS__
 #include <syslog.h>
@@ -187,6 +188,9 @@ namespace PluginHost
 
         WARNING_REPORTING_THREAD_SETCALLSIGN_GUARD(callsign.c_str());
     #endif
+
+    /* Ensuring that crash handler is set up in case it has been over-ridden */
+    SetupCrashHandler();
 
     #ifdef __CORE_EXCEPTION_CATCHING__
 

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -4463,7 +4463,8 @@ POP_WARNING()
             }
 
             // Drop the workerpool info (what is currently running and what is pending) to a file..
-            Core::File dumpFile(_config.PostMortemPath() + "ThunderInternals.json");
+            string time = std::to_string(Core::Time::Now().Ticks());
+            Core::File dumpFile(_config.PostMortemPath() + "ThunderInternals_" + time + ".json");
             if (dumpFile.Create(false) == true) {
                 data.IElement::ToFile(dumpFile);
             }


### PR DESCRIPTION
Created patch on master thunder.

1. Registered ExitDaemonHandler for SIGSEGV and SIGABRT, just before Dispatch.
2. Restored Google breakpad handler for SIGSEGV and SIGABRT after dumping data.
3. Changed Dumping File name from ThunderInternals.json to ThunderInternals_<time>.json

Note:
ThunderInternals_<time>.json file path is /opt/minidumps/ .