### PR TITLE
[core/DataElement] : prevent undefined behavior

### DIFF
--- a/Source/core/DataElement.cpp
+++ b/Source/core/DataElement.cpp
@@ -96,9 +96,9 @@ namespace Core {
         ASSERT(buffer != nullptr);
 
         // Check if we cross a boundary for the read..
-        if (((offset + size) <= Size()) && (buffer != Buffer())) {
+        if ((offset + size) <= Size()) {
             // Nope, one plain copy !!!
-            ::memcpy(buffer, &(Buffer()[offset]), size);
+            ::memmove(buffer, &(Buffer()[offset]), size);
         } else {
             // If we want to read more than 4Gb ASSERT !!
             ASSERT(Size() - offset < 0xFFFFFFFF);
@@ -121,9 +121,9 @@ namespace Core {
         ASSERT(buffer != nullptr);
 
         // Check if we cross a boundary for the write..
-        if (((offset + size) <= Size()) && (buffer != Buffer())) {
+        if ((offset + size) <= Size()) {
             // Nope, one plain copy !!!
-            ::memcpy(&(Buffer()[offset]), buffer, size);
+            ::memmove(&(Buffer()[offset]), buffer, size);
         } else {
             // If we want to write more than 4Gb ASSERT !!
             ASSERT(Size() - offset < 0xFFFFFFFF);

--- a/Source/core/DataElement.cpp
+++ b/Source/core/DataElement.cpp
@@ -152,9 +152,9 @@ namespace Core {
         uint64_t copiedSize = 0;
 
         do {
-            if ((source->Size() - sourceOffset) > (destination->Size() - destinationOffset) && (source != destination)) {
+            if ((source->Size() - sourceOffset) > (destination->Size() - destinationOffset)) {
                 // The destination is the limiting factor, fill the destination up..
-                ::memcpy(&(destination->Buffer()[destinationOffset]), &(source->Buffer()[sourceOffset]), static_cast<uint32_t>(destination->Size() - destinationOffset));
+                ::memmove(&(destination->Buffer()[destinationOffset]), &(source->Buffer()[sourceOffset]), static_cast<uint32_t>(destination->Size() - destinationOffset));
 
                 sourceOffset += (destination->Size() - destinationOffset);
                 copiedSize += (destination->Size() - destinationOffset);
@@ -169,8 +169,10 @@ namespace Core {
                 source = source->m_Next;
                 sourceOffset = 0;
             }
-
-        } while ((destination != nullptr) && (source != nullptr));
+        } while (   (destination != nullptr)
+                 && (source != nullptr)
+                 && !((copiedSize >= destination->Size()) && (destination->m_Next == nullptr))
+        );
 
         return (copiedSize);
     }

--- a/Source/core/DataElement.cpp
+++ b/Source/core/DataElement.cpp
@@ -79,6 +79,7 @@ namespace Core {
     /// <returns>Calculated CRC value</returns>
     uint32_t DataElement::CRC32(const uint64_t offset, const uint64_t size) const
     {
+        ASSERT(IsValid());
         ASSERT(offset + size <= m_Size);
         uint32_t crc = 0xffffffff;
 

--- a/Source/core/DataElement.cpp
+++ b/Source/core/DataElement.cpp
@@ -91,8 +91,11 @@ namespace Core {
 
     void LinkedDataElement::GetBuffer(uint64_t offset, uint32_t size, uint8_t* buffer) const
     {
+        ASSERT(IsValid());
+        ASSERT(buffer != nullptr);
+
         // Check if we cross a boundary for the read..
-        if ((offset + size) <= Size()) {
+        if (((offset + size) <= Size()) && (buffer != Buffer())) {
             // Nope, one plain copy !!!
             ::memcpy(buffer, &(Buffer()[offset]), size);
         } else {
@@ -113,8 +116,11 @@ namespace Core {
 
     void LinkedDataElement::SetBuffer(uint64_t offset, uint32_t size, const uint8_t* buffer)
     {
+        ASSERT(IsValid());
+        ASSERT(buffer != nullptr);
+
         // Check if we cross a boundary for the write..
-        if ((offset + size) <= Size()) {
+        if (((offset + size) <= Size()) && (buffer != Buffer())) {
             // Nope, one plain copy !!!
             ::memcpy(&(Buffer()[offset]), buffer, size);
         } else {
@@ -135,6 +141,9 @@ namespace Core {
 
     uint64_t LinkedDataElement::Copy(const uint64_t offset, const LinkedDataElement& copy)
     {
+        ASSERT(IsValid());
+        ASSERT(copy.IsValid());
+
         const LinkedDataElement* source = &copy;
         LinkedDataElement* destination = this;
         uint64_t sourceOffset = 0;
@@ -142,7 +151,7 @@ namespace Core {
         uint64_t copiedSize = 0;
 
         do {
-            if ((source->Size() - sourceOffset) > (destination->Size() - destinationOffset)) {
+            if ((source->Size() - sourceOffset) > (destination->Size() - destinationOffset) && (source != destination)) {
                 // The destination is the limiting factor, fill the destination up..
                 ::memcpy(&(destination->Buffer()[destinationOffset]), &(source->Buffer()[sourceOffset]), static_cast<uint32_t>(destination->Size() - destinationOffset));
 

--- a/Source/core/DataElement.h
+++ b/Source/core/DataElement.h
@@ -75,6 +75,8 @@ namespace Core {
     public:
         inline void Copy(const uint8_t data[], const uint16_t length, const uint16_t offset = 0)
         {
+            ASSERT(_buffer != nullptr);
+
             ASSERT(offset < _size);
             if (offset < _size) {
                 ASSERT(static_cast<uint32_t>(offset + length) <= _size);
@@ -345,6 +347,8 @@ namespace Core {
 
         bool Expand(const uint64_t offset, const uint32_t size)
         {
+            ASSERT(IsValid());
+
             bool expanded = false;
 
             // Make sure we are not shrinking beyond the size boundary
@@ -362,7 +366,9 @@ namespace Core {
         }
 
         bool Shrink(const uint64_t offset, const uint32_t size)
-        {
+       {
+            ASSERT(IsValid());
+
             // Make sure we are not shrinking beyond the size boundary
             ASSERT(m_Size >= (offset + size));
 
@@ -370,18 +376,21 @@ namespace Core {
             m_Size -= size;
 
             // Shift all data back the beginning in..
-            ::memcpy(&m_Buffer[static_cast<size_t>(offset)], &m_Buffer[static_cast<size_t>(offset) + size], static_cast<size_t>(m_Size - offset));
+            ::memmove(&m_Buffer[static_cast<size_t>(offset)], &m_Buffer[static_cast<size_t>(offset) + size], static_cast<size_t>(m_Size - offset));
 
             return (true);
         }
 
         bool Copy(const DataElement& RHS, const uint64_t offset = 0)
         {
+            ASSERT(IsValid());
+            ASSERT(RHS.IsValid());
+
             bool copied = false;
 
             // see if we need to resize
             if ((RHS.Size() + offset) > m_Size) {
-                if (Size(offset + RHS.m_Size) == true) {
+                if ((Size(offset + RHS.m_Size) == true) && (this != &RHS)) {
                     ::memcpy(&(m_Buffer[offset]), RHS.m_Buffer, static_cast<size_t>(RHS.m_Size));
                     m_Size = offset + RHS.m_Size;
                     copied = true;
@@ -577,6 +586,9 @@ namespace Core {
 
         inline void GetBuffer(const uint64_t offset, const uint32_t size, uint8_t* buffer) const
         {
+            ASSERT(IsValid());
+            ASSERT(buffer != nullptr);
+
             // Check if we cross a boundary for the read..
             ASSERT((offset + size) <= m_Size);
 
@@ -694,6 +706,9 @@ namespace Core {
 
         void SetBuffer(const uint64_t offset, const uint32_t size, const uint8_t* buffer)
         {
+            ASSERT(IsValid());
+            ASSERT(buffer != nullptr);
+
             // Check if we cross a boundary for the write..
             ASSERT((offset + size) <= m_Size);
 

--- a/Source/core/DataElement.h
+++ b/Source/core/DataElement.h
@@ -307,6 +307,9 @@ namespace Core {
         }
         inline bool operator==(const DataElement& RHS) const
         {
+            ASSERT(IsValid());
+            ASSERT(RHS.IsValid());
+
             return ((m_Size == RHS.m_Size) && (::memcmp(m_Buffer, RHS.m_Buffer, static_cast<size_t>(m_Size)) == 0));
         }
         inline bool operator!=(const DataElement& RHS) const
@@ -334,16 +337,24 @@ namespace Core {
 
         inline uint8_t& operator[](const uint32_t index)
         {
+            ASSERT(IsValid());
+            ASSERT(index < m_Size);
+
             return (m_Buffer[index]);
         }
 
         inline const uint8_t& operator[](const uint32_t index) const
         {
+            ASSERT(IsValid());
+            ASSERT(index < m_Size);
+
             return (m_Buffer[index]);
         }
 
         void Set(const uint8_t value, const uint64_t offset = 0, const uint64_t size = NUMBER_MAX_UNSIGNED(uint64_t))
         {
+            ASSERT(IsValid());
+
             ASSERT((size == NUMBER_MAX_UNSIGNED(uint64_t)) || ((offset + size) < m_Size));
             if (size == NUMBER_MAX_UNSIGNED(uint64_t)) {
                 ::memset(&m_Buffer[offset], value, static_cast<size_t>(m_Size - offset));
@@ -417,6 +428,8 @@ namespace Core {
 
         uint64_t Search(const uint64_t offset, const uint8_t pattern[], const uint32_t size) const
         {
+            ASSERT(IsValid());
+
             bool found = false;
             uint64_t index = offset;
 
@@ -451,6 +464,8 @@ namespace Core {
         template <typename TYPENAME, const NumberEndian ENDIAN>
         uint64_t SearchNumber(const uint64_t offset, const TYPENAME info) const
         {
+            ASSERT(IsValid());
+
             // Make sure we do not pass the boundaries !!!
             ASSERT(offset < m_Size);
 

--- a/Source/core/DataElement.h
+++ b/Source/core/DataElement.h
@@ -397,7 +397,7 @@ namespace Core {
 
             // see if we need to resize
             if ((RHS.Size() + offset) > m_Size) {
-                if ((Size(offset + RHS.m_Size) == true) && (this != &RHS)) {
+                if ((this != &RHS) && (Size(offset + RHS.m_Size) == true)) {
                     ::memcpy(&(m_Buffer[offset]), RHS.m_Buffer, static_cast<size_t>(RHS.m_Size));
                     m_Size = offset + RHS.m_Size;
                     copied = true;

--- a/Source/core/DataElement.h
+++ b/Source/core/DataElement.h
@@ -118,6 +118,8 @@ namespace Core {
     protected:
         void UpdateCache(const uint64_t offset, uint8_t* buffer, const uint64_t size, const uint64_t maxSize)
         {
+            ASSERT(buffer != nullptr);
+
             // Update the cache...
             m_Offset = offset;
             m_Size = size;
@@ -126,6 +128,7 @@ namespace Core {
         }
         void UpdateCache(const Core::DataElement& data, const uint64_t offset, const uint64_t size)
         {
+            ASSERT(data.IsValid());
             ASSERT((offset + size) <= data.Size());
 
             // Update the cache...
@@ -193,6 +196,8 @@ namespace Core {
             , m_Size(move.m_Size)
             , m_MaxSize(move.m_MaxSize)
         {
+            ASSERT(this != &move);
+
             move.m_Buffer = nullptr;
             move.m_Offset = 0;
             move.m_Size = 0;
@@ -219,6 +224,8 @@ namespace Core {
             , m_Size(move.m_Size - offset)
             , m_MaxSize(move.m_MaxSize)
         {
+            ASSERT(this != &move);
+
             if (size != 0) {
                 m_Size = size;
             }

--- a/Tests/unit/core/test_dataelement.cpp
+++ b/Tests/unit/core/test_dataelement.cpp
@@ -91,6 +91,7 @@ TEST(test_linkeddata, simple_linkeddata)
     LinkedDataElement ob2(objt1);
     LinkedDataElement ob3(ob2);
     ob3.Enclosed(&ob2);
+    EXPECT_EQ(ob3.Enclosed(), &ob2);
     ob3.SetBuffer(2,9,arr);
     ob3.GetBuffer(2,9,arr1);
     LinkedDataElement ob4;


### PR DESCRIPTION
'memcpy' and 'memmove' may experience undefined behavior under certain conditions