### PR TITLE
[Config] By default no traces enabled

### DIFF
--- a/Source/WPEFramework/WPEFramework.conf.in
+++ b/Source/WPEFramework/WPEFramework.conf.in
@@ -106,7 +106,8 @@ if boolean('@MESSAGING@'):
   
   __tracing_settings = []
 
-  __modules = "@ENABLE_TRACING_MODULES@".split(' ')
+  __enable_tracing_modules = "@ENABLE_TRACING_MODULES@".strip()
+  __modules =__enable_tracing_modules.split(' ') if __enable_tracing_modules else []
   
   if len(__modules) > 0:
     for module in __modules:


### PR DESCRIPTION
string.split() has very peculiar behaviour... 
this ended up with module:"" if ENABLE_TRACING_MODULES was empty