### PR TITLE
Thunder R4.4 Build Error Fixed when ProcessContainer enabled

### DIFF
--- a/Source/extensions/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
+++ b/Source/extensions/processcontainers/implementations/DobbyImplementation/DobbyImplementation.cpp
@@ -56,16 +56,16 @@ namespace ProcessContainers {
             };
 
             Core::File configBundleFile(path + "/Container" + CONFIG_NAME);
-            TRACE(ProcessContainers::ProcessContainerization, (_T("searching %s container at %s, %s"), id.c_str(), configBundleFile.Name().c_str(), configBundleFile.PathName().c_str()));
+            TRACE(Trace::Information, (_T("searching %s container at %s, %s"), id.c_str(), configBundleFile.Name().c_str(), configBundleFile.PathName().c_str()));
             if (configBundleFile.Exists()) {
-                TRACE(ProcessContainers::ProcessContainerization, (_T("Found %s container!"), id.c_str()));
+                TRACE(Trace::Information, (_T("Found %s container!"), id.c_str()));
                 return createContainer(false, configBundleFile.PathName());
             }
 
             Core::File configSpecFile(path + CONFIG_NAME_SPEC);
-            TRACE(ProcessContainers::ProcessContainerization, (_T("searching %s container at %s"), id.c_str(), configSpecFile.Name().c_str(), configSpecFile.Name().c_str()));
+            TRACE(Trace::Information, (_T("searching %s container at %s"), id.c_str(), configSpecFile.Name().c_str(), configSpecFile.Name().c_str()));
             if (configSpecFile.Exists()) {
-                TRACE(ProcessContainers::ProcessContainerization, (_T("Found %s container!"), id.c_str()));
+                TRACE(Trace::Information, (_T("Found %s container!"), id.c_str()));
                 return createContainer(true, configSpecFile.Name());
             }
         }
@@ -112,7 +112,7 @@ namespace ProcessContainers {
             for (const std::pair<int32_t, std::string>& c : runningContainers) {
                 if (c.second == name) {
                     // found the container, now try stopping it...
-                    TRACE(ProcessContainers::ProcessContainerization, (_T("destroying container: %s "), name.c_str()));
+                    TRACE(Trace::Information, (_T("destroying container: %s "), name.c_str()));
 
                     // Dobby stop is async - block until we get the notification the container
                     // has actually stopped
@@ -134,7 +134,7 @@ namespace ProcessContainers {
                         // Block here until container has stopped (max 5 seconds)
                         std::future_status status = future.wait_for(std::chrono::seconds(5));
                         if (status == std::future_status::ready) {
-                            TRACE(ProcessContainers::ProcessContainerization, (_T("Container %s has stopped"), name.c_str()));
+                            TRACE(Trace::Information, (_T("Container %s has stopped"), name.c_str()));
                         } else if (status == std::future_status::timeout) {
                             TRACE(Trace::Warning, (_T("Timeout waiting for container %s to stop"), name.c_str()));
                         }
@@ -163,7 +163,7 @@ namespace ProcessContainers {
         if (!runningContainers.empty()) {
             for (const std::pair<int32_t, std::string>& c : runningContainers) {
                 if (c.second == name) {
-                    TRACE(ProcessContainers::ProcessContainerization, (_T("container %s already running..."), name.c_str()));
+                    TRACE(Trace::Information, (_T("container %s already running..."), name.c_str()));
                     result = true;
                     break;
                 }
@@ -361,7 +361,7 @@ namespace ProcessContainers {
         }
 
         if (_useSpecFile) {
-            TRACE(ProcessContainers::ProcessContainerization, (_T("path set to %s for name %s"), _path.c_str(), _name.c_str()));
+            TRACE(Trace::Information, (_T("path set to %s for name %s"), _path.c_str(), _name.c_str()));
 
             std::ifstream jsonSpecFile(_path);
 
@@ -370,7 +370,7 @@ namespace ProcessContainers {
 
             // convert ostringstream to std::string
             std::string containerSpecString = specFileStream.str();
-            TRACE(ProcessContainers::ProcessContainerization, (_T("container spec string: %s"), containerSpecString.c_str()));
+            TRACE(Trace::Information, (_T("container spec string: %s"), containerSpecString.c_str()));
 
             _descriptor = admin.mDobbyProxy->startContainerFromSpec(_name, containerSpecString , emptyList, fullCommand);
         } else {
@@ -381,10 +381,10 @@ namespace ProcessContainers {
             TRACE(Trace::Error, (_T("Failed to start container %s - internal Dobby error."), _name.c_str()));
             result = false;
         } else {
-            TRACE(ProcessContainers::ProcessContainerization, (_T("started %s container! descriptor: %d"), _name.c_str(), _descriptor));
+            TRACE(Trace::Information, (_T("started %s container! descriptor: %d"), _name.c_str(), _descriptor));
             result = true;
         }
-        _adminLock.UnLock();
+        _adminLock.Unlock();
 
         return result;
     }

--- a/Source/extensions/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
+++ b/Source/extensions/processcontainers/implementations/DobbyImplementation/DobbyImplementation.h
@@ -24,7 +24,7 @@
 #include "processcontainers/common/BaseRefCount.h"
 #include "processcontainers/common/CGroupContainerInfo.h"
 
-#include "Messaging.h"
+#include "messaging/messaging.h"
 
 #include <Dobby/DobbyProtocol.h>
 #include <Dobby/Public/Dobby/IDobbyProxy.h>

--- a/Source/extensions/processcontainers/implementations/LXCImplementation/LXCImplementation.cpp
+++ b/Source/extensions/processcontainers/implementations/LXCImplementation/LXCImplementation.cpp
@@ -210,7 +210,7 @@ namespace ProcessContainers {
             Stop(2000);
         }
 
-        TRACE(ProcessContainers::ProcessContainerization, (_T("Container [%s] released"), _name.c_str()));
+        TRACE(Trace::Information, (_T("Container [%s] released"), _name.c_str()));
 
         static_cast<LXCContainerAdministrator&>(LXCContainerAdministrator::Instance()).RemoveContainer(this);
     }
@@ -360,9 +360,9 @@ namespace ProcessContainers {
 
         if (result == true) {
             _pid = _lxcContainer->init_pid(_lxcContainer);
-            TRACE(ProcessContainers::ProcessContainerization, (_T("Container [%s] was started successfully! pid=%u"), _name.c_str(), _pid));
+            TRACE(Trace::Information, (_T("Container [%s] was started successfully! pid=%u"), _name.c_str(), _pid));
         } else {
-            TRACE(ProcessContainers::ProcessContainerization, (_T("Container [%s] could not be started!"), _name.c_str()));
+            TRACE(Trace::Information, (_T("Container [%s] could not be started!"), _name.c_str()));
         }
         _adminLock.Unlock();
 
@@ -375,7 +375,7 @@ namespace ProcessContainers {
 
         _adminLock.Lock();
         if (_lxcContainer->is_running(_lxcContainer) == true) {
-            TRACE(ProcessContainers::ProcessContainerization, (_T("Container name [%s] Stop activated"), _name.c_str()));
+            TRACE(Trace::Information, (_T("Container name [%s] Stop activated"), _name.c_str()));
             int internaltimeout = defaultTimeOutInMSec / 1000;
 #if 0
             if (timeout == Core::infinite) {
@@ -453,7 +453,7 @@ namespace ProcessContainers {
         : BaseContainerAdministrator()
         , _globalLogDir()
     {
-        TRACE(ProcessContainers::ProcessContainerization, (_T("LXC library initialization, version: %s"), lxc_get_version()));
+        TRACE(Trace::Information, (_T("LXC library initialization, version: %s"), lxc_get_version()));
     }
 
     LXCContainerAdministrator::~LXCContainerAdministrator()
@@ -490,7 +490,7 @@ namespace ProcessContainers {
         };
 
         if (container == nullptr) {
-            TRACE(ProcessContainers::ProcessContainerization, (_T("Container Definition for name [%s] could not be found!"), name.c_str()));
+            TRACE(Trace::Information, (_T("Container Definition for name [%s] could not be found!"), name.c_str()));
         }
 
         return static_cast<IContainer*>(container);


### PR DESCRIPTION
* Fixed Thunder R4.4..1 Compilation error when enabled ProcessContiainer 
* Correct the UnLock spelling
* Correct the messaging  header file
* updated the ProcessContainers::ProcessContainerization into Trace::Information
