### PR TITLE
[Controller] Bring back IController and fix COMRPCStarter

### DIFF
--- a/Source/WPEFramework/Controller.h
+++ b/Source/WPEFramework/Controller.h
@@ -33,12 +33,12 @@ namespace Plugin {
         : public PluginHost::IPlugin
         , public PluginHost::IWeb
         , public PluginHost::JSONRPC
-        , public Exchange::IController::IConfiguration
-        , public Exchange::IController::IDiscovery
-        , public Exchange::IController::ISystemManagement
-        , public Exchange::IController::IMetadata
-        , public Exchange::IController::ILifeTime
-        , public Exchange::IController::ILifeTime::INotification {
+        , public PluginHost::IController
+        , public Exchange::Controller::IConfiguration
+        , public Exchange::Controller::IDiscovery
+        , public Exchange::Controller::ISystemManagement
+        , public Exchange::Controller::IMetadata
+        , public Exchange::Controller::ILifeTime {
     public:
 	class SubsystemsData : public Core::JSON::Container {
         public:
@@ -333,8 +333,8 @@ namespace Plugin {
         Core::hresult Configuration(const string& callsign, string& configuration) const override;
         Core::hresult Configuration(const string& callsign, const string& configuration) override;
 
-        Core::hresult Register(Exchange::IController::ILifeTime::INotification* notification) override;
-        Core::hresult Unregister(Exchange::IController::ILifeTime::INotification* notification) override;
+        Core::hresult Register(Exchange::Controller::ILifeTime::INotification* notification) override;
+        Core::hresult Unregister(Exchange::Controller::ILifeTime::INotification* notification) override;
 
         Core::hresult Activate(const string& callsign) override;
         Core::hresult Deactivate(const string& callsign) override;
@@ -351,21 +351,23 @@ namespace Plugin {
         Core::hresult Subsystems(string& response) const override;
         Core::hresult Version(string& response) const override;
 
-        void StateChange(const string& callsign, const PluginHost::IShell::state& state, const PluginHost::IShell::reason& reason) override;
-
         //  IUnknown methods
         // -------------------------------------------------------------------------------------------------------
+PUSH_WARNING(DISABLE_WARNING_DEPRECATED_USE) // for now we must support the deprecated interface for backwards compatibility reasons 
+
         BEGIN_INTERFACE_MAP(Controller)
         INTERFACE_ENTRY(PluginHost::IPlugin)
         INTERFACE_ENTRY(PluginHost::IWeb)
         INTERFACE_ENTRY(PluginHost::IDispatcher)
-        INTERFACE_ENTRY(Exchange::IController::IConfiguration)
-        INTERFACE_ENTRY(Exchange::IController::IDiscovery)
-        INTERFACE_ENTRY(Exchange::IController::ISystemManagement)
-        INTERFACE_ENTRY(Exchange::IController::IMetadata)
-        INTERFACE_ENTRY(Exchange::IController::ILifeTime)
-        INTERFACE_ENTRY(Exchange::IController::ILifeTime::INotification)
+        INTERFACE_ENTRY(PluginHost::IController)
+        INTERFACE_ENTRY(Exchange::Controller::IConfiguration)
+        INTERFACE_ENTRY(Exchange::Controller::IDiscovery)
+        INTERFACE_ENTRY(Exchange::Controller::ISystemManagement)
+        INTERFACE_ENTRY(Exchange::Controller::IMetadata)
+        INTERFACE_ENTRY(Exchange::Controller::ILifeTime)
         END_INTERFACE_MAP
+
+POP_WARNING()
 
     private:
         //  ILocalDispatcher methods
@@ -407,7 +409,7 @@ namespace Plugin {
         std::list<string> _resumes;
         uint32_t _lastReported;
         std::vector<PluginHost::ISubSystem::subsystem> _externalSubsystems;
-        std::list<Exchange::IController::ILifeTime::INotification*> _observers;
+        std::list<Exchange::Controller::ILifeTime::INotification*> _observers;
     };
 }
 }

--- a/Source/plugins/CMakeLists.txt
+++ b/Source/plugins/CMakeLists.txt
@@ -24,11 +24,12 @@ option(VIRTUALINPUT_TOOLS "Build VirtualInput tools" OFF)
 ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IPlugin.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IShell.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 ProxyStubGenerator(NAMESPACE "WPEFramework::Exchange" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IController.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
+ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IControllerDeprecated.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IStateControl.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/ISubSystem.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IDispatcher.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
-JsonGenerator(CODE NAMESPACE WPEFramework::Exchange::IController INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IController.h OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/jsonrpc" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.." NO_INCLUDES)
+JsonGenerator(CODE NAMESPACE WPEFramework::Exchange::Controller INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IController.h OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/jsonrpc" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.." NO_INCLUDES)
 
 add_library(${TARGET} SHARED
         Channel.cpp
@@ -56,6 +57,7 @@ set(PUBLIC_HEADERS
         IPlugin.h
         IShell.h
         IController.h
+        IControllerDeprecated.h
         Shell.h
         IStateControl.h
         StateControl.h
@@ -91,6 +93,10 @@ if (WARNING_REPORTING)
               ${NAMESPACE}WarningReporting::${NAMESPACE}WarningReporting
             )
 endif()
+
+# when compiling proxy/stubs we should ignore deprecated warnings (which are treated as erros nowadays) 
+# as usage of those deprecated methods is valid here
+target_compile_options(${TARGET_PROXYSTUBS} PRIVATE -Wno-deprecated-declarations)
 
 target_link_libraries(${TARGET_PROXYSTUBS}
         PRIVATE

--- a/Source/plugins/IController.h
+++ b/Source/plugins/IController.h
@@ -21,11 +21,14 @@
 #include "Module.h"
 #include "IShell.h"
 
+#include "IControllerDeprecated.h"
+
 // @stubgen:include <plugins/IShell.h>
 
 namespace WPEFramework {
+
 namespace Exchange {
-namespace IController {
+namespace Controller {
 
     /* @json */
     struct EXTERNAL ISystemManagement : virtual public Core::IUnknown {
@@ -140,5 +143,7 @@ namespace IController {
         virtual Core::hresult CallStack(const string& index /* @index */, string& callstack /* @out @opaque */) const = 0;
     };
 }
+
 } // namespace Exchange
+
 } // namespace WPEFramework

--- a/Source/plugins/IControllerDeprecated.h
+++ b/Source/plugins/IControllerDeprecated.h
@@ -20,26 +20,30 @@
 #pragma once
 #include "Module.h"
 
-#include "IPluginStarter.h"
+namespace WPEFramework {
 
-using namespace WPEFramework;
+namespace PluginHost {
 
-/**
- * @brief COM-RPC implementation of a plugin starter
- *
- * Connects to Thunder over COM-RPC and attempts to start a given plugin
- */
-class COMRPCStarter : public IPluginStarter {
-public:
-    explicit COMRPCStarter(const string& pluginName);
-    ~COMRPCStarter() override;
+struct DEPRECATED EXTERNAL IController : public virtual Core::IUnknown {
 
-    bool activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) override;
-    
-private:
-    using ControllerConnector = RPC::SmartControllerInterfaceType<Exchange::Controller::ILifeTime>;
+    enum { ID = RPC::ID_CONTROLLER };
 
-private:
-    ControllerConnector _connector;
-    const string _pluginName;
+    ~IController() override = default;
+
+    virtual uint32_t Persist() = 0;
+
+    virtual uint32_t Delete(const string& path) = 0;
+
+    virtual uint32_t Reboot() = 0;
+
+    virtual uint32_t Environment(const string& index, string& environment /* @out */ ) const = 0;
+
+    virtual uint32_t Configuration(const string& callsign, string& configuration /* @out */) const = 0;
+    virtual uint32_t Configuration(const string& callsign, const string& configuration) = 0;
+
+    virtual uint32_t Clone(const string& basecallsign, const string& newcallsign) = 0;
 };
+
+}
+
+} // namespace WPEFramework

--- a/Utils/PluginActivator/source/COMRPCStarter.cpp
+++ b/Utils/PluginActivator/source/COMRPCStarter.cpp
@@ -25,29 +25,14 @@
 #include <thread>
 
 COMRPCStarter::COMRPCStarter(const string& pluginName)
-    : _pluginName(pluginName)
-    , _engine(Core::ProxyType<RPC::InvokeServerType<1, 0, 4>>::Create())
-    , _client(Core::ProxyType<RPC::CommunicatorClient>::Create(getConnectionEndpoint(),
-          Core::ProxyType<Core::IIPCServer>(_engine)))
+    : IPluginStarter()
+    , _connector()
+    , _pluginName(pluginName)
 {
-    // Announce our arrival
-    _engine->Announcements(_client->Announcement());
-
-    if (!_client.IsValid()) {
-        LOG_ERROR(pluginName.c_str(), "Failed to create valid COM-RPC client");
-    }
 }
 
 COMRPCStarter::~COMRPCStarter()
 {
-    // Close the connection just in case something left it open
-    if (_client->IsOpen()) {
-        _client->Close(RPC::CommunicationTimeOut);
-    }
-
-    if (_client.IsValid()) {
-        _client.Release();
-    }
 }
 
 /**
@@ -60,63 +45,56 @@ COMRPCStarter::~COMRPCStarter()
  */
 bool COMRPCStarter::activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs)
 {
+
     // Attempt to open the plugin shell
     bool success = false;
     int currentRetry = 1;
-
-    PluginHost::IShell* shell = nullptr;
 
     while (!success && currentRetry <= maxRetries) {
         LOG_INF(_pluginName.c_str(), "Attempting to activate plugin - attempt %d/%d", currentRetry, maxRetries);
 
         auto start = Core::Time::Now();
 
-        if (!shell) {
-            shell = _client->Open<PluginHost::IShell>(_pluginName, ~0, RPC::CommunicationTimeOut);
+        if (_connector.IsOperational() == false) {
+            uint32_t result = _connector.Open(RPC::CommunicationTimeOut, ControllerConnector::Connector());
+            if(result != Core::ERROR_NONE) {
+                LOG_ERROR(_pluginName.c_str(), "Failed to get controller interface, error %u (%s)", result, Core::ErrorToString(result));
+            }
         }
 
-        // We could not open IShell for some reason - Thunder doesn't give an error about why this might have failed
-        // Normally this is because either:
-        //  a) Thunder isn't running or we can't connect to /tmp/communicator
-        //  b) A plugin with the specified callsign does not exist
-        if (!shell) {
-            LOG_ERROR(_pluginName.c_str(), "Failed to open IShell interface for %s", _pluginName.c_str());
+        Exchange::Controller::ILifeTime* lifetime = _connector.Interface();
+
+        if (lifetime == nullptr) {
+            LOG_ERROR(_pluginName.c_str(), "Failed to open ILifeTime interface" );
             currentRetry++;
 
-            // Must close the connection before we retry, since even if shell is null the underlying
-            // connection will still have been opened
-            _client->Close(RPC::CommunicationTimeOut);
+            _connector.Close(RPC::CommunicationTimeOut);
 
             // Sleep, then try again
             std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
         } else {
-            // Connected to Thunder successfully and got the plugin shell
-            if (shell->State() == PluginHost::IShell::ACTIVATED) {
-                LOG_INF(_pluginName.c_str(), "Plugin is already activated - nothing to do");
-                success = true;
-            } else {
-                // Will block until plugin is activated
-                uint32_t result = shell->Activate(PluginHost::IShell::REQUESTED);
+            // Will block until plugin is activated
+            uint32_t result = lifetime->Activate(_pluginName.c_str());
 
-                auto duration = Core::Time::Now().Sub(start.MilliSeconds());
+            auto duration = Core::Time::Now().Sub(start.MilliSeconds());
 
-                if (result != Core::ERROR_NONE) {
-                    if (result == Core::ERROR_PENDING_CONDITIONS) {
-                        // Ideally we'd print out which preconditions are un-met for debugging, but that data is not exposed through the IShell interface
-                        LOG_ERROR(_pluginName.c_str(), "Failed to activate plugin due to unmet preconditions after %dms", duration.MilliSeconds());
-                    } else {
-                        LOG_ERROR(_pluginName.c_str(), "Failed to activate plugin with error %u (%s) after %dms", result, Core::ErrorToString(result), duration.MilliSeconds());
-                    }
-
-                    // Try activation again up until the max number of retries
-                    currentRetry++;
-                    std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
+            if (result != Core::ERROR_NONE) {
+                if (result == Core::ERROR_PENDING_CONDITIONS) {
+                    // Ideally we'd print out which preconditions are un-met for debugging, but that data is not exposed through the IShell interface
+                    LOG_ERROR(_pluginName.c_str(), "Failed to activate plugin due to unmet preconditions after %dms", duration.MilliSeconds());
                 } else {
-                    // Our work here is done!
-                    LOG_INF(_pluginName.c_str(), "Successfully activated plugin after %dms", duration.MilliSeconds());
-                    success = true;
+                    LOG_ERROR(_pluginName.c_str(), "Failed to activate plugin with error %u (%s) after %dms", result, Core::ErrorToString(result), duration.MilliSeconds());
                 }
+
+                // Try activation again up until the max number of retries
+                currentRetry++;
+                std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
+            } else {
+                // Our work here is done!
+                LOG_INF(_pluginName.c_str(), "Successfully activated plugin after %dms", duration.MilliSeconds());
+                success = true;
             }
+            lifetime->Release();
         }
     }
 
@@ -124,31 +102,9 @@ bool COMRPCStarter::activatePlugin(const uint8_t maxRetries, const uint16_t retr
         LOG_ERROR(_pluginName.c_str(), "Max retries hit - giving up activating the plugin");
     }
 
-    if (shell) {
-        shell->Release();
-    }
-
-    // Be a good citizen and don't leave any open connections
-    if (_client->IsOpen()) {
-        _client->Close(RPC::CommunicationTimeOut);
+    if (_connector.IsOperational() == true) {
+        _connector.Close(RPC::CommunicationTimeOut);
     }
 
     return success;
-}
-
-/**
- * Retrieves the socket we will communicate over for COM-RPC
- */
-Core::NodeId COMRPCStarter::getConnectionEndpoint() const
-{
-    string communicatorPath;
-    Core::SystemInfo::GetEnvironment(_T("COMMUNICATOR_PATH"), communicatorPath);
-
-    // On linux, Thunder defaults to /tmp/communicator for the generic COM-RPC
-    // interface
-    if (communicatorPath.empty()) {
-        communicatorPath = _T("/tmp/communicator");
-    }
-
-    return Core::NodeId(communicatorPath.c_str());
 }


### PR DESCRIPTION
- Bring back IController (as deprecated)
- Fix PluginActivator for changed CommunicatorClient
Please note after this is merged, this must me merged as well: https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK/pull/257