### PR TITLE
Cleanup Resources when Socket Class destroyed

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -419,7 +419,7 @@ namespace WPEFramework {
             ASSERT((m_Socket == INVALID_SOCKET) || (IsClosed()));
 
             if (m_Socket != INVALID_SOCKET) {
-                DestroySocket(m_Socket);
+                Closed();
             }
 
             ::free(m_SendBuffer);


### PR DESCRIPTION
When destructor of SocketClass identifies that the Socket is NOT Closed, it must call Close() to update the state n unregister resource monitors