### PR TITLE
[CONSOLE] Console redirect should not be handled by the Thunder Resou…

### DIFF
--- a/Source/core/TextStreamRedirectType.h
+++ b/Source/core/TextStreamRedirectType.h
@@ -143,13 +143,13 @@ namespace Core {
 			TCHAR _buffer[1024];
 		};
 
-#ifdef __WINDOWS__
+		#ifdef __WINDOWS__
 		class ReaderImplementation : public Reader {
 		private:
 			class ResourceMonitor : public Core::Thread {
 			private:
 				using Implementations = std::vector<ReaderImplementation*>;
-				friend class Core::SingletonType<ResourceMonitor>;
+				friend Core::SingletonType<ResourceMonitor>;
 
 				ResourceMonitor()
 					: Core::Thread(Core::Thread::DefaultStackSize(), _T("FileResourceMonitor"))
@@ -353,11 +353,28 @@ namespace Core {
 			Core::IResource::handle _copy;
 			HANDLE _handle;
 		};
-
-		// friend class Core::SingletonType<ReaderImplementation::ResourceMonitor>;
-
-#else
+		#else
 		class ReaderImplementation : public Core::IResource, public Reader {
+		private:
+			class ResourceMonitor : public Core::ResourceMonitorType<Core::IResource, Void, 1 * 1024 * 1024, 4> {
+			private:
+				friend Core::SingletonType<ResourceMonitor>;
+
+				ResourceMonitor() = default;
+
+			public:
+				ResourceMonitor(ResourceMonitor&&) = delete;
+				ResourceMonitor(const ResourceMonitor&) = delete;
+				ResourceMonitor& operator=(ResourceMonitor&&) = delete;
+				ResourceMonitor& operator=(const ResourceMonitor&) = delete;
+
+				static ResourceMonitor& Instance() {
+					static ResourceMonitor& _instance = Core::SingletonType<ResourceMonitor>::Instance();
+					return (_instance);				}
+
+				~ResourceMonitor() = default;
+			};
+
 		public:
 			ReaderImplementation() = delete;
 			ReaderImplementation(ReaderImplementation&&) = delete;
@@ -391,7 +408,7 @@ namespace Core {
 					::dup2(_handle[1], _index);
 					::close(_handle[1]);
 					_handle[1] = Core::IResource::INVALID;
-					Core::ResourceMonitor::Instance().Register(*this);
+					ResourceMonitor::Instance().Register(*this);
 				}
 				return (_handle[0] != Core::IResource::INVALID);
 			}
@@ -403,7 +420,7 @@ namespace Core {
 					if (::dup2(_copy, _index) != -1) {
 						::close(_handle[0]);
 						::close(_copy);
-						Core::ResourceMonitor::Instance().Unregister(*this);
+						ResourceMonitor::Instance().Unregister(*this);
 						_handle[0] = Core::IResource::INVALID;
 						_copy = Core::IResource::INVALID;
 						Reader::Flush();
@@ -444,7 +461,7 @@ namespace Core {
 			Core::IResource::handle _copy;
 			Core::IResource::handle _handle[2];
 		};
-#endif
+		#endif
 
 	public:
 		TextStreamRedirectType(TextStreamRedirectType<STREAMTYPE>&&) = delete;


### PR DESCRIPTION
…rceMonitor.

As the Console stream redirecting is writing data to filebuffers, the file buffers might block as the buffer is full and first nees to be flushed. However if this happens while code is being executed on the ResourceMonitor thread it create a clissical deadlock.

This use-case was observed by TRACE_LX macros that use a printf (to stderr) to write data to the console. In case of redirection, this is done to the intermediate file descriptor. If this intermediate file descriptor can not continue to write (as the buffer is full) the printf (to stderr) will block, witing for the data to be read so new buffer space becomes avaialble. However the readin of this data has to be doen by this ResourceMonitor thread which is currently blocked by this printf.

To avoid this classical deadlock, the StreamRedirectType template now uses its own instantiation of the ResourceMonitor. As this ResourceMonitor will only be used by (best case) 2 descriptors (stdout and stderr) enhanced the template to control the number of descriptors it expects and the Stack size required by these threads.