### PR TITLE
JSON: fix the deserialization of JSON::ArrayType

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3305,6 +3305,7 @@ namespace Core {
                         if (loaded < maxLength) {
                             switch (stream[loaded]) {
                             case ']':
+                                _state |= (modus::SET);
                                 offset = FIND_MARKER;
                                 loaded++;
                                 break;


### PR DESCRIPTION
 In the context of the JSON::ArrayType type, a previous change was added as part of this PR -> https://github.com/rdkcentral/Thunder/pull/1112 for the serialization of empty array ie: to differentiate, between a set but empty and a null JSON array container. The resulting implementation, however, failed to deserialize properly, because when finding a empty JSON array (i.e. `someArray: []`), the resulting object would be equivalent to `someArray: null`, which is incorrect.

To fix this, this commit adds the setting of the `_state` data member in the `Deserialize` method when a matching pair of square brackets are correctly parsed.