### PR TITLE
[JSONRPC] Support method and notification aliases in framework

### DIFF
--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -686,7 +686,7 @@ namespace Core {
                 auto retval = _handlers.emplace(std::piecewise_construct,
                                     std::make_tuple(methodName),
                                     std::make_tuple(lambda));
-                    
+
                 if ( retval.second == false ) {
                     retval.first->second = lambda;
                 }
@@ -702,6 +702,25 @@ namespace Core {
 
                 if ( retval.second == false ) {
                     retval.first->second = lambda;
+                }
+            }
+            void Register(const string& methodName, const string& primaryName)
+            {
+                ASSERT(methodName.empty() == false);
+                ASSERT(primaryName.empty() == false);
+
+                auto retval = _handlers.find(primaryName);
+                ASSERT(retval != _handlers.end());
+
+                auto retvalAlias = _handlers.find(methodName);
+                ASSERT(retvalAlias == _handlers.end());
+
+                // Register the handler under an alternative name.
+
+                if ((retval != _handlers.end()) && (retvalAlias == _handlers.end()))  {
+                    _handlers.emplace(std::piecewise_construct,
+                        std::make_tuple(methodName),
+                        std::make_tuple(retval->second));
                 }
             }
             void Unregister(const string& methodName)
@@ -1078,8 +1097,8 @@ namespace Core {
                     else {
                         code = Core::ERROR_PARSE_FAILURE;
                         result = report.Value().Message();
-                    }                    
-                    
+                    }
+
                     return (code);
                 };
                 Register(methodName, implementation);

--- a/Source/plugins/JSONRPC.cpp
+++ b/Source/plugins/JSONRPC.cpp
@@ -29,6 +29,9 @@ namespace WPEFramework {
             , _service(nullptr)
             , _callsign()
             , _validate()
+            , _versions()
+            , _observers()
+            , _eventAliases()
         {
             std::vector<uint8_t> versions = { 1 };
 
@@ -41,6 +44,9 @@ namespace WPEFramework {
             , _service(nullptr)
             , _callsign()
             , _validate()
+            , _versions()
+            , _observers()
+            , _eventAliases()
         {
             _handlers.emplace_back(versions);
         }
@@ -51,6 +57,9 @@ namespace WPEFramework {
             , _service(nullptr)
             , _callsign()
             , _validate(validation)
+            , _versions()
+            , _observers()
+            , _eventAliases()
         {
             std::vector<uint8_t> versions = { 1 };
 
@@ -63,6 +72,9 @@ namespace WPEFramework {
             , _service(nullptr)
             , _callsign()
             , _validate(validation)
+            , _versions()
+            , _observers()
+            , _eventAliases()
         {
             _handlers.emplace_back(versions);
         }


### PR DESCRIPTION
Adds new API on PluginHost::JSONRPC.

```
Register(const string& alias, const string& primary)
```
To register an alternative name for a method or property:
Regular Unregister() applies. Because of this the generator will not have to emit doubled code.

```
RegisterEventAlias(const string& alias, const string& primary)
UnregisterEventAlias(const string& alias, const string& primary)
```
To register/unregister a notification alternative name.
Because of this a Notify(primaryEventName) is sufficient, no need to repeat Notify() calls for different aliases.

Both can be called multiple times.