### PR TITLE
[OOP] Move the plugin as a whole OOP.

### DIFF
--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's LICENSE file the
+ * If not stated otherwise in this file or this component's LICENSE file the 
  * following copyright and licenses apply:
  *
  * Copyright 2020 Metrological

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -280,33 +280,42 @@ namespace PluginHost {
         /* @stubgen:stub */
         virtual uint32_t Submit(const uint32_t Id, const Core::ProxyType<Core::JSON::IElement>& response) = 0;
 
-        inline void Register(RPC::IRemoteConnection::INotification* sink)
+        inline Core::hresult Register(RPC::IRemoteConnection::INotification* sink)
         {
+            Core::hresult result;
+
             ASSERT(sink != nullptr);
 
             ICOMLink* handler(QueryInterface<ICOMLink>());
 
-            // This method can only be used in the main process. Only this process, can instantiate a new process
-            ASSERT(handler != nullptr);
-
-            if (handler != nullptr) {
+            if (handler == nullptr) {
+                result = Core::ERROR_NOT_SUPPORTED;
+            }
+            else {
                 handler->Register(sink);
                 handler->Release();
+                result = Core::ERROR_NONE;
             }
+
+            return (result);
         }
-        inline void Unregister(const RPC::IRemoteConnection::INotification* sink)
+        inline Core::hresult Unregister(const RPC::IRemoteConnection::INotification* sink)
         {
+            Core::hresult result;
+
             ASSERT(sink != nullptr);
 
             ICOMLink* handler(QueryInterface<ICOMLink>());
 
-            // This method can only be used in the main process. Only this process, can instantiate a new process
-            ASSERT(handler != nullptr);
-
-            if (handler != nullptr) {
+            if (handler == nullptr) {
+                result = Core::ERROR_NOT_SUPPORTED;
+            }
+            else {
                 handler->Unregister(sink);
                 handler->Release();
             }
+
+            return (result);
         }
         inline void Register(ICOMLink::INotification* sink)
         {
@@ -364,9 +373,6 @@ namespace PluginHost {
         {
             RPC::IRemoteConnection* connection(nullptr);
             ICOMLink* handler(QueryInterface<ICOMLink>());
-
-            // This method can only be used in the main process. Only this process, can instantiate a new process
-            ASSERT(handler != nullptr);
 
             if (handler != nullptr) {
                 connection = handler->RemoteConnection(connectionId);


### PR DESCRIPTION
These tests are conducted to see how far the plugin can be run OOP even if it is not prepared for OOP (Root<> functionality not used in the plugin) or if it is used if, if the plugin configuration now configures it in process, can be run as a whole out of process.
Tested the WebServer plugin (designed for creating a part running out of process), if it can be configured to run in process and than use the Plugin OOP functionality (full plugin running OOP.
Ran into some ASSERTS that prevented the plugin from running as a whole out of process, analyzed the ASSERT and came to the conclusion that it is safe to remove the ASSERTS. This PR, removes those asserts.