### PR TITLE
RDKVREFPLT-1728 [BCM] [memcr] Thunder hibernate configuration

### DIFF
--- a/Source/WPEFramework/GenericConfig.cmake
+++ b/Source/WPEFramework/GenericConfig.cmake
@@ -44,6 +44,7 @@ set(EXIT_REASONS "Failure;MemoryExceeded;WatchdogExpired" CACHE STRING "Process 
 set(ETHERNETCARD_NAME "eth0" CACHE STRING "Ethernet Card name which has to be associated for the Raw Device Id creation")
 set(GROUP "" CACHE STRING "Define which system group will be used")
 set(UMASK "" CACHE STRING "Set the permission mask for the creation of new files. e.g. 0760")
+set(LOCATOR "/tmp/memcrcom" CACHE STRING "Default Memecr Socket path")
 
 # Controller Plugin Settings.
 set(PLUGIN_CONTROLLER_UI_ENABLED "true" CACHE STRING "Enable the Controller's UI")
@@ -85,6 +86,12 @@ map_set(${CONFIG} ethernetcard ${ETHERNETCARD_NAME})
 if(COMMUNICATOR)
     map_set(${CONFIG} communicator ${COMMUNICATOR})
 endif()
+
+map()
+kv(locator ${LOCATOR})
+end()
+ans(HIBERNATE_CONFIG)
+map_append(${CONFIG} hibernate ${HIBERNATE_CONFIG})
 
 map()
     kv(priority ${PRIORITY})

--- a/Source/WPEFramework/WPEFramework.conf.in
+++ b/Source/WPEFramework/WPEFramework.conf.in
@@ -15,6 +15,9 @@ redirect = '/Service/Controller/UI'
 ethernetcard = '@ETHERNETCARD_NAME@'
 communicator = '@COMMUNICATOR@'
 
+hibernate = JSON()
+hibernate.add("locator", '@LOCATOR@')
+
 process = JSON()
 process.add("priority", '@PRIORITY@')
 process.add("policy", '@POLICY@')

--- a/Source/WPEFramework/params.config
+++ b/Source/WPEFramework/params.config
@@ -15,6 +15,7 @@ postmortempath
 redirect
 ethernetcard
 communicator
+hibernate
 exitreasons
 messaging
 plugins


### PR DESCRIPTION
Reason for change: Added the thunder hibernate configuration.
Test Procedure: build and verify.
Risks: low.
Signed-off-by: Dinesh_kumar2@comcast.com