### PR TITLE
RDK-50885 : Crash handling [Thunder Master]

### DIFF
--- a/Source/Thunder/PluginHost.cpp
+++ b/Source/Thunder/PluginHost.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "PluginServer.h"
+#include "core/Library.h"
 #include <fstream>
 
 #ifndef __WINDOWS__
@@ -268,8 +269,9 @@ POP_WARNING()
     Core::CriticalSection ExitHandler::_adminLock;
     
     #ifndef __WINDOWS__
-    struct sigaction _originalSegmentationHandler;
-    struct sigaction _originalAbortHandler;
+    static struct sigaction _originalSegmentationHandler;
+    static struct sigaction _originalAbortHandler;
+    static Core::CriticalSection _adminLock;
     #endif
 
     static string GetDeviceId(PluginHost::Server* dispatcher)
@@ -304,6 +306,7 @@ POP_WARNING()
 
     void ExitDaemonHandler(int signo)
     {
+        const char* segname = "";
         if (_background) {
             syslog(LOG_NOTICE, "Signal received %d. in process [%d]", signo, getpid());
         } else {
@@ -330,11 +333,12 @@ POP_WARNING()
             sigaction(SIGABRT, &_originalAbortHandler, nullptr);
 
             ExitHandler::DumpMetadata();
+            segname = (signo == SIGSEGV) ? "a segmentation fault" : (signo == SIGABRT) ? "an abort" : "";
 
             if (_background) {
-                syslog(LOG_NOTICE, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a segmentation fault. All relevant data dumped");
+                syslog(LOG_NOTICE, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to %s signal. All relevant data dumped", segname);
             } else {
-                fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a segmentation fault. All relevant data dumped\n");
+                fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to %s signal. All relevant data dumped\n", segname);
                 fflush(stderr);
             }
 
@@ -343,6 +347,49 @@ POP_WARNING()
         else if (signo == SIGUSR1) {
             ExitHandler::DumpMetadata();
         }
+    }
+	
+    static void SetupCrashHandler(void)
+    {
+        _adminLock.Lock();
+        struct sigaction sa, current_sa;
+
+        memset(&current_sa, 0, sizeof(struct sigaction));
+        sigaction(SIGSEGV, nullptr, &current_sa);
+        if (ExitDaemonHandler  != current_sa.sa_handler)
+        {
+            _originalSegmentationHandler = current_sa;
+             memset(&sa, 0, sizeof(struct sigaction));
+             sigemptyset(&sa.sa_mask);
+             sa.sa_handler = ExitDaemonHandler;
+             sa.sa_flags = 0;
+             if (_background) {
+                 syslog(LOG_NOTICE, "Registering ExitDaemonHandler for SIGSEGV");
+             } else {
+                 fprintf(stdout, "Registering ExitDaemonHandler for SIGSEGV \n");
+                 fflush(stdout);
+             }
+             sigaction(SIGSEGV, &sa, nullptr);
+        }
+
+        memset(&current_sa, 0, sizeof(struct sigaction));
+        sigaction(SIGABRT, nullptr, &current_sa);
+        if (ExitDaemonHandler  != current_sa.sa_handler)
+        {
+            _originalAbortHandler = current_sa;
+             memset(&sa, 0, sizeof(struct sigaction));
+             sigemptyset(&sa.sa_mask);
+             sa.sa_handler = ExitDaemonHandler;
+             sa.sa_flags = 0;
+             if (_background) {
+                 syslog(LOG_NOTICE, "Registering ExitDaemonHandler for SIGABRT");
+             } else {
+                 fprintf(stdout, "Registering ExitDaemonHandler for SIGABRT \n");
+                 fflush(stdout);
+             }
+             sigaction(SIGABRT, &sa, nullptr);
+        }
+        _adminLock.Unlock();
     }
 
 #endif
@@ -523,6 +570,7 @@ POP_WARNING()
 #endif
 
         ConsoleOptions options(argc, argv);
+        WPEFramework::Core::Library::RegisterLibraryLoadCallback(SetupCrashHandler);
 
         if (options.RequestUsage()) {
 #ifndef __WINDOWS__

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -4357,6 +4357,12 @@ namespace PluginHost {
                 std::list<Core::callstack_info> stackList;
 
                 ::DumpCallStack((ThreadId)index.Current().Id.Value(), stackList);
+                for(const Core::callstack_info& entry : stackList)
+                {
+                    std::string symbol = entry.function.empty() ? "Unknown symbol" : entry.function;
+                    fprintf(stderr, "[%s]:[%s]:[%d]:[%p]\n",entry.module.c_str(), symbol.c_str(),entry.line,entry.address);
+                }
+                fflush(stderr);
 
                 PostMortemData::Callstack dump;
                 dump.Id = index.Current().Id.Value();

--- a/Source/core/Library.cpp
+++ b/Source/core/Library.cpp
@@ -27,6 +27,16 @@
 
 namespace Thunder {
 namespace Core {
+	
+    Library::LibraryLoadCallback Library::g_loadCallback = nullptr;
+
+    void Library::RegisterLibraryLoadCallback(LibraryLoadCallback callback)
+    {
+       assert(callback != nullptr);
+       assert(g_loadCallback == nullptr);
+       g_loadCallback = callback;
+    }
+
 
     static const TCHAR* GlobalSymbols = "Global Symbols";
 
@@ -116,6 +126,11 @@ namespace Core {
             }
 
             TRACE_L1("Loaded library: %s", fileName);
+            // Trigger the callback to notify that a library has been loaded
+            if (g_loadCallback)
+            {
+               g_loadCallback();
+            }
         } else {
 #ifdef __LINUX__
             _error = dlerror();

--- a/Source/core/Library.h
+++ b/Source/core/Library.h
@@ -42,6 +42,8 @@ namespace Core {
         typedef void (*ModuleUnload)();
 
     public:
+        typedef void (*LibraryLoadCallback)();
+        static void RegisterLibraryLoadCallback(LibraryLoadCallback callback);
         Library();
         Library(const void* functionInLibrary);
         Library(const TCHAR fileName[]);
@@ -76,6 +78,7 @@ namespace Core {
     private:
         RefCountedHandle* _refCountedHandle;
         string _error;
+        static LibraryLoadCallback g_loadCallback;
     };
 }
 } // namespace Core


### PR DESCRIPTION
Reason for change: Improve Thunder Responsiveness [Crash handling in Thunder Master]
Test Procedure: Simulate crash in rdkservices and verify the call stack activity logs are generated
Risks: NO
Priority: P1
Signed-off-by: Sethulakshmi SK (ssk@synamedia.com)