### PR TITLE
[ResourceMonitor] Using vector instead of list for Resources but making sure iterator is valid after the reallocation

### DIFF
--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -61,7 +61,7 @@ namespace Core {
     class ResourceMonitorType {
     private:
         using Parent = ResourceMonitorType<RESOURCE, WATCHDOG, STACK_SIZE, RESOURCE_SLOTS>;
-        using Resources = std::list<RESOURCE*>;
+        using Resources = std::vector<RESOURCE*>;
 
         class MonitorWorker : public Core::Thread {
         public:
@@ -459,8 +459,22 @@ POP_WARNING()
                 int fd_index = 1;
                 index = _resources.begin();
 
+                size_t capacity = _resources.capacity();
+
                 while (fd_index < filledFileDescriptors) {
                     ASSERT(index != _resources.end());
+
+                    if (capacity != _resources.capacity()) {
+                        // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
+                        index = _resources.begin();
+                        int current = fd_index;
+
+                        while ((index != _resources.end()) && (current > 1)) {
+                            index++;
+                            current--;
+                        }
+                        capacity = _resources.capacity();
+                    }
 
                     RESOURCE* entry = (*index);
 

--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -458,7 +458,6 @@ POP_WARNING()
                 // We also know that once a file descriptor is not found, we handled them all...
                 int fd_index = 1;
                 index = _resources.begin();
-
                 size_t capacity = _resources.capacity();
 
                 while (fd_index < filledFileDescriptors) {
@@ -548,10 +547,23 @@ POP_WARNING()
 
                 // Find all "pending" sockets and signal them..
                 index = _resources.begin();
+                size_t capacity = _resources.capacity();
 
                 ::WSAResetEvent(_action);
 
                 while (index != _resources.end()) {
+                    if (capacity != _resources.capacity()) {
+                        // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
+                        index = _resources.begin();
+                        int current = fd_index;
+
+                        while ((index != _resources.end()) && (current > 1)) {
+                            index++;
+                            current--;
+                        }
+                        capacity = _resources.capacity();
+                    }
+
                     RESOURCE* entry = (*index);
 
                     if (entry != nullptr) {

--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -548,6 +548,7 @@ POP_WARNING()
                 // Find all "pending" sockets and signal them..
                 index = _resources.begin();
                 size_t capacity = _resources.capacity();
+                uint8_t counter = 0;
 
                 ::WSAResetEvent(_action);
 
@@ -555,11 +556,10 @@ POP_WARNING()
                     if (capacity != _resources.capacity()) {
                         // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
                         index = _resources.begin();
-                        int current = fd_index;
 
-                        while ((index != _resources.end()) && (current > 1)) {
+                        while ((index != _resources.end()) && (counter > 0)) {
                             index++;
-                            current--;
+                            counter--;
                         }
                         capacity = _resources.capacity();
                     }
@@ -583,6 +583,7 @@ POP_WARNING()
                         Reset();
                     }
                     index++;
+                    counter++;
                 }
             } else {
                 delay = Core::infinite;


### PR DESCRIPTION
Turns out vector's index is invalidated after a reallocation due to a capacity change which can happen after e.g. a ```push_back()```. Because of that, we have to rebuild the iterator after detecting a change in capacity.

Since this does not happen very often and the capacity is doubled after each reallocation, as well as the condition is relatively simple with an inline call to vector's member, we believe it justifies the usage of vector with some extra logic, instead of simply sticking to the list.