### PR TITLE
[PluginActivator] Improve logging & minor improvements

### DIFF
--- a/Utils/PluginActivator/CMakeLists.txt
+++ b/Utils/PluginActivator/CMakeLists.txt
@@ -24,6 +24,7 @@ set( CMAKE_CXX_STANDARD 11 )
 
 add_executable(${PROJECT_NAME}
     source/Module.cpp
+    source/Log.cpp
     source/main.cpp
     source/COMRPCStarter.cpp
 )

--- a/Utils/PluginActivator/source/Log.cpp
+++ b/Utils/PluginActivator/source/Log.cpp
@@ -17,29 +17,27 @@
  * limitations under the License.
  */
 
-#pragma once
-#include "Module.h"
+#include "Log.h"
 
-#include "IPluginStarter.h"
+int gActivatorLogLevel = LEVEL_ERROR;
 
-using namespace WPEFramework;
+void initLogging(int logLevel)
+{
+    gActivatorLogLevel = logLevel;
+}
 
-/**
- * @brief COM-RPC implementation of a plugin starter
- *
- * Connects to Thunder over COM-RPC and attempts to start a given plugin
- */
-class COMRPCStarter : public IPluginStarter {
-public:
-    explicit COMRPCStarter(const string& pluginName);
-    ~COMRPCStarter() override = default;
-
-    bool activatePlugin(const uint8_t maxRetries, const uint16_t retryDelayMs) override;
-
-private:
-    using ControllerConnector = RPC::SmartControllerInterfaceType<Exchange::Controller::ILifeTime>;
-
-private:
-    ControllerConnector _connector;
-    const string _pluginName;
-};
+const char* getLogLevel(int level)
+{
+    switch (level) {
+    case LEVEL_DEBUG:
+        return "[DBG]";
+    case LEVEL_INFO:
+        return "[NFO]";
+    case LEVEL_WARN:
+        return "[WRN]";
+    case LEVEL_ERROR:
+        return "[ERR]";
+    default:
+        return "";
+    }
+}

--- a/Utils/PluginActivator/source/Log.h
+++ b/Utils/PluginActivator/source/Log.h
@@ -20,9 +20,10 @@
 #pragma once
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-#define LOG_LEVEL 3
+extern int gActivatorLogLevel;
 
 #ifndef __FILENAME__
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
@@ -47,22 +48,9 @@
 
 #define __LOG(level, plugin, fmt, ...)                                                                                                        \
     do {                                                                                                                                      \
-        if (__builtin_expect(((level) <= LOG_LEVEL), 0))                                                                                      \
+        if (__builtin_expect(((level) <= gActivatorLogLevel), 0))                                                                             \
             fprintf(stderr, "%s[%s:%d][%s] (%s) " fmt "\n", getLogLevel(level), __FILENAME__, __LINE__, __FUNCTION__, plugin, ##__VA_ARGS__); \
     } while (0)
 
-inline const char* getLogLevel(int level)
-{
-    switch (level) {
-    case LEVEL_DEBUG:
-        return "[DBG]";
-    case LEVEL_INFO:
-        return "[NFO]";
-    case LEVEL_WARN:
-        return "[WRN]";
-    case LEVEL_ERROR:
-        return "[ERR]";
-    default:
-        return "";
-    }
-}
+void initLogging(int logLevel);
+const char* getLogLevel(int level);


### PR DESCRIPTION
Some minor improvements to the PluginActivator utility

* Use the stopwatch class to time activation for accuracy during NTP time sync
* Ability to set log level at runtime & add some debug messages (should probably switch logging to LocalTracer, but that's a job for another time...)
* Minor code tidy-up