### PR TITLE
[Tests/unit/core] : Fix build 'test_rpc'.

### DIFF
--- a/Tests/unit/core/CMakeLists.txt
+++ b/Tests/unit/core/CMakeLists.txt
@@ -54,7 +54,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_rangetype.cpp
    test_readwritelock.cpp
    test_rectangle.cpp
-   #test_rpc.cpp
+   test_rpc.cpp
    test_semaphore.cpp
    test_sharedbuffer.cpp
    test_singleton.cpp
@@ -110,6 +110,7 @@ target_link_libraries(${TEST_RUNNER_NAME}
     ${NAMESPACE}Core::${NAMESPACE}Core
     ${NAMESPACE}COM::${NAMESPACE}COM
     ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket
+    ${NAMESPACE}Messaging::${NAMESPACE}Messaging
 )
 
 install(

--- a/Tests/unit/core/test_rpc.cpp
+++ b/Tests/unit/core/test_rpc.cpp
@@ -278,7 +278,6 @@ namespace Tests {
           EXPECT_TRUE(engine.IsValid());
           Core::ProxyType<RPC::CommunicatorClient> client = Core::ProxyType<RPC::CommunicatorClient>::Create(remoteNode, Core::ProxyType<Core::IIPCServer>(engine));
           EXPECT_TRUE(client.IsValid());
-          engine->Announcements(client->Announcement());
 
           // Create remote instance of "IAdder".
           Exchange::IAdder * adder = client->Open<Exchange::IAdder>(_T("Adder"));


### PR DESCRIPTION
- 'Announcements' was removed in 'a3d08b81dc5b192a0952ad8c0ccfc3a94bc08339'

- Missing dependency library specification resulted in undefined symbol.