### PR TITLE
RDK-41134 Improve Thunder Responsiveness [Thunder R4_4]

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,9 @@ Licensed under the Apache License, Version 2.0
 Copyright 2014 Fraunhofer FOKUS
 Licensed under the Apache License, Version 2.0
 
+Copyright 2024 Synamedia Ltd.
+Licensed under the Apache License, Version 2.0
+
 Copyright 2016-2017 TATA ELXSI
 Licensed under the Apache License, Version 2.0
 

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "PluginServer.h"
+#include "PluginHost.h"
 #include <fstream>
 
 #ifndef __WINDOWS__
@@ -262,10 +263,11 @@ POP_WARNING()
 
     ExitHandler* ExitHandler::_instance = nullptr;
     Core::CriticalSection ExitHandler::_adminLock;
-    
+
     #ifndef __WINDOWS__
     struct sigaction _originalSegmentationHandler;
     struct sigaction _originalAbortHandler;
+    static Core::CriticalSection _adminLock;
     #endif
 
     static string GetDeviceId(PluginHost::Server* dispatcher)
@@ -300,6 +302,7 @@ POP_WARNING()
 
     void ExitDaemonHandler(int signo)
     {
+        string segname = "";
         if (_background) {
             syslog(LOG_NOTICE, "Signal received %d. in process [%d]", signo, getpid());
         } else {
@@ -327,11 +330,12 @@ POP_WARNING()
 
 
             ExitHandler::DumpMetadata();
+            segname = (signo == SIGSEGV) ? "a segmentation fault" : (signo == SIGABRT) ? "an abort" : "";
 
             if (_background) {
-                syslog(LOG_NOTICE, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a segmentation fault. All relevant data dumped");
+                syslog(LOG_NOTICE, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to %s signal. All relevant data dumped", segname.c_str());
             } else {
-                fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a segmentation fault. All relevant data dumped\n");
+                fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to %s signal. All relevant data dumped\n", segname.c_str());
                 fflush(stderr);
             }
 
@@ -340,6 +344,48 @@ POP_WARNING()
         else if (signo == SIGUSR1) {
             ExitHandler::DumpMetadata();
         }
+    }
+
+    void SetupCrashHandler(void)
+    {
+        _adminLock.Lock();
+        struct sigaction sa, current_sa;
+
+        sigaction(SIGSEGV, nullptr, &current_sa);
+        if (current_sa.sa_handler != ExitDaemonHandler)
+        {
+            _originalSegmentationHandler = current_sa;
+             memset(&sa, 0, sizeof(struct sigaction));
+             sigemptyset(&sa.sa_mask);
+             sa.sa_handler = ExitDaemonHandler;
+             sa.sa_flags = 0;
+             if (_background) {
+                 syslog(LOG_NOTICE, "Registering ExitDaemonHandler for SIGSEGV");
+             } else {
+                 fprintf(stdout, "Registering ExitDaemonHandler for SIGSEGV \n");
+                 fflush(stdout);
+             }
+             sigaction(SIGSEGV, &sa, nullptr);
+        }
+
+        memset(&current_sa, 0, sizeof(struct sigaction));
+        sigaction(SIGABRT, nullptr, &current_sa);
+        if (current_sa.sa_handler != ExitDaemonHandler)
+        {
+            _originalAbortHandler = current_sa;
+             memset(&sa, 0, sizeof(struct sigaction));
+             sigemptyset(&sa.sa_mask);
+             sa.sa_handler = ExitDaemonHandler;
+             sa.sa_flags = 0;
+             if (_background) {
+                 syslog(LOG_NOTICE, "Registering ExitDaemonHandler for SIGABRT");
+             } else {
+                 fprintf(stdout, "Registering ExitDaemonHandler for SIGABRT \n");
+                 fflush(stdout);
+             }
+             sigaction(SIGABRT, &sa, nullptr);
+        }
+        _adminLock.Unlock();
     }
 
 #endif

--- a/Source/WPEFramework/PluginHost.h
+++ b/Source/WPEFramework/PluginHost.h
@@ -1,0 +1,32 @@
+/*
+ * * If not stated otherwise in this file or this component's LICENSE file the
+ * * following copyright and licenses apply:
+ * *
+ * * Copyright 2024 Synamedia Ltd.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * */
+
+#ifndef __PLUGINHOST_H
+#define __PLUGINHOST_H
+
+namespace WPEFramework {
+    namespace PluginHost {
+        extern "C" {
+
+        void SetupCrashHandler(void);
+        }
+    }
+}
+#endif // __PLUGINHOST_H
+

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -19,6 +19,7 @@
 
 #include "PluginServer.h"
 #include "Controller.h"
+#include "PluginHost.h"
 
 #ifndef __WINDOWS__
 #include <syslog.h>
@@ -187,6 +188,8 @@ namespace PluginHost
 
         WARNING_REPORTING_THREAD_SETCALLSIGN_GUARD(callsign.c_str());
     #endif
+
+        SetupCrashHandler();
 
     #ifdef __CORE_EXCEPTION_CATCHING__
 

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -4445,6 +4445,12 @@ POP_WARNING()
                 std::list<Core::callstack_info> stackList;
 
                 ::DumpCallStack(static_cast<ThreadId>(index.Current().Id.Value()), stackList);
+                for(const Core::callstack_info& entry : stackList)
+                {
+                    std::string symbol = entry.function.empty() ? "Unknown symbol" : entry.function;
+                    fprintf(stderr, "[%s]:[%s]:[%d]:[%p]\n",entry.module.c_str(), symbol.c_str(),entry.line,entry.address);
+                }
+                fflush(stderr);
 
                 PostMortemData::Callstack dump;
                 dump.Id = index.Current().Id.Value();


### PR DESCRIPTION
Reason for change: Improve Thunder Responsiveness [Crash handling in Thunder R4_4]
Test Procedure: Simulate crash in rdkservices and verify the call stack actvity logs are generated
Risks: NO
Priority: P1
Signed-off-by: Sethulakshmi SK (ssk@synamedia.com)