### PR TITLE
RDK-50885 : Crash handling [R4_2]

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "PluginServer.h"
-#include "../core/Library.h"
+#include "core/Library.h"
 #include <fstream>
 
 #ifndef __WINDOWS__
@@ -353,9 +353,7 @@ POP_WARNING()
         }
     }
 
-namespace {
-
-    void SetupCrashHandler(void)
+    static void SetupCrashHandler(void)
     {
         _adminLock.Lock();
         struct sigaction sa, current_sa;
@@ -397,7 +395,6 @@ namespace {
         }
         _adminLock.Unlock();
     }
-}
 #endif
 
     void LoadPlugins(const string& name, PluginHost::Config& config)

--- a/Source/core/Library.cpp
+++ b/Source/core/Library.cpp
@@ -28,6 +28,15 @@
 namespace WPEFramework {
 namespace Core {
 
+    Library::LibraryLoadCallback Library::g_loadCallback = nullptr;
+
+    void Library::RegisterLibraryLoadCallback(LibraryLoadCallback callback)
+    {
+       assert(callback != nullptr);
+       assert(g_loadCallback == nullptr);
+       g_loadCallback = callback;
+    }
+
     Library::Library()
         : _refCountedHandle(nullptr)
         , _error()
@@ -89,6 +98,11 @@ namespace Core {
             _refCountedHandle->_handle = handle;
             _refCountedHandle->_name = fileName;
             TRACE_L1("Loaded library: %s", fileName);
+            // Trigger the callback to notify that a library has been loaded
+            if (g_loadCallback)
+            {
+               g_loadCallback();
+            }
         } else {
 #ifdef __LINUX__
             _error = dlerror();

--- a/Source/core/Library.h
+++ b/Source/core/Library.h
@@ -42,6 +42,8 @@ namespace Core {
         typedef void (*ModuleUnload)();
 
     public:
+        typedef void (*LibraryLoadCallback)();
+        static void RegisterLibraryLoadCallback(LibraryLoadCallback callback);
         Library();
         Library(const void* functionInLibrary);
         Library(const TCHAR fileName[]);
@@ -75,6 +77,7 @@ namespace Core {
     private:
         RefCountedHandle* _refCountedHandle;
         string _error;
+        static LibraryLoadCallback g_loadCallback;
     };
 }
 } // namespace Core


### PR DESCRIPTION
Reason for change: Improve Thunder Responsiveness [Crash handling in Thunder R4]
Test Procedure: Simulate crash in rdkservices and verify the call stack actvity logs are generated
Risks: NO
Priority: P1
Signed-off-by: Sethulakshmi SK (ssk@synamedia.com)