### PR TITLE
[Messaging] Fixing the issues with messaging on framework shutdown

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1948,7 +1948,7 @@ namespace Core {
                         } else if (current == '\"') {
                             // We are done! leave this element.
                             finished = true;
-                        } else if (current >= 0x0 && current <= 0x1F) {
+                        } else if (current <= 0x1F) {
                             error = Error{ "Unescaped control character detected" };
                         } else {
                             // Just copy and onto the next;

--- a/Source/core/MessageStore.cpp
+++ b/Source/core/MessageStore.cpp
@@ -49,6 +49,7 @@ namespace WPEFramework {
 
                 ASSERT(std::find(_controlList.begin(), _controlList.end(), control) == _controlList.end());
                 _controlList.push_back(control);
+
                 _adminLock.Unlock();
             }
 

--- a/Source/core/MessageStore.cpp
+++ b/Source/core/MessageStore.cpp
@@ -21,6 +21,7 @@
 #include "Proxy.h"
 #include "Sync.h"
 #include "Frame.h"
+#include "Singleton.h"
 
 namespace WPEFramework {
 
@@ -88,8 +89,7 @@ namespace WPEFramework {
 
         Controls& ControlsInstance()
         {
-            static Controls controls;
-            return (controls);
+            return (Core::SingletonType<Controls>::Instance());
         }
 
         static Core::Messaging::IStore* _storage;

--- a/Source/core/MessageStore.cpp
+++ b/Source/core/MessageStore.cpp
@@ -49,7 +49,6 @@ namespace WPEFramework {
 
                 ASSERT(std::find(_controlList.begin(), _controlList.end(), control) == _controlList.end());
                 _controlList.push_back(control);
-
                 _adminLock.Unlock();
             }
 
@@ -86,7 +85,12 @@ namespace WPEFramework {
             ControlList _controlList;
         };
 
-        static Controls _registeredControls;
+        Controls& ControlsInstance()
+        {
+            static Controls controls;
+            return (controls);
+        }
+
         static Core::Messaging::IStore* _storage;
     }
 
@@ -362,7 +366,7 @@ namespace Core {
 
         /* static */ void IControl::Announce(IControl* control)
         {
-            _registeredControls.Announce(control);
+            ControlsInstance().Announce(control);
 
             if (_storage != nullptr) {
                 control->Enable(_storage->Default(control->Metadata()));
@@ -370,11 +374,11 @@ namespace Core {
         }
 
         /* static */ void IControl::Revoke(IControl* control) {
-            _registeredControls.Revoke(control);
+            ControlsInstance().Revoke(control);
         }
 
         /* static */ void IControl::Iterate(IControl::IHandler& handler) {
-            _registeredControls.Iterate(handler);
+            ControlsInstance().Iterate(handler);
         }
 
         /* static */ IStore* IStore::Instance() {

--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -120,6 +120,7 @@ namespace Core {
 #ifdef __DEBUG__
             // All resources should be gone !!!
             for (const auto& resource : _resourceList) {
+                TRACE_L1("Resource name: %s", typeid(resource).name());
                 ASSERT(resource == nullptr);
             }
 #endif

--- a/Source/core/WarningReportingControl.h
+++ b/Source/core/WarningReportingControl.h
@@ -132,6 +132,7 @@ namespace WPEFramework {
 namespace Core {
     template <typename THREADLOCALSTORAGE>
     class ThreadLocalStorageType;
+    class CriticalSection;
 }
 
 namespace WarningReporting {
@@ -174,7 +175,7 @@ namespace WarningReporting {
         WarningReportingUnitProxy(const WarningReportingUnitProxy&) = delete;
         WarningReportingUnitProxy& operator=(const WarningReportingUnitProxy&) = delete;
 
-        ~WarningReportingUnitProxy() = default;
+        ~WarningReportingUnitProxy();
 
         static WarningReportingUnitProxy& Instance();
 
@@ -188,17 +189,14 @@ namespace WarningReporting {
         void FillBoundsConfig(const string& boundsConfig, uint32_t& outReportingBound, uint32_t& outWarningBound, string& outSpecificConfig) const;
 
     protected:
-        WarningReportingUnitProxy()
-            : _handler(nullptr)
-            , _waitingAnnounces()
-        {
-        }
+        WarningReportingUnitProxy();
 
     private:
         using WaitingAnnounceContainer = std::vector<IWarningReportingUnit::IWarningReportingControl*>;
 
         IWarningReportingUnit* _handler;
         WaitingAnnounceContainer _waitingAnnounces;
+        Core::CriticalSection* _adminLock;
     };
 
     template <typename CONTROLCATEGORY>

--- a/Source/extensions/warningreporting/WarningReportingUnit.cpp
+++ b/Source/extensions/warningreporting/WarningReportingUnit.cpp
@@ -31,8 +31,7 @@ namespace WarningReporting {
 
     WarningReportingUnit& WarningReportingUnit::Instance()
     {
-        static WarningReportingUnit instance;
-        return (instance);
+        return Core::SingletonType<WarningReportingUnit>::Instance();
     }
 
     WarningReportingUnit::~WarningReportingUnit()

--- a/Source/extensions/warningreporting/WarningReportingUnit.cpp
+++ b/Source/extensions/warningreporting/WarningReportingUnit.cpp
@@ -31,7 +31,8 @@ namespace WarningReporting {
 
     WarningReportingUnit& WarningReportingUnit::Instance()
     {
-        return Core::SingletonType<WarningReportingUnit>::Instance();
+        static WarningReportingUnit instance;
+        return (instance);
     }
 
     WarningReportingUnit::~WarningReportingUnit()


### PR DESCRIPTION
Controls and mutexes are now lazy initialized to ensure a proper destruction of statics when shutting down the framework.

@pwielders as I can't add you as reviewer