### PR TITLE
[JSON] Allow UTF-8 characters in parsed strings

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1947,7 +1947,7 @@ namespace Core {
                         } else if (current == '\"') {
                             // We are done! leave this element.
                             finished = true;
-                        } else if (current <= 0x1F) {
+                        } else if (static_cast<std::make_unsigned<TCHAR>::type>(current) <= 0x1F) {
                             error = Error{ "Unescaped control character detected" };
                         } else {
                             // Just copy and onto the next;


### PR DESCRIPTION
Ensure the comparison here is unsigned even if  _char_ happens to be signed, so characters above ASCII code 0x7F (including UTF-8/16/32 characters) are read through and not treated as un-escaped control codes.