### PR TITLE
[LIBRARIES] Refernce counted Library COMRPC objects.

### DIFF
--- a/Source/core/Library.h
+++ b/Source/core/Library.h
@@ -49,6 +49,7 @@ namespace Core {
         Library(const Library& copy);
         ~Library();
 
+        Library& operator=(Library&& RHS);
         Library& operator=(const Library& RHS);
 
     public:

--- a/Source/core/Services.h
+++ b/Source/core/Services.h
@@ -177,8 +177,6 @@ namespace Core {
             , _referenceLib()
         {
         }
-        void LockLibrary() {
-        }
 
     public:
         ServiceType(ServiceType<ACTUALSERVICE>&&) = delete;


### PR DESCRIPTION
If COMRPC objects are created through the C interface, the object itself should hold on to a reference of the library it is created from this way, the library will not be unloaded as long as there are still COMRPC object living which reside in this SO. This PR makes sure that any instance instantiated through Core::ServiceType<COMRPCOBJECTIMPL> will also grab a refenrence onto the SO it is located in. On deletion (Last reference release of the COMRPC object) this reference on the SO will be dropped as well!