### PR TITLE
[Core] Compile fix for EXCEPTION_CATCHING=ON

### DIFF
--- a/Source/core/CallsignTLS.cpp
+++ b/Source/core/CallsignTLS.cpp
@@ -20,7 +20,7 @@
 #include "CallsignTLS.h"
 #include "Thread.h"
 
-#ifdef __CORE_WARNING_REPORTING__
+#if defined(__CORE_WARNING_REPORTING__) || defined(__CORE_EXCEPTION_CATCHING__)
 
 namespace WPEFramework {
 namespace Core {
@@ -41,4 +41,4 @@ namespace Core {
 }
 } 
 
-#endif
+#endif // defined(__CORE_WARNING_REPORTING__) || defined(__CORE_EXCEPTION_CATCHING__)


### PR DESCRIPTION
Match #if conditions inside CallsighTLS.h and CallsignTLS.cpp