### PR TITLE
RDK-41134 Improve Thunder Responsiveness [Master]

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,9 @@ Licensed under the Apache License, Version 2.0
 Copyright 2014 Fraunhofer FOKUS
 Licensed under the Apache License, Version 2.0
 
+Copyright 2024 Synamedia Ltd.
+Licensed under the Apache License, Version 2.0
+
 Copyright 2016-2017 TATA ELXSI
 Licensed under the Apache License, Version 2.0
 

--- a/Source/WPEFramework/PluginHost.h
+++ b/Source/WPEFramework/PluginHost.h
@@ -1,0 +1,32 @@
+/*
+ * * If not stated otherwise in this file or this component's LICENSE file the
+ * * following copyright and licenses apply:
+ * *
+ * * Copyright 2024 Synamedia Ltd.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * */
+
+#ifndef __PLUGINHOST_H
+#define __PLUGINHOST_H
+
+namespace WPEFramework {
+    namespace PluginHost {
+        extern "C" {
+
+        void SetupCrashHandler(void);
+        }
+    }
+}
+#endif // __PLUGINHOST_H
+

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -19,6 +19,7 @@
 
 #include "PluginServer.h"
 #include "Controller.h"
+#include "PluginHost.h"
 
 #ifndef __WINDOWS__
 #include <syslog.h>
@@ -193,6 +194,8 @@ namespace PluginHost {
 
         WARNING_REPORTING_THREAD_SETCALLSIGN_GUARD(callsign.c_str());
     #endif
+      
+	    SetupCrashHandler();
 
     #ifdef __CORE_EXCEPTION_CATCHING__
 

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -4393,6 +4393,12 @@ namespace PluginHost {
                 std::list<Core::callstack_info> stackList;
 
                 ::DumpCallStack((ThreadId)index.Current().Id.Value(), stackList);
+                for(const Core::callstack_info& entry : stackList)
+                {
+                    std::string symbol = entry.function.empty() ? "Unknown symbol" : entry.function;
+                    fprintf(stderr, "[%s]:[%s]:[%d]:[%p]\n",entry.module.c_str(), symbol.c_str(),entry.line,entry.address);
+                }
+                fflush(stderr);
 
                 PostMortemData::Callstack dump;
                 dump.Id = index.Current().Id.Value();


### PR DESCRIPTION
Reason for change: Improve Thunder Responsiveness [Crash handling in Thunder Master]
Test Procedure: Simulate crash in rdkservices and verify the call stack actvity logs are generated
Risks: NO
Priority: P1
Signed-off-by: Sethulakshmi SK (ssk@synamedia.com)