### PR TITLE
[Messaging] Fixing an issue with the REPORT_DURATION_WARNING macro

### DIFF
--- a/Source/core/WarningReportingControl.h
+++ b/Source/core/WarningReportingControl.h
@@ -32,6 +32,7 @@
 #include "TypeTraits.h"
 #include <unordered_set>
 #include <vector>
+#include <iostream>
 
 #ifndef __CORE_WARNING_REPORTING__
 
@@ -110,9 +111,9 @@
 
 #define REPORT_DURATION_WARNING(CODE, CATEGORY, ...)                                                                                                           \
     if (WPEFramework::WarningReporting::WarningReportingType<WPEFramework::WarningReporting::WarningReportingBoundsCategory<CATEGORY>>::IsEnabled() == true) { \
-        WPEFramework::Core::Time start = WPEFramework::Core::Time::Now();                                                                                      \
+        uint64_t start = WPEFramework::Core::SystemInfo::Instance().Ticks();                                                                                   \
         CODE                                                                                                                                                   \
-            uint32_t duration = static_cast<uint32_t>((Core::Time::Now().Ticks() - start.Ticks()) / Core::Time::TicksPerMillisecond);                          \
+        uint64_t duration = (WPEFramework::Core::SystemInfo::Instance().Ticks() - start) / 1000;                                                               \
         WPEFramework::WarningReporting::WarningReportingType<WPEFramework::WarningReporting::WarningReportingBoundsCategory<CATEGORY>> __message__;            \
         if (__message__.Analyze(WPEFramework::Core::System::MODULE_NAME,                                                                                       \
                 WPEFramework::Core::CallsignTLS::CallsignAccess<&WPEFramework::Core::System::MODULE_NAME>::Callsign(),                                         \

--- a/Source/core/WarningReportingControl.h
+++ b/Source/core/WarningReportingControl.h
@@ -112,7 +112,7 @@
     if (WPEFramework::WarningReporting::WarningReportingType<WPEFramework::WarningReporting::WarningReportingBoundsCategory<CATEGORY>>::IsEnabled() == true) { \
         uint64_t start = WPEFramework::Core::SystemInfo::Instance().Ticks();                                                                                   \
         CODE                                                                                                                                                   \
-        uint64_t duration = (WPEFramework::Core::SystemInfo::Instance().Ticks() - start) / WPEFramework::Core::Time::MicroSecondsPerMilliSecond;                                                               \
+        uint64_t duration = (WPEFramework::Core::SystemInfo::Instance().Ticks() - start) / WPEFramework::Core::Time::MicroSecondsPerMilliSecond;               \
         WPEFramework::WarningReporting::WarningReportingType<WPEFramework::WarningReporting::WarningReportingBoundsCategory<CATEGORY>> __message__;            \
         if (__message__.Analyze(WPEFramework::Core::System::MODULE_NAME,                                                                                       \
                 WPEFramework::Core::CallsignTLS::CallsignAccess<&WPEFramework::Core::System::MODULE_NAME>::Callsign(),                                         \

--- a/Source/core/WarningReportingControl.h
+++ b/Source/core/WarningReportingControl.h
@@ -32,7 +32,6 @@
 #include "TypeTraits.h"
 #include <unordered_set>
 #include <vector>
-#include <iostream>
 
 #ifndef __CORE_WARNING_REPORTING__
 

--- a/Source/core/WarningReportingControl.h
+++ b/Source/core/WarningReportingControl.h
@@ -112,7 +112,7 @@
     if (WPEFramework::WarningReporting::WarningReportingType<WPEFramework::WarningReporting::WarningReportingBoundsCategory<CATEGORY>>::IsEnabled() == true) { \
         uint64_t start = WPEFramework::Core::SystemInfo::Instance().Ticks();                                                                                   \
         CODE                                                                                                                                                   \
-        uint64_t duration = (WPEFramework::Core::SystemInfo::Instance().Ticks() - start) / 1000;                                                               \
+        uint64_t duration = (WPEFramework::Core::SystemInfo::Instance().Ticks() - start) / WPEFramework::Core::Time::MicroSecondsPerMilliSecond;                                                               \
         WPEFramework::WarningReporting::WarningReportingType<WPEFramework::WarningReporting::WarningReportingBoundsCategory<CATEGORY>> __message__;            \
         if (__message__.Analyze(WPEFramework::Core::System::MODULE_NAME,                                                                                       \
                 WPEFramework::Core::CallsignTLS::CallsignAccess<&WPEFramework::Core::System::MODULE_NAME>::Callsign(),                                         \


### PR DESCRIPTION
The macro was using Ticks() method from Core::Time, and thus if the `TimeSync` plugin was initialized exactly when the code inside the `REPORT_DURATION_WARNING` macro was being executed, we were getting a situation where Thunder could potentially become a time machine:

The amount of ticks before was higher than the one after, resulting in the negative duration, which then was static-casted to an unsinged integer, resulting in a weirdly huge duration time.

Now this should be fixed since SystemInfo always uses `std::chrono::steady_clock`.