### PR TITLE
[Core] Adding a new macro in TypeTraits

### DIFF
--- a/Source/core/IPCConnector.h
+++ b/Source/core/IPCConnector.h
@@ -342,7 +342,7 @@ namespace Core {
             // -----------------------------------------------------
             // Search for custom handling, Compile time !!!
             // -----------------------------------------------------
-            IS_MEMBER_AVAILABLE(Length, hasLength);
+            IS_MEMBER_AVAILABLE_CONVERTIBLE(Length, hasLength);
 
             template <typename SUBJECT=PACKAGE>
             typename Core::TypeTraits::enable_if<hasLength<const SUBJECT, uint32_t>::value, uint32_t>::type

--- a/Source/core/TypeTraits.h
+++ b/Source/core/TypeTraits.h
@@ -169,7 +169,7 @@ namespace Core {
 // T:    type on which it should be chekced if func is available. If only const versions of func need to be taken into account specify it as const T
 // R:    expected return type for func
 // Args: arguments that func should have, note it will also work if overrides of Func are available on T. Note: passing Args&&... itself is also allowed here to allow for variable parameters
-// use this one instead of IS_MEMBER_AVAILABLE when the return type of the function can be only convertible and does not have to be exactly the same
+// use this macro instead of IS_MEMBER_AVAILABLE when the return type of the function does not have to be exactly the same but instead it can be convertible to the expected one
 #define IS_MEMBER_AVAILABLE_CONVERTIBLE(func, name)                                             \
     template <typename T, typename R, typename... Args>                                         \
     struct name {                                                                               \

--- a/Source/core/TypeTraits.h
+++ b/Source/core/TypeTraits.h
@@ -164,6 +164,26 @@ namespace Core {
         static bool const value = sizeof(chk<T>(0)) == sizeof(yes);                             \
     }
 
+// func: name of function that should be present
+// name: name of the struct that later can be used to override using SFINEA
+// T:    type on which it should be chekced if func is available. If only const versions of func need to be taken into account specify it as const T
+// R:    expected return type for func
+// Args: arguments that func should have, note it will also work if overrides of Func are available on T. Note: passing Args&&... itself is also allowed here to allow for variable parameters
+// use this one instead of IS_MEMBER_AVAILABLE when the return type of the function can be only convertible and does not have to be exactly the same
+#define IS_MEMBER_AVAILABLE_CONVERTIBLE(func, name)                                             \
+    template <typename T, typename R, typename... Args>                                         \
+    struct name {                                                                               \
+        typedef char yes[1];                                                                    \
+        typedef char no[2];                                                                     \
+        template <typename U,                                                                   \
+                  typename RR = decltype(std::declval<U>().func(std::declval<Args>()...)),      \
+                  typename Z = typename std::enable_if<std::is_convertible<RR, R>::value>::type>\
+        static yes& chk(int);                                                                   \
+        template <typename U>                                                                   \
+        static no& chk(...);                                                                    \
+        static bool const value = sizeof(chk<T>(0)) == sizeof(yes);                             \
+    }
+
 // func: name of function that should be present in the inheritance tree and accessable (public or protected)
 // name: name of the struct that later can be used to override using SFINEA
 // T:    type on which it should be chekced if func is available in the Inheritance tree. If only const versions of func need to be taken into account specify it as const T


### PR DESCRIPTION
The new `IS_MEMBER_AVAILABLE_CONVERTIBLE` macro checks whether a function is available, just like `IS_MEMBER_AVAILABLE` macro, but with this one the return type can be convertible instead of having to be exactly the same