### PR TITLE
[Actions] Using the already merged workflows instead of my forks

### DIFF
--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   # change the user and branch name in each one after the templates are merged
   Thunder:
-    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderInterfaces:
     needs: Thunder
@@ -25,16 +25,16 @@ jobs:
 
   ThunderLibraries:
     needs: Thunder
-    uses: VeithMetro/ThunderLibraries/.github/workflows/Linux build template.yml@development/actions
+    uses: WebPlatformForEmbedded/ThunderLibraries/.github/workflows/Linux build template.yml@master
 
   ThunderClientLibraries:
     needs: ThunderInterfaces
-    uses: VeithMetro/ThunderClientLibraries/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@master
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-    uses: VeithMetro/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@master
 
   ThunderNanoServicesRDK:
     needs: ThunderInterfaces
-    uses: VeithMetro/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@development/actions
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -21,7 +21,7 @@ jobs:
 
   ThunderInterfaces:
     needs: Thunder
-    uses: VeithMetro/ThunderInterfaces/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/ThunderInterfaces/.github/workflows/Linux build template.yml@master
 
   ThunderLibraries:
     needs: Thunder

--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -2,7 +2,7 @@ name: Build Thunder on Linux
 
 on:
   push:
-    # branches: ["master"]
+    branches: ["master"]
     paths-ignore:
       - 'doc/**'
       - 'docs/**'
@@ -15,7 +15,6 @@ on:
       - 'ReleaseNotes/**'
 
 jobs:
-  # change the user and branch name in each one after the templates are merged
   Thunder:
     uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 

--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -25,7 +25,7 @@ jobs:
 
   ThunderLibraries:
     needs: Thunder
-    uses: WebPlatformForEmbedded/ThunderLibraries/.github/workflows/Linux build template.yml@master
+    uses: WebPlatformForEmbedded/ThunderLibraries/.github/workflows/Linux build template.yml@main
 
   ThunderClientLibraries:
     needs: ThunderInterfaces

--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -2,7 +2,7 @@ name: Build Thunder on Linux
 
 on:
   push:
-    branches: ["master"]
+    # branches: ["master"]
     paths-ignore:
       - 'doc/**'
       - 'docs/**'


### PR DESCRIPTION
The last set of pull requests, now the new Actions will use workflows from our repos instead of my forks, which sadly couldn't have been done in one go.