### PR TITLE
[ToFromHex] Enahce the serialization to and from hex strings.

### DIFF
--- a/Source/core/Serialization.cpp
+++ b/Source/core/Serialization.cpp
@@ -158,28 +158,25 @@ POP_WARNING()
 
     static const TCHAR hex_chars[] = "0123456789abcdef";
 
-    void EXTERNAL ToHexString(const uint8_t object[], const uint32_t length, string& result)
+    void EXTERNAL ToHexString(const uint8_t object[], const uint32_t length, string& result, const TCHAR delimiter)
     {
         ASSERT(object != nullptr);
 
         uint32_t index = static_cast<uint32_t>(result.length());
-        result.resize(index + (length * 2));
+        result.resize(index + (length * 2) + (delimiter == '\0' ? 0 : (length - 1)));
 
         result[1] = hex_chars[object[0] & 0xF];
 
         for (uint32_t i = 0, j = index; i < length; i++) {
-            if ((object[i] == '\\') && ((i + 3) < length) && (object[i + 1] == 'x')) {
-                result[j++] = object[i + 2];
-                result[j++] = object[i + 3];
-                i += 3;
-            } else {
-                result[j++] = hex_chars[object[i] >> 4];
-                result[j++] = hex_chars[object[i] & 0xF];
+            if ((delimiter != '\0') && (i > 0)) {
+                result[j++] = delimiter;
             }
+            result[j++] = hex_chars[object[i] >> 4];
+            result[j++] = hex_chars[object[i] & 0xF];
         }
     }
 
-    uint32_t EXTERNAL FromHexString(const string& hexString, uint8_t* object, const uint32_t maxLength)
+    uint32_t EXTERNAL FromHexString(const string& hexString, uint8_t* object, const uint32_t maxLength, const TCHAR delimiter)
     {
         ASSERT(object != nullptr || maxLength == 0); 
         uint8_t highNibble;
@@ -187,14 +184,31 @@ POP_WARNING()
         uint32_t bufferIndex = 0, strIndex = 0;
 
         // assume first character is 0 if length is odd. 
-        if (hexString.length() % 2 == 1) {
+        if ((delimiter == '\0') && (hexString.length() % 2 == 1)) {
             lowNibble = FromHexDigits(hexString[strIndex++]);
             object[bufferIndex++] = lowNibble;
         }
 
         while ((bufferIndex < maxLength) && (strIndex < hexString.length())) {
-            highNibble = FromHexDigits(hexString[strIndex++]);
-            lowNibble = FromHexDigits(hexString[strIndex++]);
+            if (delimiter == '\0') {
+                highNibble = FromHexDigits(hexString[strIndex++]);
+                lowNibble = FromHexDigits(hexString[strIndex++]);
+            }
+            else {
+                uint8_t nibble = FromHexDigits(hexString[strIndex++]);
+                if (hexString[strIndex] == delimiter) {
+                    highNibble = 0;
+                    lowNibble = nibble;
+                    ++strIndex;
+                }
+                else {
+                    highNibble = nibble;
+                    lowNibble = FromHexDigits(hexString[strIndex++]);
+                    if (hexString[strIndex] == delimiter) {
+                        ++strIndex;
+                    }
+                }
+            }
 
             object[bufferIndex++] = (highNibble << 4) + lowNibble; 
         }

--- a/Source/core/Serialization.h
+++ b/Source/core/Serialization.h
@@ -255,8 +255,8 @@ POP_WARNING()
     //------------------------------------------------------------------------
     // Serialize: binary buffer
     //------------------------------------------------------------------------
-    void EXTERNAL ToHexString(const uint8_t object[], const uint32_t length, string& result);
-    uint32_t EXTERNAL FromHexString(const string& hexString, uint8_t* object, const uint32_t maxLength);
+    void EXTERNAL ToHexString(const uint8_t object[], const uint32_t length, string& result, const TCHAR delimiter = '\0');
+    uint32_t EXTERNAL FromHexString(const string& hexString, uint8_t* object, const uint32_t maxLength, const TCHAR delimiter = '\0');
 
     //------------------------------------------------------------------------
     // Serialize: Base64


### PR DESCRIPTION
1) Remove a strange feature where a hex byte array could be prefixed with characters \ and an x ??? I guess this is a check for the layer calling this functionality and should not be part of this. 
2) allow serialization of bytestreams and Deserializeation of bytestreams to include a delimter between the diffreent bytes.

This feature is backwards compatible. Default the '\0' character is passed as the delimiter which means that there will be no delimiting used in either step.