### PR TITLE
[Tests/unit/core] : Build fix 'test_hash'.

### DIFF
--- a/Tests/unit/core/CMakeLists.txt
+++ b/Tests/unit/core/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_hex2strserialization.cpp
    test_filesystem.cpp
    test_frametype.cpp
-   #test_hash.cpp
+   test_hash.cpp
    #test_ipc.cpp
    #test_ipcclient.cpp
    test_iso639.cpp
@@ -110,6 +110,7 @@ target_link_libraries(${TEST_RUNNER_NAME}
     ${NAMESPACE}Core::${NAMESPACE}Core
     ${NAMESPACE}COM::${NAMESPACE}COM
     ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket
+    ${NAMESPACE}Cryptalgo::${NAMESPACE}Cryptalgo
 )
 
 install(


### PR DESCRIPTION
Missing dependency library specification resulted in undefined symbol.