### PR TITLE
Support for autowakeup on IPC call to hibernated plugin

### DIFF
--- a/Source/Thunder/CMakeLists.txt
+++ b/Source/Thunder/CMakeLists.txt
@@ -88,10 +88,15 @@ if (PROCESSCONTAINERS)
 endif(PROCESSCONTAINERS)
 
 if(HIBERNATESUPPORT)
+    option(HIBERNATESUPPORT_AUTOWAKEUP "Autowakeup on IPC call for Hibernate" OFF)
     target_link_libraries(${TARGET} PRIVATE
         ${NAMESPACE}Hibernate::${NAMESPACE}Hibernate)
     target_compile_definitions(${TARGET} PUBLIC
          HIBERNATE_SUPPORT_ENABLED=1)
+    if(HIBERNATESUPPORT_AUTOWAKEUP)
+         target_compile_definitions(${TARGET} PUBLIC
+               HIBERNATE_SUPPORT_AUTOWAKEUP_ENABLED=1)
+     endif()
 endif()
 
 set_target_properties(${TARGET} PROPERTIES

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -648,6 +648,27 @@ namespace RPC {
                 }
             }
 
+            uint32_t Hibernate(uint32_t timeout)
+            {
+                uint32_t result = Core::ERROR_ILLEGAL_STATE;
+                if (_channel.IsValid() == true) {
+                    result = _channel->Hibernate(timeout);
+                }
+                return result;
+            }
+
+            void Wakeup()
+            {
+                if (_channel.IsValid() == true) {
+                    _channel->Wakeup();
+                }
+            }
+
+            void RegisterWakeupRequest(Core::IPCChannel::IPCWakeupRequest *request)
+            {
+                _channel->RegisterWakeupRequest(request);
+            }
+
             BEGIN_INTERFACE_MAP(RemoteConnection)
                 INTERFACE_ENTRY(IRemoteConnection)
             END_INTERFACE_MAP
@@ -1568,6 +1589,32 @@ POP_WARNING()
             _connectionMap.Destroy();
         }
         void Destroy(const uint32_t id);
+        uint32_t HibernateConnection(const uint32_t id, uint32_t timeout)
+        {
+            uint32_t result = Core::ERROR_UNAVAILABLE;
+            RemoteConnection *connection = _connectionMap.Connection(id);
+            if(connection != nullptr)
+            {
+                result = connection->Hibernate(timeout);
+            }
+            return result;
+        }
+        void WakeupConnection(const uint32_t id)
+        {
+            RemoteConnection *connection = _connectionMap.Connection(id);
+            if(connection != nullptr)
+            {
+                connection->Wakeup();
+            }
+        }
+        void RegisterWakeupRequestInConnection(const uint32_t id, Core::IPCChannel::IPCWakeupRequest *request)
+        {
+            RemoteConnection *connection = _connectionMap.Connection(id);
+            if(connection != nullptr)
+            {
+                connection->RegisterWakeupRequest(request);
+            }
+        }
 
     private:
         void Closed(const Core::ProxyType<Core::IPCChannel>& channel)


### PR DESCRIPTION
We need a way to detect if someone is trying to call API of hibernated plugin via Thunder and eventually wakeup the plugin to continue API call execution, or return error.