### PR TITLE
[core/cyclicbuffer] : Cherry-picked from '907031e6b3d4055be0859fa8934…ea404ca2b42f9' 'development/cylicbuffer'.

### DIFF
--- a/Source/core/CyclicBuffer.cpp
+++ b/Source/core/CyclicBuffer.cpp
@@ -572,9 +572,6 @@ namespace Core {
         uint32_t result = Core::ERROR_TIMEDOUT;
         uint32_t timeLeft = waitTime;
 
-        // Lock can not be called recursive, unlock if you would like to lock it..
-        ASSERT(_administration->_lockPID == 0);
-
         // Lock the administrator..
         AdminLock();
 
@@ -619,8 +616,6 @@ namespace Core {
         // Lock the administrator..
         AdminLock();
 
-        // Lock can not be called recursive, unlock if you would like to lock it..
-        ASSERT(_administration->_lockPID == Core::ProcessInfo().Id());
         ASSERT((_administration->_state.load() & state::LOCKED) == state::LOCKED);
 
         // Only unlock if it is "our" lock.


### PR DESCRIPTION
Triggers false positives with Thread use as multiple Worker execution might be done from the same underlying POSIX pthread.