### PR TITLE
Increased queueSize for WorkerPool to avoid full queue when over 30 

### DIFF
--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -123,7 +123,7 @@ namespace PluginHost {
             WorkerPoolImplementation& operator=(const WorkerPoolImplementation&) = delete;
 
             WorkerPoolImplementation(const uint32_t stackSize)
-                : Core::WorkerPool(THREADPOOL_COUNT, stackSize, 16, &_dispatch, this)
+                : Core::WorkerPool(THREADPOOL_COUNT, stackSize, 50, &_dispatch, this)
                 , _dispatch()
             {
                 Run();


### PR DESCRIPTION
plugins are trying to activate.