### PR TITLE
[Actions] Adding process containers with runC backend to be built in the Linux workflow

### DIFF
--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/actions-containers
 
   ThunderInterfaces:
     needs: Thunder

--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/actions-containers
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderInterfaces:
     needs: Thunder

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -113,6 +113,8 @@ jobs:
         -DVOLATILE_PATH="tmp" \
         -DLOCALTRACER=ON \
         -DWARNING_REPORTING=ON \
+        -DPROCESSCONTAINERS=ON \
+        -DPROCESSCONTAINERS_RUNC=ON \
         ${{steps.regexthunder.outputs.first_match}}
         cmake --build ${{matrix.build_type}}/build/Thunder --target install
 

--- a/Source/extensions/processcontainers/CMakeLists.txt
+++ b/Source/extensions/processcontainers/CMakeLists.txt
@@ -24,8 +24,6 @@ option(PROCESSCONTAINERS_RUNC
         "Use RunC backend." OFF)
 option(PROCESSCONTAINERS_CRUN
         "Use CRun backend." OFF)
-option(PROCESSCONTAINERS_CLIB
-        "Use c-library backend." OFF)
 option(PROCESSCONTAINERS_DOBBY
         "Use Dobby backend." OFF)
 option(PROCESSCONTAINERS_AWC
@@ -45,8 +43,6 @@ elseif(PROCESSCONTAINERS_RUNC)
 elseif(PROCESSCONTAINERS_CRUN)
         target_sources(${TARGET} PRIVATE implementations/CRunImplementation/CRunImplementation.cpp
         )
-elseif(PROCESSCONTAINERS_CLIB)
-        target_sources(${TARGET} PRIVATE implementations/RunCImplementation/RunCImplementation.cpp)
 elseif(PROCESSCONTAINERS_DOBBY)
         target_sources(${TARGET} PRIVATE implementations/DobbyImplementation/DobbyImplementation.cpp)
 elseif(PROCESSCONTAINERS_AWC)

--- a/Source/extensions/processcontainers/implementations/RunCImplementation/RunCImplementation.cpp
+++ b/Source/extensions/processcontainers/implementations/RunCImplementation/RunCImplementation.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "RunCImplementation.h"
-#include "JSON.h"
+#include <core/JSON.h>
 #include <thread>
 
 namespace Thunder {
@@ -108,7 +108,7 @@ namespace ProcessContainers {
         return runCContainerAdministrator;
     }
 
-    IContainer* RunCContainerAdministrator::Container(const string& id, IStringIterator& searchpaths, const string& logpath, const string& configuration)
+    IContainer* RunCContainerAdministrator::Container(const string& id, IStringIterator& searchpaths, const string& logpath, const string& /* configuration */)
     {
         searchpaths.Reset(0);
         while (searchpaths.Next()) {
@@ -142,7 +142,7 @@ namespace ProcessContainers {
     {
     }
 
-    void RunCContainerAdministrator::Logging(const string& logPath, const string& loggingOptions)
+    void RunCContainerAdministrator::Logging(const string& /* logPath */, const string& /* loggingOptions */)
     {
         // Only container-scope logging
     }

--- a/Source/extensions/processcontainers/implementations/RunCImplementation/RunCImplementation.cpp
+++ b/Source/extensions/processcontainers/implementations/RunCImplementation/RunCImplementation.cpp
@@ -219,7 +219,7 @@ namespace ProcessContainers {
                 } else {
 
                     char data[1024];
-                    process.Output((uint8_t*)data, 2048);
+                    process.Output((uint8_t*)data, sizeof(data));
 
                     RunCStatus info;
                     info.FromString(string(data));


### PR DESCRIPTION
The idea was described in this Jira ticket: https://jira.rdkcentral.com/jira/browse/METROL-994
The other backends need some dependencies, so it would be more tricky to add them as well, but like we discussed - one should be enough just to make sure it compiles after any changes.

Also, the target source of `PROCESSCONTAINERS_CLIB` option was `RunCImplementation.cpp`, just like in case of the `PROCESSCONTAINERS_RUNC` option, so it seems we can remove one of them.