### PR TITLE
Add a new deactivation reason "MemoryExceededOnSuspend"

### DIFF
--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -72,6 +72,7 @@ namespace PluginHost {
             AUTOMATIC,
             FAILURE,
             MEMORY_EXCEEDED,
+            MEMORY_EXCEEDED_ON_SUSPEND,
             STARTUP,
             SHUTDOWN,
             CONDITIONS,

--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -41,6 +41,7 @@ ENUM_CONVERSION_BEGIN(PluginHost::IShell::reason)
     { PluginHost::IShell::AUTOMATIC, _TXT("Automatic") },
     { PluginHost::IShell::FAILURE, _TXT("Failure") },
     { PluginHost::IShell::MEMORY_EXCEEDED, _TXT("MemoryExceeded") },
+    { PluginHost::IShell::MEMORY_EXCEEDED_ON_SUSPEND, _TXT("MemoryExceededOnSuspend") },
     { PluginHost::IShell::STARTUP, _TXT("Startup") },
     { PluginHost::IShell::SHUTDOWN, _TXT("Shutdown") },
     { PluginHost::IShell::CONDITIONS, _TXT("Conditions") },


### PR DESCRIPTION
This is added to decide whether to discard a plugin (like WebKitBrowser) if it takes more memory on suspended state