### PR TITLE
[DANGLING] Decouple Dangling reporting from the Communication thread.

### DIFF
--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -335,7 +335,7 @@ namespace RPC {
         return(index != _stubs.end() ? index->second->Convert(rawImplementation) : nullptr);
     }
 
-    void Administrator::DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, std::list<ProxyStub::UnknownProxy*>& pendingProxies)
+    void Administrator::DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, Proxies& pendingProxies)
     {
         _adminLock.Lock();
 

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -197,7 +197,7 @@ namespace RPC {
             return (_factory.Element());
         }
 
-        void DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, std::list<ProxyStub::UnknownProxy*>& pendingProxies);
+        void DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, Proxies& pendingProxies);
 
         template <typename ACTUALINTERFACE>
         ACTUALINTERFACE* ProxyFind(const Core::ProxyType<Core::IPCChannel>& channel, const Core::instance_id& impl)

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -769,7 +769,7 @@ namespace Core {
 
     struct EXTERNAL IUnknown : public IReferenceCounted  {
 
-        enum {
+        enum : uint32_t {
             ID_OFFSET_INTERNAL  = 0x00000000,
             ID_OFFSET_PUBLIC    = 0x00000040,
             ID_OFFSET_CUSTOM    = 0x80000000

--- a/Source/messaging/MessageUnit.h
+++ b/Source/messaging/MessageUnit.h
@@ -624,7 +624,7 @@ namespace WPEFramework {
                     _channel.Open(Core::infinite);
                 }
                 ~Client() {
-                    _channel.Close(Core::infinite);
+                    _channel.Close(100);
                 }
 
             public:


### PR DESCRIPTION
The reporting of dangling objects was triggered by the Close of a communication channel. The communication thread triggeres this Close and thus the reporting of the Dangling pointers is done on the communication thread.

Stephen Foulds created a test app to validate the Dangling Pointer notification (see https://github.com/TeknoVenus/ComRpcDanglingTest) this test case forwards the handling of the dangling notification to an out-of-process part of the plugin. This was causing a deadlock as the Dangling pointer was reported (and thus handled) on the communication thread and now this communication thread is needed to "send" and "receive" the COMRPC messages. However that will not work as the communication thread is now *blocked* in the COMRPC invoke.

With this PR, the application  is working correctly.

Tested it under Windows, updated Stephen's example app above to run on Windows :-) See: https://github.com/pwielders/ComRpcDanglingTest