### PR TITLE
SecureSocketPort: Enable Server Name Indication (SNI) by default

### DIFF
--- a/Source/core/NodeId.cpp
+++ b/Source/core/NodeId.cpp
@@ -224,6 +224,7 @@ namespace Core {
         const uint16_t nPortNumber,
         const enumType defaultType)
         : m_hostName()
+        , m_remoteHostName(strHostName)
     {
 
         m_structInfo.IPV4Socket.sin_family = TYPE_UNSPECIFIED;
@@ -241,6 +242,7 @@ namespace Core {
         const TCHAR strHostName[],
         const enumType defaultType)
         : m_hostName()
+        , m_remoteHostName(strHostName)
     {
 
         m_structInfo.IPV4Socket.sin_family = TYPE_UNSPECIFIED;
@@ -368,6 +370,7 @@ namespace Core {
         memcpy(&m_structInfo, &rInfo.m_structInfo, sizeof(m_structInfo));
 
         m_hostName = rInfo.m_hostName;
+        m_remoteHostName = rInfo.m_remoteHostName;
 
         // Give back our-selves.
         return (*this);
@@ -554,6 +557,12 @@ namespace Core {
         }
 
         return (m_hostName);
+    }
+
+    string
+    NodeId::RemoteHostName() const
+    {
+        return (m_remoteHostName);
     }
 
     void NodeId::HostName(const TCHAR strHostName[])

--- a/Source/core/NodeId.h
+++ b/Source/core/NodeId.h
@@ -243,6 +243,7 @@ namespace Core {
         }
 
         string HostName() const;
+        string RemoteHostName() const;
         void HostName(const TCHAR strHostName[]);
 
         NodeId AnyInterface() const;
@@ -285,6 +286,7 @@ namespace Core {
         }
 
         mutable string m_hostName;
+        string m_remoteHostName;
         SocketInfo m_structInfo;
         static bool m_isIPV6Enabled;
     };

--- a/Source/cryptalgo/SecureSocketPort.cpp
+++ b/Source/cryptalgo/SecureSocketPort.cpp
@@ -63,6 +63,13 @@ bool SecureSocketPort::Handler::Initialize() {
     _ssl = SSL_new(static_cast<SSL_CTX*>(_context));
     SSL_set_fd(static_cast<SSL*>(_ssl), static_cast<Core::IResource&>(*this).Descriptor());
 
+    // Enable SNI by default (Server Name Indication) in case there's a host name set in the remote
+    // node, so that the TLS "Client Hello" message contains a "server_name" extension with the host
+    // name, this way allowing a better interoperability with TLS servers.
+    if (!RemoteNode().RemoteHostName().empty()) {
+        SSL_set_tlsext_host_name(static_cast<SSL*>(_ssl), RemoteNode().RemoteHostName().c_str());
+    }
+
     return (Core::SocketPort::Initialize());
 }
 


### PR DESCRIPTION
When establishing TLS connections, the WPEFramework's SecureSocketPort implementation, based on OpenSSL, is not enabling the SNI (Server Name Indication [1]) extension by default. Most server implementations do require SNI, i.e., that the client, when doing the TLS handshake, does provide information about which server is handshaking to, so that it can then provide a suitable certificate. This is particularly true for cloud based services. To comply with these, we should enable SNI by default. Enabling this, does not create any problems to servers that do not support or require SNI, so no harm done in enabling SNI by default.

Enabling the TLS SNI feature with OpenSSL can be done by calling the `SSL_set_tlsext_host_name()` ([2]) on the associated SSL context, with the host name we're trying to connect to, so that the host name is then set on the "server_name" extension in the "Client Hello" TLS message.

This way, in `SecureSocketPort::Handler::Initialize()`, which is where the SSL context is created and prepared, make the required call to `SSL_set_tlsext_host_name()` with the host name that is configured on the remote node associated with the `SecureSocketPort` instance.

For supporting this, extend the `Core::NodeId` class so that it "remembers" the original host name provided when creating nodes for representing IP connections to a remote host, which is the case of the TLS connections. For this, add a new `m_remoteHostName` member and an associated `RemoteHostName()` getter. There was already a `m_hostName` member and a `HostName()` getter which seem to suggest this feature was already present in `Core::NodeId`. However, further inspection and debugging shows that in fact this is not always the case and it is used for different purposes, hence the decision to use a new member/getter, to ensure the new needs and not breaking any current uses of `m_hostName`.

[1] https://en.wikipedia.org/wiki/Server_Name_Indication
[2] https://www.openssl.org/docs/man1.1.1/man3/SSL_get_servername_type.html

[RDKDEV-886](https://jira.rdkcentral.com/jira/browse/RDKDEV-886)