### PR TITLE
RDKDEV-941/ SGMM393-547: RDKServices: RDK service APIs responds to requests with invalid security token.

### DIFF
--- a/Source/websocket/JSONWebToken.cpp
+++ b/Source/websocket/JSONWebToken.cpp
@@ -168,10 +168,12 @@ namespace Web
 
                 // Extract the signature and convert it to a binary string.
 				uint8_t signature[Crypto::SHA256HMAC::Length];
-                if (Core::URL::Base64Decode(token.substr(pos + 1).c_str(), static_cast<uint16_t>(token.length() - pos - 1), signature, sizeof(signature), nullptr) == sizeof(signature)) {
+                                if ((token.length() - pos - 1) == ((((8 * sizeof(signature)) + 5)/6))) {
+                                       if (Core::URL::Base64Decode(token.substr(pos + 1).c_str(), static_cast<uint16_t>(token.length() - pos - 1), signature, sizeof(signature), nullptr) == sizeof(signature)) {
 
 					hash.Input(reinterpret_cast<const uint8_t*>(token.substr(0, pos).c_str()), static_cast<uint16_t>(pos * sizeof(TCHAR)));
 					result = (::memcmp(hash.Result(), signature, sizeof(signature)) == 0);
+				       }
 				}
             }
 		}


### PR DESCRIPTION
Reason for change: Including input security token value fully to validate signature.

Risks: Low

Signed-off-by: Dineshkumar P <dineshkumar.p@ltts.com>