### PR TITLE
[Core] Fix 'non-pointer-type' compilation error

### DIFF
--- a/Source/core/SocketServer.h
+++ b/Source/core/SocketServer.h
@@ -97,7 +97,7 @@ namespace Core {
             }
             inline uint32_t Count() const
             {
-                return (_clients->size());
+                return (_clients.size());
             }
             HANDLECLIENT Client()
             {


### PR DESCRIPTION
Fix compilation error `error: base operand of ‘->’ has non-pointer type` when calling `Clients().Count()` on a socket server