### PR TITLE
[Messaging] Necessary adjustments to allow using enum from MessageStore in the interfaces

### DIFF
--- a/Source/core/MessageStore.cpp
+++ b/Source/core/MessageStore.cpp
@@ -21,8 +21,17 @@
 #include "Proxy.h"
 #include "Sync.h"
 #include "Frame.h"
+#include "Enumerate.h"
 
 namespace WPEFramework {
+
+ENUM_CONVERSION_BEGIN(Core::Messaging::Metadata::type)
+    { Core::Messaging::Metadata::type::TRACING, _TXT("Tracing") },
+    { Core::Messaging::Metadata::type::LOGGING, _TXT("Logging") },
+    { Core::Messaging::Metadata::type::REPORTING, _TXT("Reporting") },
+    { Core::Messaging::Metadata::type::STANDARD_OUT, _TXT("StandardOut") },
+    { Core::Messaging::Metadata::type::STANDARD_ERROR, _TXT("StandardError") },
+ENUM_CONVERSION_END(Core::Messaging::Metadata::type)
 
     namespace {
         /**

--- a/Source/core/MessageStore.h
+++ b/Source/core/MessageStore.h
@@ -55,8 +55,6 @@ namespace Core {
         public:
             Metadata(const Metadata&) = default;
             Metadata& operator=(const Metadata&) = default;
-            Metadata(Metadata&&) = default;
-            Metadata& operator=(Metadata&&) = default;
 
             Metadata()
                 : _type(INVALID)

--- a/Source/core/MessageStore.h
+++ b/Source/core/MessageStore.h
@@ -52,9 +52,13 @@ namespace Core {
                 STANDARD_ERROR = 5
             };
 
+// @stop
+
         public:
             Metadata(const Metadata&) = default;
             Metadata& operator=(const Metadata&) = default;
+            Metadata(Metadata&&) = default;
+            Metadata& operator=(Metadata&&) = default;
 
             Metadata()
                 : _type(INVALID)


### PR DESCRIPTION
@pwielders I also created a PR to ThunderInterfaces (https://github.com/rdkcentral/ThunderInterfaces/pull/266), but I'll have to rerun Actions there after this one is merged