### PR TITLE
[Resource Monitor] Using std::list instead of std::vector for Resources

### DIFF
--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -61,16 +61,7 @@ namespace Core {
     class ResourceMonitorType {
     private:
         using Parent = ResourceMonitorType<RESOURCE, WATCHDOG, STACK_SIZE, RESOURCE_SLOTS>;
-
-        // Using the std::vector here caused an issue on Windows as the iterator in the Worker was corrupted after
-        // a new connection was added during the worker run (accept on listen) Although this should be added to 
-        // the end of the vector/list, it did cause an issue on Windows and probbaly *not* on linux. Requires further 
-        // investigation
-        #ifdef __WINDOWS__
         using Resources = std::list<RESOURCE*>;
-        #else
-        using Resources = std::vector<RESOURCE*>;
-        #endif
 
         class MonitorWorker : public Core::Thread {
         public:


### PR DESCRIPTION
It looks like using std::vector causes an issue not only on Windows like it's been previously discovered, but also on Linux as the iterator in the Worker gets corrupted after a new connection is added during the worker run.

Like we discussed, let's for now first apply this patch, but in the meantime we will also investigate other possible solutions.