### PR TITLE
[DEADLOCK] Resolving the ABBA deadlock between the RPC::Administrator…

### DIFF
--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -37,11 +37,11 @@ namespace RPC {
 
     /* virtual */ Administrator::~Administrator()
     {
-        for (std::pair<uint32_t, IMetadata*> proxy : _proxy) {
+        for (auto& proxy : _proxy) {
             delete proxy.second;
         }
 
-        for (std::pair<uint32_t, ProxyStub::UnknownStub*> stub : _stubs) {
+        for (auto& stub : _stubs) {
             delete stub.second;
         }
 
@@ -59,10 +59,10 @@ namespace RPC {
         return (systemAdministrator);
     }
 
-    void Administrator::AddRef(Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId)
+    void Administrator::AddRef(const Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId)
     {
         // stub are loaded before any action is taken and destructed if the process closes down, so no need to lock..
-        std::map<uint32_t, ProxyStub::UnknownStub*>::iterator index(_stubs.find(interfaceId));
+        Stubs::iterator index(_stubs.find(interfaceId));
 
         if (index != _stubs.end()) {
             Core::IUnknown* implementation(index->second->Convert(impl));
@@ -70,8 +70,12 @@ namespace RPC {
             ASSERT(implementation != nullptr);
 
             if (implementation != nullptr) {
-                implementation->AddRef();
-                RegisterUnknownInterface(channel, implementation, interfaceId);
+                _adminLock.Lock();
+                if (channel.IsValid() == true) {
+                    implementation->AddRef();
+                    RegisterUnknown(channel, implementation, interfaceId);
+                }
+                _adminLock.Unlock();
             }
         } else {
             // Oops this is an unknown interface, Do not think this could happen.
@@ -79,10 +83,10 @@ namespace RPC {
         }
     }
 
-    void Administrator::Release(Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId, const uint32_t dropCount)
+    void Administrator::Release(const Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId, const uint32_t dropCount)
     {
         // stub are loaded before any action is taken and destructed if the process closes down, so no need to lock..
-        std::map<uint32_t, ProxyStub::UnknownStub*>::iterator index(_stubs.find(interfaceId));
+        Stubs::iterator index(_stubs.find(interfaceId));
 
         if (index != _stubs.end()) {
             Core::IUnknown* implementation(index->second->Convert(impl));
@@ -90,8 +94,12 @@ namespace RPC {
             ASSERT(implementation != nullptr);
 
             if (implementation != nullptr) {
-                UnregisterInterface(channel, implementation, interfaceId, dropCount);
-                implementation->Release();
+                _adminLock.Lock();
+                if (channel.IsValid() == true) {
+                    UnregisterInterface(channel, implementation, interfaceId, dropCount);
+                    implementation->Release();
+                }
+                _adminLock.Unlock();
             }
         } else {
             // Oops this is an unknown interface, Do not think this could happen.
@@ -150,7 +158,7 @@ namespace RPC {
         uint32_t interfaceId(message->Parameters().InterfaceId());
 
         // stub are loaded before any action is taken and destructed if the process closes down, so no need to lock..
-        std::map<uint32_t, ProxyStub::UnknownStub*>::iterator index(_stubs.find(interfaceId));
+        Stubs::iterator index(_stubs.find(interfaceId));
 
         if (index != _stubs.end()) {
             uint32_t methodId(message->Parameters().MethodId());
@@ -245,43 +253,47 @@ namespace RPC {
 
             _adminLock.Lock();
 
-            ChannelMap::iterator index(_channelProxyMap.find(channel->LinkId()));
+            if (channel.IsValid() == true) {
 
-            if (index != _channelProxyMap.end()) {
-                Proxies::iterator entry(index->second.begin());
-                while ((entry != index->second.end()) && (((*entry)->InterfaceId() != id) || ((*entry)->Implementation() != impl))) {
-                    entry++;
-                }
-                if (entry != index->second.end()) {
-                    interface = (*entry)->Acquire(outbound, id);
+                uintptr_t channelId(channel->LinkId());
+                ChannelMap::iterator index(_channelProxyMap.find(channelId));
 
-                    // The implementation could be found, but the current implemented proxy is not
-                    // for the given interface. If that cae, the interface == nullptr and we still
-                    // need to create a proxy for this specific interface.
-                    if (interface != nullptr) {
-                        result = (*entry);
+                if (index != _channelProxyMap.end()) {
+                    Proxies::iterator entry(index->second.begin());
+                    while ((entry != index->second.end()) && (((*entry)->InterfaceId() != id) || ((*entry)->Implementation() != impl))) {
+                        entry++;
+                    }
+                    if (entry != index->second.end()) {
+                        interface = (*entry)->Acquire(outbound, id);
+
+                        // The implementation could be found, but the current implemented proxy is not
+                        // for the given interface. If that cae, the interface == nullptr and we still
+                        // need to create a proxy for this specific interface.
+                        if (interface != nullptr) {
+                            result = (*entry);
+                        }
                     }
                 }
-            }
 
-            if (result == nullptr) {
-                std::map<uint32_t, IMetadata*>::iterator factory(_proxy.find(id));
+                if (result == nullptr) {
+                    Factories::iterator factory(_proxy.find(id));
 
-                if (factory != _proxy.end()) {
+                    if (factory != _proxy.end()) {
 
-                    result = factory->second->CreateProxy(channel, impl, outbound);
+                        result = factory->second->CreateProxy(channel, impl, outbound);
 
-                    ASSERT(result != nullptr);
+                        ASSERT(result != nullptr);
 
-                    // Register it as it is remotely registered :-)
-                    _channelProxyMap[channel->LinkId()].push_back(result);
+                        // Register it as it is remotely registered :-)
+                        _channelProxyMap[channelId].push_back(result);
 
-                    // This will increment the reference count to 2 (one in the ChannelProxyMap and one in the QueryInterface ).
-                    interface = result->QueryInterface(id);
-                    ASSERT(interface != nullptr);
+                        // This will increment the reference count to 2 (one in the ChannelProxyMap and one in the QueryInterface ).
+                        interface = result->QueryInterface(id);
+                        ASSERT(interface != nullptr);
 
-                } else {
-                    TRACE_L1("Failed to find a Proxy for %d.", id);
+                    } else {
+                        TRACE_L1("Failed to find a Proxy for %d.", id);
+                    }
                 }
             }
 
@@ -291,17 +303,18 @@ namespace RPC {
         return (result);
     }
 
-    void Administrator::RegisterUnknownInterface(Core::ProxyType<Core::IPCChannel>& channel, Core::IUnknown* reference, const uint32_t id)
+    // Locked by the Callee and the channel has been checked that it exists.. (IsValid)
+    void Administrator::RegisterUnknown(const Core::ProxyType<Core::IPCChannel>& channel, Core::IUnknown* reference, const uint32_t id)
     {
         ASSERT(reference != nullptr);
+        ASSERT(channel.IsValid() == true);
 
-        _adminLock.Lock();
-
-        ReferenceMap::iterator index = _channelReferenceMap.find(channel->LinkId());
+        uintptr_t channelId(channel->LinkId());
+        ReferenceMap::iterator index = _channelReferenceMap.find(channelId);
 
         if (index == _channelReferenceMap.end()) {
             auto result = _channelReferenceMap.emplace(std::piecewise_construct,
-                std::forward_as_tuple(channel->LinkId()),
+                std::forward_as_tuple(channelId),
                 std::forward_as_tuple());
             result.first->second.emplace_back(id, reference);
             TRACE_L3("Registered interface %p(0x%08x).", reference, id);
@@ -337,19 +350,49 @@ namespace RPC {
                 element->Increment();
             }
         }
+    }
 
-        _adminLock.Unlock();
+    // Locked by the Callee and the channel has been checked that it exists.. (IsValid)
+    void Administrator::UnregisterUnknown(const Core::ProxyType<Core::IPCChannel>& channel, const Core::IUnknown* source, const uint32_t interfaceId, const uint32_t dropCount) {
+        ASSERT(source != nullptr);
+        ASSERT(channel.IsValid() == true);
+
+        ReferenceMap::iterator index(_channelReferenceMap.find(channel->LinkId()));
+
+        if (index != _channelReferenceMap.end()) {
+            std::list< RecoverySet >::iterator element(index->second.begin());
+
+            while ( (element != index->second.end()) && ((element->Id() != interfaceId) || (element->Unknown() != source)) ) {
+                element++;
+            }
+
+            ASSERT(element != index->second.end());
+
+            if (element != index->second.end()) {
+                if (element->Decrement(dropCount) == false) {
+                    index->second.erase(element);
+                    if (index->second.size() == 0) {
+                        _channelReferenceMap.erase(index);
+                        TRACE_L3("Unregistered interface %p(%u).", source, interfaceId);
+                    }
+                }
+            } else {
+                printf("====> Unregistering an interface [0x%x, %d] which has not been registered!!!\n", interfaceId, Core::ProcessInfo().Id());
+            }
+        } else {
+            printf("====> Unregistering an interface [0x%x, %d] from a non-existing channel!!!\n", interfaceId, Core::ProcessInfo().Id());
+        }
     }
 
     Core::IUnknown* Administrator::Convert(void* rawImplementation, const uint32_t id)
     {
-        std::map<uint32_t, ProxyStub::UnknownStub*>::const_iterator index (_stubs.find(id));
+        Stubs::const_iterator index (_stubs.find(id));
         return(index != _stubs.end() ? index->second->Convert(rawImplementation) : nullptr);
     }
 
     const Core::IUnknown* Administrator::Convert(void* rawImplementation, const uint32_t id) const
     {
-        std::map<uint32_t, ProxyStub::UnknownStub*>::const_iterator index (_stubs.find(id));
+        Stubs::const_iterator index (_stubs.find(id));
         return(index != _stubs.end() ? index->second->Convert(rawImplementation) : nullptr);
     }
 
@@ -357,7 +400,8 @@ namespace RPC {
     {
         _adminLock.Lock();
 
-        ReferenceMap::iterator remotes(_channelReferenceMap.find(channel->LinkId()));
+        uintptr_t channelId(channel->LinkId());
+        ReferenceMap::iterator remotes(_channelReferenceMap.find(channelId));
 
         if (remotes != _channelReferenceMap.end()) {
             std::list<RecoverySet>::iterator loop(remotes->second.begin());
@@ -382,7 +426,7 @@ namespace RPC {
             _channelReferenceMap.erase(remotes);
         }
 
-        ChannelMap::iterator index(_channelProxyMap.find(channel->LinkId()));
+        ChannelMap::iterator index(_channelProxyMap.find(channelId));
 
         if (index != _channelProxyMap.end()) {
             for (auto entry : index->second) {

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -46,9 +46,6 @@ namespace RPC {
     };
 
     class EXTERNAL Administrator {
-    public:
-        using Proxies = std::vector<ProxyStub::UnknownProxy*>;
-
     private:
         Administrator();
 
@@ -103,9 +100,6 @@ namespace RPC {
             uint32_t _referenceCount;
         };
 
-        using ChannelMap = std::unordered_map<uintptr_t, Proxies>;
-        using ReferenceMap = std::unordered_map<uintptr_t, std::list< RecoverySet > >;
-
         struct EXTERNAL IMetadata {
             virtual ~IMetadata() = default;
 
@@ -128,6 +122,13 @@ namespace RPC {
                 return (new PROXY(channel, implementation, remoteRefCounted))->Administration();
             }
         };
+
+    public:
+        using Proxies = std::vector<ProxyStub::UnknownProxy*>;
+        using ChannelMap = std::unordered_map<uintptr_t, Proxies>;
+        using ReferenceMap = std::unordered_map<uintptr_t, std::list< RecoverySet > >;
+        using Stubs = std::unordered_map<uint32_t, ProxyStub::UnknownStub*>;
+        using Factories = std::unordered_map<uint32_t, IMetadata*>;
 
     public:
         Administrator(Administrator&&) = delete;
@@ -186,7 +187,7 @@ namespace RPC {
         {
             _adminLock.Lock();
 
-            std::map<uint32_t, ProxyStub::UnknownStub*>::iterator stub(_stubs.find(ACTUALINTERFACE::ID));
+            Stubs::iterator stub(_stubs.find(ACTUALINTERFACE::ID));
             if (stub != _stubs.end()) {
                 delete stub->second;
                 _stubs.erase(ACTUALINTERFACE::ID);
@@ -194,7 +195,7 @@ namespace RPC {
                 TRACE_L1("Failed to find a Stub for %d.", ACTUALINTERFACE::ID);
             }
 
-            std::map<uint32_t, IMetadata*>::iterator proxy(_proxy.find(ACTUALINTERFACE::ID));
+            Factories::iterator proxy(_proxy.find(ACTUALINTERFACE::ID));
             if (proxy != _proxy.end()) {
                 delete proxy->second;
                 _proxy.erase(ACTUALINTERFACE::ID);
@@ -236,8 +237,8 @@ namespace RPC {
         // ----------------------------------------------------------------------------------------------------
         // Methods for the Proxy Environment
         // ----------------------------------------------------------------------------------------------------
-        void AddRef(Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId);
-        void Release(Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId, const uint32_t dropCount);
+        void AddRef(const Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId);
+        void Release(const Core::ProxyType<Core::IPCChannel>& channel, void* impl, const uint32_t interfaceId, const uint32_t dropCount);
 
         // ----------------------------------------------------------------------------------------------------
         // Methods for the Stub Environment
@@ -250,19 +251,23 @@ namespace RPC {
         // ----------------------------------------------------------------------------------------------------
         // Stub method for entries that the Stub returns to the callee
         template <typename ACTUALINTERFACE>
-        bool RegisterInterface(Core::ProxyType<Core::IPCChannel>& channel, ACTUALINTERFACE* reference)
+        bool RegisterInterface(const Core::ProxyType<Core::IPCChannel>& channel, ACTUALINTERFACE* reference)
         {
             return (RegisterInterface(channel, reference, ACTUALINTERFACE::ID));
         }
-        bool RegisterInterface(Core::ProxyType<Core::IPCChannel>& channel, const void* source, const uint32_t id)
+        bool RegisterInterface(const Core::ProxyType<Core::IPCChannel>& channel, const void* source, const uint32_t id)
         {
             bool result = false;
 
             Core::IUnknown* converted = Convert(const_cast<void*>(source), id);
 
             if (converted != nullptr) {
-                RegisterUnknownInterface(channel, converted, id);
-                result = true;
+                _adminLock.Lock();
+                if (channel.IsValid() == true) {
+                    RegisterUnknown(channel, converted, id);
+                    result = true;
+                }
+                _adminLock.Unlock();
             }
             else {
                 TRACE_L1("Failed to find a Stub for interface 0x%08x!", id);
@@ -270,35 +275,12 @@ namespace RPC {
 
             return (result);
         }
-
-        void UnregisterInterface(Core::ProxyType<Core::IPCChannel>& channel, const Core::IUnknown* source, const uint32_t interfaceId, const uint32_t dropCount)
+        void UnregisterInterface(const Core::ProxyType<Core::IPCChannel>& channel, const Core::IUnknown* source, const uint32_t interfaceId, const uint32_t dropCount)
         {
             _adminLock.Lock();
 
-            ReferenceMap::iterator index(_channelReferenceMap.find(channel->LinkId()));
-
-            if (index != _channelReferenceMap.end()) {
-                std::list< RecoverySet >::iterator element(index->second.begin());
-
-                while ( (element != index->second.end()) && ((element->Id() != interfaceId) || (element->Unknown() != source)) ) {
-                    element++;
-                }
-
-                ASSERT(element != index->second.end());
-
-                if (element != index->second.end()) {
-                    if (element->Decrement(dropCount) == false) {
-                        index->second.erase(element);
-                        if (index->second.size() == 0) {
-                            _channelReferenceMap.erase(index);
-                            TRACE_L3("Unregistered interface %p(%u).", source, interfaceId);
-                        }
-                    }
-                } else {
-                    printf("====> Unregistering an interface [0x%x, %d] which has not been registered!!!\n", interfaceId, Core::ProcessInfo().Id());
-                }
-            } else {
-                printf("====> Unregistering an interface [0x%x, %d] from a non-existing channel!!!\n", interfaceId, Core::ProcessInfo().Id());
+            if (channel.IsValid() == true) {
+                UnregisterUnknown(channel, source, interfaceId, dropCount);
             }
 
             _adminLock.Unlock();
@@ -311,13 +293,14 @@ namespace RPC {
         // ----------------------------------------------------------------------------------------------------
         Core::IUnknown* Convert(void* rawImplementation, const uint32_t id);
         const Core::IUnknown* Convert(void* rawImplementation, const uint32_t id) const;
-        void RegisterUnknownInterface(Core::ProxyType<Core::IPCChannel>& channel, Core::IUnknown* source, const uint32_t id);
+        void RegisterUnknown(const Core::ProxyType<Core::IPCChannel>& channel, Core::IUnknown* source, const uint32_t id);
+        void UnregisterUnknown(const Core::ProxyType<Core::IPCChannel>& channel, const Core::IUnknown* source, const uint32_t interfaceId, const uint32_t dropCount);
 
     private:
         // Seems like we have enough information, open up the Process communcication Channel.
         mutable Core::CriticalSection _adminLock;
-        std::map<uint32_t, ProxyStub::UnknownStub*> _stubs;
-        std::map<uint32_t, IMetadata*> _proxy;
+        Stubs _stubs;
+        Factories _proxy;
         Core::ProxyPoolType<InvokeMessage> _factory;
         ChannelMap _channelProxyMap;
         ReferenceMap _channelReferenceMap;

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -155,12 +155,6 @@ namespace ProxyStub {
         uint32_t ReferenceCount() const {
             return(_refCount);
         }
-    	void Invalidate() {
-            ASSERT(_refCount > 0);
-            _adminLock.Lock();
-            _channel.Release();
-            _adminLock.Unlock();
-        }
         // -------------------------------------------------------------------------------------------------------------------------------
         // Proxy/Stub (both) environment calls
         // -------------------------------------------------------------------------------------------------------------------------------
@@ -263,10 +257,11 @@ namespace ProxyStub {
             else {
                 RPC::Data::Frame::Reader response(message->Response().Reader());
                 Core::instance_id impl = response.Number<Core::instance_id>();
+                _adminLock.Unlock();
+
                 // From what is returned, we need to create a proxy
                 RPC::Administrator::Instance().ProxyInstance(_channel, impl, true, id, result);
 
-                _adminLock.Unlock();
             }
             return (result);
         }
@@ -274,23 +269,11 @@ namespace ProxyStub {
         {
             return (&_parent);
         }
-        uintptr_t LinkId() const
-        {
-            Core::SafeSyncType<Core::CriticalSection> lock(_adminLock);
-            return (_channel.IsValid() ? _channel->LinkId() : 0);
-        }
         const Core::SocketPort* Socket() const;
         void* Interface(const Core::instance_id& implementation, const uint32_t id) const
         {
             void* result = nullptr;
-
-            _adminLock.Lock();
-
-            if (_channel.IsValid() == true) {
-                RPC::Administrator::Instance().ProxyInstance(_channel, implementation, true, id, result);
-            }
-            _adminLock.Unlock();
-
+            RPC::Administrator::Instance().ProxyInstance(_channel, implementation, true, id, result);
             return (result);
         }
         inline uint32_t InterfaceId() const
@@ -334,49 +317,32 @@ namespace ProxyStub {
 
             return (result);
         }
-        inline uint32_t Complete(const Core::instance_id& impl, const uint32_t id, const RPC::Data::Output::mode how)
+        inline void Complete(RPC::Data::Setup& response)
         {
-            // This method is called from the stubs.
-            uint32_t result = Core::ERROR_NONE;
+            uint32_t result = Release();
 
             _adminLock.Lock();
 
-            if (_channel.IsValid() == true) {
-                if (how == RPC::Data::Output::mode::CACHED_ADDREF) {
-                    // Just AddRef this implementation
-                    RPC::Administrator::Instance().AddRef(_channel, reinterpret_cast<void*>(impl), id);
+            if ((_mode & CACHING_ADDREF) != 0) {
+                _mode ^= CACHING_ADDREF;
+
+                if (_refCount > 1) {
+                    response.Action(RPC::Data::Output::mode::CACHED_ADDREF);
                 }
-                else if (how == RPC::Data::Output::mode::CACHED_RELEASE) {
-                    // Just Release this implementation
-                    RPC::Administrator::Instance().Release(_channel, reinterpret_cast<void*>(impl), id, 1);
-                }
-                else {
-                    ASSERT(!"Invalid caching data");
-                    result = Core::ERROR_INVALID_RANGE;
+            }
+            else if ((_mode & CACHING_RELEASE) != 0)  {
+                _mode ^= CACHING_RELEASE;
+
+                if (result == Core::ERROR_DESTRUCTION_SUCCEEDED) {
+                    response.Action(RPC::Data::Output::mode::CACHED_RELEASE);
                 }
             }
 
             _adminLock.Unlock();
 
-            return (result);
-        }
-
-        // -------------------------------------------------------------------------------------------------------------------------------
-        // Stub environment calls
-        // -------------------------------------------------------------------------------------------------------------------------------
-        // This method should only be called from the administrator from stub implementation methods
-        // It should be called through the Administrator::Release(ProxyStub*, Message::Response) !!
-	    // Concurrent access trhough this code is prevented by the CriticalSection in the Administrator
-        template <typename ACTUAL_INTERFACE>
-        inline ACTUAL_INTERFACE* QueryInterface() const
-        {
-            return (reinterpret_cast<ACTUAL_INTERFACE*>(QueryInterface(ACTUAL_INTERFACE::ID)));
-        }
-        inline void* QueryInterface(const uint32_t id) const
-        {
-            ASSERT (_interfaceId == id);
-
-            return (_parent.QueryInterface(id));
+            if (result == Core::ERROR_DESTRUCTION_SUCCEEDED) {
+                delete &_parent;
+            }
         }
         inline void Complete(RPC::Data::Output& response)
         {
@@ -409,34 +375,64 @@ namespace ProxyStub {
                 delete &_parent;
             }
         }
-        inline void Complete(RPC::Data::Setup& response)
+        inline uint32_t Complete(const Core::instance_id& impl, const uint32_t id, const RPC::Data::Output::mode how)
         {
-            uint32_t result = Release();
+            // This method is called from the stubs.
+            uint32_t result = Core::ERROR_NONE;
 
-            _adminLock.Lock();
-
-            if ((_mode & CACHING_ADDREF) != 0) {
-                _mode ^= CACHING_ADDREF;
-
-                if (_refCount > 1) {
-                    response.Action(RPC::Data::Output::mode::CACHED_ADDREF);
-                }
+            if (how == RPC::Data::Output::mode::CACHED_ADDREF) {
+                // Just AddRef this implementation
+                RPC::Administrator::Instance().AddRef(_channel, reinterpret_cast<void*>(impl), id);
             }
-            else if ((_mode & CACHING_RELEASE) != 0)  {
-                _mode ^= CACHING_RELEASE;
-
-                if (result == Core::ERROR_DESTRUCTION_SUCCEEDED) {
-                    response.Action(RPC::Data::Output::mode::CACHED_RELEASE);
-                }
+            else if (how == RPC::Data::Output::mode::CACHED_RELEASE) {
+                // Just Release this implementation
+                RPC::Administrator::Instance().Release(_channel, reinterpret_cast<void*>(impl), id, 1);
+            }
+            else {
+                ASSERT(!"Invalid caching data");
+                result = Core::ERROR_INVALID_RANGE;
             }
 
-            _adminLock.Unlock();
-
-            if (result == Core::ERROR_DESTRUCTION_SUCCEEDED) {
-                delete &_parent;
-            }
+            return (result);
         }
+ 
+    private:
+        friend RPC::Administrator;
 
+        // -------------------------------------------------------------------------------------------------------------------------------
+        // Stub environment calls
+        // -------------------------------------------------------------------------------------------------------------------------------
+        // This method should only be called from the administrator from stub implementation methods
+        // It should be called through the Administrator::Release(ProxyStub*, Message::Response) !!
+        // Concurrent access trhough this code is prevented by the CriticalSection in the Administrator
+        template <typename ACTUAL_INTERFACE>
+        inline ACTUAL_INTERFACE* QueryInterface() const
+        {
+            return (reinterpret_cast<ACTUAL_INTERFACE*>(QueryInterface(ACTUAL_INTERFACE::ID)));
+        }
+        inline void* QueryInterface(const uint32_t id) const
+        {
+            ASSERT (_interfaceId == id);
+
+            return (_parent.QueryInterface(id));
+        }
+       // The RPC::Administrator uses this to identifiy to what link this 
+        // proxy belongs. The LinkId is always called within the lock of the
+        // RPC::Administrator, and since it is onl used and called from there 
+        // and the clearing of the _channel is also only called from there,
+        // Invalidate(), It is safe to use it on the _channel in an unlocked
+        // fashion!!
+        uintptr_t LinkId() const
+        {
+            return (_channel.IsValid() ? _channel->LinkId() : 0);
+        }
+        void Invalidate() {
+            ASSERT(_refCount > 0);
+            _adminLock.Lock();
+            _channel.Release();
+            _adminLock.Unlock();
+        }
+ 
     private:
         mutable Core::CriticalSection _adminLock;
         mutable uint32_t _refCount;


### PR DESCRIPTION
… and the ProxyStub::UnknownProxy!

The essence is that the calls to RPC::Administrator from within the ProxyStub::UnknownProxy are now always outside of the administration lock required by the ProxyStub::UnknownProxy. This is possible as the only member variable that is fluctuating and could cause an issue is the _channel. However, resetting the _channel in the ProxyStub::UnknownProxy is only possible through the Invalidate. The Invalidate can only be called by the RPC::Administrator, whois now usin it's own lock in case the Invalidate is called. This way using/checking the _channel member frm ProxyStub::UnknownProxy is now safe from an RPC::Administrator point of view.
But the proof of the pudding is in the eating, time to start eating :-)