### PR TITLE
[COM] Making sure the Terminate() notification will be sent exactly once in all cases

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -120,6 +120,7 @@ namespace RPC {
     public:
         ProcessShutdown(ProcessShutdown&&) = delete;
         ProcessShutdown(const ProcessShutdown&) = delete;
+        ProcessShutdown& operator=(ProcessShutdown&&) = delete;
         ProcessShutdown& operator=(const ProcessShutdown&) = delete;
 
         ProcessShutdown()

--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -157,7 +157,7 @@ namespace RPC {
         {
             _adminLock.Lock();
 
-            if (_destructors.find(id) == _destructors.end()) {
+            if ((entry.IsTerminated() == false) && (_destructors.find(id) == _destructors.end())) {
                 entry.AddRef();
                 _destructors.emplace(std::piecewise_construct,
                     std::forward_as_tuple(id),


### PR DESCRIPTION
The origin of this issue observed by us, and then also by Haseena in this [ticket](https://jira.rdkcentral.com/jira/browse/METROL-921) was that the ASSERT in MessageControl fired, because first the notification about the termination of a connection came from [here](https://github.com/rdkcentral/Thunder/blob/master/Source/com/Communicator.h#L660), which was the result of Closed() [here](https://github.com/rdkcentral/Thunder/blob/master/Source/com/Communicator.h#L1108). And then the second notification came right after from [here](https://github.com/rdkcentral/Thunder/blob/master/Source/com/Communicator.h#L651).