### PR TITLE
RDK-50885 : Crash handling [R4_4]

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "PluginServer.h"
-#include "../core/Library.h"
+#include "core/Library.h"
 
 #include <fstream>
 
@@ -347,9 +347,7 @@ POP_WARNING()
         }
     }
     
-namespace {
-
-    void SetupCrashHandler(void)
+    static void SetupCrashHandler(void)
     {
         _adminLock.Lock();
         struct sigaction sa, current_sa;
@@ -391,7 +389,6 @@ namespace {
         }
         _adminLock.Unlock();
     }
-}
 #endif
 
     void LoadPlugins(const string& name, PluginHost::Config& config)

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -4445,6 +4445,12 @@ POP_WARNING()
                 std::list<Core::callstack_info> stackList;
 
                 ::DumpCallStack(static_cast<ThreadId>(index.Current().Id.Value()), stackList);
+                for(const Core::callstack_info& entry : stackList)
+                {
+                    std::string symbol = entry.function.empty() ? "Unknown symbol" : entry.function;
+                    fprintf(stderr, "[%s]:[%s]:[%d]:[%p]\n",entry.module.c_str(), symbol.c_str(),entry.line,entry.address);
+                }
+                fflush(stderr);
 
                 PostMortemData::Callstack dump;
                 dump.Id = index.Current().Id.Value();

--- a/Source/core/Library.cpp
+++ b/Source/core/Library.cpp
@@ -28,6 +28,15 @@
 namespace WPEFramework {
 namespace Core {
 
+    Library::LibraryLoadCallback Library::g_loadCallback = nullptr;
+
+    void Library::RegisterLibraryLoadCallback(LibraryLoadCallback callback)
+    {
+       assert(callback != nullptr);
+       assert(g_loadCallback == nullptr);
+       g_loadCallback = callback;
+    }
+
     Library::Library()
         : _refCountedHandle(nullptr)
         , _error()
@@ -89,7 +98,14 @@ namespace Core {
             _refCountedHandle->_handle = handle;
             _refCountedHandle->_name = fileName;
             TRACE_L1("Loaded library: %s", fileName);
-        } else {
+            
+            // Trigger the callback to notify that a library has been loaded
+            if (g_loadCallback)
+            {
+               g_loadCallback();
+            }
+
+       } else {
 #ifdef __LINUX__
             _error = dlerror();
             TRACE_L1("Failed to load library: %s, error %s", fileName, _error.c_str());

--- a/Source/core/Library.h
+++ b/Source/core/Library.h
@@ -42,6 +42,8 @@ namespace Core {
         typedef void (*ModuleUnload)();
 
     public:
+        typedef void (*LibraryLoadCallback)();
+        static void RegisterLibraryLoadCallback(LibraryLoadCallback callback);
         Library();
         Library(const void* functionInLibrary);
         Library(const TCHAR fileName[]);
@@ -75,6 +77,7 @@ namespace Core {
     private:
         RefCountedHandle* _refCountedHandle;
         string _error;
+        static LibraryLoadCallback g_loadCallback;
     };
 }
 } // namespace Core


### PR DESCRIPTION
Reason for change: Improve Thunder Responsiveness [Crash handling in Thunder R4]
Test Procedure: Simulate crash in rdkservices and verify the call stack actvity logs are generated
Risks: NO
Priority: P1
Signed-off-by: Sethulakshmi SK (ssk@synamedia.com)