### PR TITLE
[COM] Fixing another rare double termination notification scenario

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -141,7 +141,6 @@ namespace RPC {
 
             if (index != _destructors.end()) {
                 handler = index->second;
-                _destructors.erase(index);
             }
 
             _adminLock.Unlock();
@@ -152,6 +151,16 @@ namespace RPC {
                 handler->Destruct();
                 handler->Release();
             }
+
+            _adminLock.Lock();
+
+            index = _destructors.find(id);
+
+            if (index != _destructors.end()) {
+                _destructors.erase(index);
+            }
+
+            _adminLock.Unlock();
         }
         void Destruct(const uint32_t id, Communicator::MonitorableProcess& entry)
         {


### PR DESCRIPTION
Moving the erase from destructors to take place after the actual destruction but still within the lock. Sadly we have to do find() again in case the map was changed in the meantime.

Thanks to this, if Destruct() comes after ForceDestruct(), but still before the process is actually killed by EndProcess(), the ID will not be added back to the `_destructors` map, which would lead to double notification and an ASSERT in MessageControl, as described in this JIRA ticket from Haseena: https://jira.rdkcentral.com/jira/browse/METROL-938

Alternatively, we could use one bit of `cycle` to signal this, but then we could need a method to set it and also do bit operation on cycle each time it is used, so not sure if this is preferable.