### PR TITLE
[FLOWCONTROL] Control the flow from the jobs to the Workerpool.

### DIFF
--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -1072,6 +1072,7 @@ namespace PluginHost {
         , _security(_parent.Officer())
         , _service()
         , _requestClose(false)
+        , _jobs()
     {
         TRACE(Activity, (_T("Construct a link with ID: [%d] to [%s]"), Id(), remoteId.QualifiedName().c_str()));
     }

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -674,7 +674,6 @@ namespace PluginHost {
                 ControlData& operator=(const ControlData&) = delete;
                 ControlData(const uint32_t maxRequests)
                     : _isExtended(false)
-                    , _queued(0)
                     , _maxRequests(maxRequests)
                     , _state(0)
                     , _major(~0)
@@ -713,19 +712,6 @@ namespace PluginHost {
                 }
 
             public:
-                bool IsRequestAllowed() const {
-                    uint32_t newValue = Core::InterlockedIncrement(_queued);
-                    if (newValue > _maxRequests) {
-                        Core::InterlockedDecrement(_queued);
-                    }
-                    return (newValue <= _maxRequests);
-                }
-                void RequestHandled() const {
-                    Core::InterlockedDecrement(_queued);
-                }
-                uint32_t Requests() const {
-                    return (_queued);
-                }
                 uint32_t MaxRequests() const {
                     return (_maxRequests);
                 }
@@ -766,7 +752,6 @@ namespace PluginHost {
             private:
                 bool _isExtended;
                 uint32_t _maxRequests;
-                mutable uint32_t _queued;
                 uint8_t _state;
                 uint8_t _major;
                 uint8_t _minor;

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -47,6 +47,69 @@ namespace Core {
         typedef const IService::IMetadata* (*ModuleServiceMetadataImpl)();
         }
     }
+
+    template<typename CONTENT, typename FORWARDER> 
+    class ThrottleQueueType {
+    private:
+        using Queue = std::queue<CONTENT>;
+
+    public:
+        ThrottleQueueType(ThrottleQueueType<CONTENT, FORWARDER>&&) = delete;
+        ThrottleQueueType(const ThrottleQueueType<CONTENT, FORWARDER>&) = delete;
+        ThrottleQueueType<CONTENT, FORWARDER>& operator= (ThrottleQueueType<CONTENT, FORWARDER>&&) = delete;
+        ThrottleQueueType<CONTENT, FORWARDER>& operator= (const ThrottleQueueType<CONTENT, FORWARDER>&) = delete;
+
+        template <typename... Args>
+        ThrottleQueueType(Args&&... args)
+            : _adminLock()
+            , _forwarder(std::forward<Args>(args)...)
+            , _slots(1)
+            , _used(0)
+            , _queue() {
+        }
+        ~ThrottleQueueType() = default;
+
+    public:
+        inline void Slots(const uint32_t slots) {
+            _slots = slots;
+        }
+        inline uint32_t Slots() const {
+            return (_slots);
+        }
+        inline uint32_t Used() const {
+            return (_used);
+        }
+        inline void Push(CONTENT&& object) {
+            _adminLock.Lock();
+            if (_used < _slots) {
+                _used++;
+                _forwarder.Submit(std::move(object));
+            }
+            else {
+                _queue.emplace(object);
+            }
+            _adminLock.Unlock();
+        }
+        inline void Pop() {
+            _adminLock.Lock();
+            ASSERT(_used > 0);
+            if (_queue.empty() == false) {
+                _forwarder.Submit(std::forward<CONTENT>(_queue.front()));
+                _queue.pop();
+            }
+            else {
+                _used--;
+            }
+            _adminLock.Unlock();
+        }
+
+    private:
+        Core::CriticalSection _adminLock;
+        FORWARDER _forwarder;
+        uint32_t _slots;
+        uint32_t _used;
+        Queue _queue;
+    };
 }
 
 namespace Plugin {
@@ -320,6 +383,7 @@ namespace PluginHost {
 
         private:
             using BaseClass = PluginHost::Service;
+            using Jobs = Core::ThrottleQueueType<Core::ProxyType<Core::IDispatch>, ServiceMap&>;
             class Composit : public PluginHost::ICompositPlugin::ICallback {
             public:
                 Composit() = delete;
@@ -603,10 +667,15 @@ namespace PluginHost {
             };
             class ControlData {
             public:
+                ControlData() = delete;
+                ControlData(ControlData&&) = delete;
                 ControlData(const ControlData&) = delete;
+                ControlData& operator=(ControlData&&) = delete;
                 ControlData& operator=(const ControlData&) = delete;
-                ControlData()
+                ControlData(const uint32_t maxRequests)
                     : _isExtended(false)
+                    , _queued(0)
+                    , _maxRequests(maxRequests)
                     , _state(0)
                     , _major(~0)
                     , _minor(~0)
@@ -644,6 +713,22 @@ namespace PluginHost {
                 }
 
             public:
+                bool IsRequestAllowed() const {
+                    uint32_t newValue = Core::InterlockedIncrement(_queued);
+                    if (newValue > _maxRequests) {
+                        Core::InterlockedDecrement(_queued);
+                    }
+                    return (newValue <= _maxRequests);
+                }
+                void RequestHandled() const {
+                    Core::InterlockedDecrement(_queued);
+                }
+                uint32_t Requests() const {
+                    return (_queued);
+                }
+                uint32_t MaxRequests() const {
+                    return (_maxRequests);
+                }
                 bool IsExtended() const {
                     return (_isExtended);
                 }
@@ -680,6 +765,8 @@ namespace PluginHost {
 
             private:
                 bool _isExtended;
+                uint32_t _maxRequests;
+                mutable uint32_t _queued;
                 uint8_t _state;
                 uint8_t _major;
                 uint8_t _minor;
@@ -748,11 +835,12 @@ namespace PluginHost {
                 , _activity(0)
                 , _connection(nullptr)
                 , _lastId(0)
-                , _metadata()
+                , _metadata(plugin.MaxRequests.Value())
                 , _library()
                 , _external(PluginNodeId(server, plugin), server.ProxyStubPath(), handler)
                 , _administrator(administrator)
                 , _composit(*this)
+                , _jobs(administrator)
             {
             }
             ~Service() override
@@ -782,6 +870,9 @@ namespace PluginHost {
             }
 
         public:
+            inline void Submit(Core::ProxyType<Core::IDispatch>&& job) {
+                _jobs.Push(std::move(job));
+            }
             inline const std::vector<PluginHost::ISubSystem::subsystem>& SubSystemControl() const {
                 return (_metadata.Control());
             }
@@ -1143,8 +1234,11 @@ namespace PluginHost {
 
                 Unlock();
             }
-            bool PostMortemAllowed(PluginHost::IShell::reason why) const {
+            inline bool PostMortemAllowed(PluginHost::IShell::reason why) const {
                 return (_administrator.Configuration().PostMortemAllowed(why));
+            }
+            inline void Pop(){
+                _jobs.Pop();
             }
  
             uint32_t Submit(const uint32_t id, const Core::ProxyType<Core::JSON::IElement>& response) override;
@@ -1568,6 +1662,7 @@ namespace PluginHost {
             ExternalAccess _external;
             ServiceMap& _administrator;
             Core::SinkType<Composit> _composit;
+            Jobs _jobs;
 
             static Core::ProxyType<Web::Response> _unavailableHandler;
             static Core::ProxyType<Web::Response> _missingHandler;
@@ -1789,12 +1884,6 @@ namespace PluginHost {
 
         class ServiceMap {
         public:
-            using Plugins = std::unordered_map<string, Core::ProxyType<Service>>;
-            using Notifiers = std::vector<PluginHost::IPlugin::INotification*>;
-            using RemoteInstantiators = std::unordered_map<string, IRemoteInstantiation*>;
-            using ShellNotifiers = std::vector< Exchange::Controller::IShells::INotification*>;
-            using ChannelObservers = std::vector<IShell::IConnectionServer::INotification*>;
-
             class Iterator {
             public:
                 Iterator()
@@ -1891,6 +1980,12 @@ namespace PluginHost {
             }; 
 
         private:
+            using Plugins = std::unordered_map<string, Core::ProxyType<Service>>;
+            using Notifiers = std::vector<PluginHost::IPlugin::INotification*>;
+            using RemoteInstantiators = std::unordered_map<string, IRemoteInstantiation*>;
+            using ShellNotifiers = std::vector< Exchange::Controller::IShells::INotification*>;
+            using ChannelObservers = std::vector<IShell::IConnectionServer::INotification*>;
+
             class CommunicatorServer : public RPC::Communicator {
             private:
                 using Observers = std::vector<IShell::ICOMLink::INotification*>;
@@ -2636,6 +2731,9 @@ namespace PluginHost {
                 _adminLock.Unlock();
                 return (result);
             }
+            inline void Submit(Core::ProxyType<Core::IDispatch>&& job) {
+                _server.Submit(std::move(job));
+            }
             inline uint32_t Submit(const uint32_t id, const Core::ProxyType<Core::JSON::IElement>& response)
             {
                 Core::ProxyType<Server::Channel> entry(_server.Connection(id));
@@ -3378,9 +3476,7 @@ namespace PluginHost {
                 }
                 ~Job() override
                 {
-                    if (_service.IsValid()) {
-                        _service.Release();
-                    }
+                    ASSERT(_service.IsValid() == false);
                     _server = nullptr;
                 }
 
@@ -3428,23 +3524,47 @@ namespace PluginHost {
                 string Process(const string& message)
                 {
                     string result;
+                    ASSERT(_service.IsValid() == true);
                     REPORT_DURATION_WARNING( { result = _service->Inbound(_ID, message); }, WarningReporting::TooLongInvokeMessage, message);
                     return result;
                 }
                 Core::ProxyType<Core::JSONRPC::Message> Process(const string& token, const Core::ProxyType<Core::JSONRPC::Message>& message)
                 {
                     Core::ProxyType<Core::JSONRPC::Message> result;
+
+                    ASSERT(message.IsValid() == true);
+                    ASSERT(_service.IsValid() == true);
+
+                    message->ImplicitCallsign(_service->Callsign());
+
+                    #if THUNDER_PERFORMANCE
+                    Core::ProxyType<TrackingJSONRPC> tracking(_element);
+                    ASSERT(tracking.IsValid() == true);
+                    tracking->Dispatch();
+                    #endif
+
                     REPORT_DURATION_WARNING( { result = _service->Invoke(_ID, token, *message); }, WarningReporting::TooLongInvokeMessage, *message);
+
+                    #if THUNDER_PERFORMANCE
+                    tracking->Execution();
+                    #endif
+
                     return result;
                 }
                 Core::ProxyType<Web::Response> Process(const Core::ProxyType<Web::Request>& message)
                 {
+                    ASSERT(message.IsValid() == true);
+                    ASSERT(_service.IsValid() == true);
+
                     Core::ProxyType<Web::Response> result;
                     REPORT_DURATION_WARNING( { result = _service->Process(*message); }, WarningReporting::TooLongInvokeMessage, *message);
                     return result;
                 }
                 Core::ProxyType<Core::JSON::IElement> Process(const Core::ProxyType<Core::JSON::IElement>& message)
                 {
+                    ASSERT(message.IsValid() == true);
+                    ASSERT(_service.IsValid() == true);
+
                     Core::ProxyType<Core::JSON::IElement> result;
                     REPORT_DURATION_WARNING( { result = _service->Inbound(_ID, message); }, WarningReporting::TooLongInvokeMessage, *message);
                     return result;
@@ -3453,6 +3573,7 @@ namespace PluginHost {
                 void Submit(PACKAGE package)
                 {
                     ASSERT(_server != nullptr);
+                   
                     Core::ProxyType<Channel> channel(_server->Connection(_ID));
                     if (channel.IsValid() == true) {
                         channel->Submit(package);
@@ -3472,10 +3593,19 @@ namespace PluginHost {
                 void Completed() {
                     ASSERT(_ID != static_cast<uint32_t>(~0));
                     ASSERT(_server != nullptr);
+                    ASSERT(_service.IsValid() == true);
+
+                    // Oke, Job is completed, maybe time for a new one ?
+                    // Let the Service (aka Plugin) know a request has been handled..
+                    _service->Pop();
+
+                    // Let the channel now a request for this channel has been handled...
                     Core::ProxyType<Channel> channel(_server->Connection(_ID));
                     if (channel.IsValid() == true) {
                         channel->Pop();
                     }
+
+                    // Clear the object for re-use..
                     Clear();
                 }
             private:
@@ -3501,10 +3631,6 @@ namespace PluginHost {
                 ~WebRequestJob() override
                 {
                     ASSERT(_request.IsValid() == false);
-
-                    if (_request.IsValid()) {
-                        _request.Release();
-                    }
                 }
 
             public:
@@ -3513,27 +3639,32 @@ namespace PluginHost {
                     _missingResponse->ErrorCode = Web::STATUS_INTERNAL_SERVER_ERROR;
                     _missingResponse->Message = _T("There is no response from the requested service.");
                 }
-                void Set(const uint32_t id, Server* server, Core::ProxyType<Service>& service, Core::ProxyType<Web::Request>& request, const string& token, const bool JSONRPC)
+                Core::ProxyType<Web::Response> Set(const uint32_t id, Server* server, Core::ProxyType<Service>& service, Core::ProxyType<Web::Request>& request, const string& token, const bool JSONRPC)
                 {
-                    Job::Set(id, server, service);
+                    Core::ProxyType<Web::Response> response;
 
                     ASSERT(_request.IsValid() == false);
 
-                    _request = request;
-                    _jsonrpc = JSONRPC && (_request->HasBody() == true);
-                    _token = token;
-                }
-                void Dispatch() override
-                {
-                    ASSERT(_request.IsValid());
-                    ASSERT(Job::HasService() == true);
+                    if (JSONRPC == true) {
+                        if ((request->Verb != Request::HTTP_POST) || (request->HasBody() != true)) {
+                            response = IFactories::Instance().Response();
+                            response->ErrorCode = Web::STATUS_METHOD_NOT_ALLOWED;
+                            response->Message = _T("JSON-RPC only supported via POST request with a body");
+                        }
+                        else {
+                            Core::ProxyType<Web::JSONRPC::Body> message(request->Body<Web::JSONRPC::Body>());
 
-                    Core::ProxyType<Web::Response> response;
-
-                    if (_jsonrpc == true) {
-                        if(_request->Verb == Request::HTTP_POST) {
-                            Core::ProxyType<Web::JSONRPC::Body> message(_request->Body<Web::JSONRPC::Body>());
-                            if ( (message->Report().IsSet() == true) || (message->IsComplete() == false) ) {
+                            if (message.IsValid() == false) {
+                                response = IFactories::Instance().Response();
+                                response->ErrorCode = Web::STATUS_BAD_REQUEST;
+                                response->Message = _T("Expected a JSONRPC body recieved something else.");
+                            }
+                            else if (message->IsSet() == false) {
+                                response = IFactories::Instance().Response();
+                                response->ErrorCode = Web::STATUS_METHOD_NOT_ALLOWED;
+                                response->Message = _T("JSON-RPC only supported via POST request");
+                            }
+                            else if ((message->Report().IsSet() == true) || (message->IsComplete() == false)) {
                                 // Looks like we have a corrupted message.. Respond if posisble, with an error
                                 response = IFactories::Instance().Response();
 
@@ -3564,57 +3695,61 @@ namespace PluginHost {
                                 message->Error.SetError(Core::ERROR_PARSE_FAILURE);
                                 response->Body(Core::ProxyType<Web::IBody>(message));
                             }
-                            else {
-                                if (HasService() == true) {
-                                    message->ImplicitCallsign(GetService().Callsign());
-                                }
-
-                                if (message->IsSet()) {
-                                    Core::ProxyType<Core::JSONRPC::Message> body = Job::Process(_token, Core::ProxyType<Core::JSONRPC::Message>(message));
-
-                                    // If we have no response body, it looks like an async-call...
-                                    if (body.IsValid() == false) {
-                                        // It's a a-synchronous call if the id was set but we do not yet have a resposne.
-                                        // If the id of the originating message was not set, it is a Notification and no
-                                        // response is expected at all, just report HTTP NO_CONTENT than
-                                        if (message->Id.IsSet() == false) {
-                                            response = IFactories::Instance().Response();
-                                            response->ErrorCode = Web::STATUS_NO_CONTENT;
-                                            response->Message = _T("A JSONRPC Notification was send to the server. Processed it..");
-                                        }
-                                    }
-                                    else {
-                                        response = IFactories::Instance().Response();
-                                        response->Body(body);
-                                        if (body->Error.IsSet() == false) {
-                                            response->ErrorCode = Web::STATUS_OK;
-                                            response->Message = _T("JSONRPC executed succesfully");
-                                        }
-                                        else {
-                                            response->ErrorCode = Web::STATUS_ACCEPTED;
-                                            response->Message = _T("Failure on JSONRPC: ") + Core::NumberType<int32_t>(body->Error.Code).Text();
-                                        }
-                                    }
-
-                                    if (_request->Connection.Value() == Web::Request::CONNECTION_CLOSE) {
-                                        Job::RequestClose();
-                                    }
-                                }
-                                else {
-                                    response = IFactories::Instance().Response();
-                                    response->ErrorCode = Web::STATUS_ACCEPTED;
-                                    response->Message = _T("Failed to parse JSONRPC message");
-                                }
-                            }
-                        } else {
-                            response = IFactories::Instance().Response();
-                            response->ErrorCode = Web::STATUS_METHOD_NOT_ALLOWED;
-                            response->Message = _T("JSON-RPC only supported via POST request");
                         }
-                    } else {
+                    }
+
+                    if (response.IsValid() == false) {
+                        Job::Set(id, server, service);
+
+                        _request = request;
+                        _jsonrpc = JSONRPC;
+                        _token = token;
+                    }
+                    return (response);
+                }
+                void Dispatch() override
+                {
+                    ASSERT(_request.IsValid());
+                    ASSERT(Job::HasService() == true);
+
+                    Core::ProxyType<Web::Response> response;
+
+                    if (_jsonrpc == false) {
                         response = Job::Process(_request);
                         if (response.IsValid() == false) {
                             response = _missingResponse;
+                        }
+                    }
+                    else {
+                        Core::ProxyType<Core::JSONRPC::Message> message(_request->Body< Core::JSONRPC::Message>());
+                        Core::ProxyType<Core::JSONRPC::Message> body = Job::Process(_token, message);
+
+                        // If we have no response body, it looks like an async-call...
+                        if (body.IsValid() == false) {
+                            // It's an a-synchronous call if the id was set but we do not yet have a response.
+                            // If the id of the originating message was not set, it is a Notification and no
+                            // response is expected at all, just report HTTP NO_CONTENT than
+                            if (message->Id.IsSet() == false) {
+                                response = IFactories::Instance().Response();
+                                response->ErrorCode = Web::STATUS_NO_CONTENT;
+                                response->Message = _T("A JSONRPC Notification was send to the server. Processed it..");
+                            }
+                        }
+                        else {
+                            response = IFactories::Instance().Response();
+                            response->Body(body);
+                            if (body->Error.IsSet() == false) {
+                                response->ErrorCode = Web::STATUS_OK;
+                                response->Message = _T("JSONRPC executed succesfully");
+                            }
+                            else {
+                                response->ErrorCode = Web::STATUS_ACCEPTED;
+                                response->Message = _T("Failure on JSONRPC: ") + Core::NumberType<int32_t>(body->Error.Code).Text();
+                            }
+                        }
+
+                        if (_request->Connection.Value() == Web::Request::CONNECTION_CLOSE) {
+                            Job::RequestClose();
                         }
                     }
 
@@ -3674,40 +3809,23 @@ namespace PluginHost {
                 ~JSONElementJob() override
                 {
                     ASSERT(_element.IsValid() == false);
-
-                    if (_element.IsValid()) {
-                        _element.Release();
-                    }
                 }
 
             public:
-                void Set(const uint32_t id, Server* server, Core::ProxyType<Service>& service, Core::ProxyType<Core::JSON::IElement>& element, const string& token, const bool JSONRPC)
+                Core::ProxyType<Core::JSON::IElement> Set(const uint32_t id, Server* server, Core::ProxyType<Service>& service, Core::ProxyType<Core::JSON::IElement>& element, const string& token, const bool JSONRPC)
                 {
-                    Job::Set(id, server, service);
+                    bool isJSONRPC = JSONRPC;
+                    Core::ProxyType<Core::JSON::IElement> response;
 
                     ASSERT(_element.IsValid() == false);
 
-                    _element = element;
-                    _jsonrpc = JSONRPC;
-                    _token = token;
-                }
-                void Dispatch() override
-                {
-                    ASSERT(Job::HasService() == true);
-                    ASSERT(_element.IsValid() == true);
+                    if (isJSONRPC == true) {
+                        Core::ProxyType<Web::JSONRPC::Body> message(element);
 
-                    if (_jsonrpc == true) {
-
-#if THUNDER_PERFORMANCE
-                        Core::ProxyType<TrackingJSONRPC> tracking (_element);
-                        ASSERT (tracking.IsValid() == true);
-                        tracking->Dispatch();
-#endif
-                        Core::ProxyType<Web::JSONRPC::Body> message(_element);
-
-                        ASSERT(message.IsValid() == true);
-
-                        if (message->Report().IsSet() == true) {
+                        if (message.IsValid() == false) {
+                            isJSONRPC = false;
+                        }
+                        else if (message->Report().IsSet() == true) {
                             // If we also do not have an id, we can not return a suitable JSON message!
                             if (message->Recorded().IsSet() == false) {
                                 message->Id.Null(true);
@@ -3718,18 +3836,27 @@ namespace PluginHost {
 
                             message->Error.SetError(Core::ERROR_PARSE_FAILURE);
                             message->Error.Text = message->Report().Value().Message();
+                            response = message;
                         }
-                        else {
-                            if (HasService() == true) {
-                                message->ImplicitCallsign(GetService().Callsign());
-                            }
+                    }
 
-                            _element = Core::ProxyType<Core::JSON::IElement>(Job::Process(_token, Core::ProxyType<Core::JSONRPC::Message>(message)));
-                        }
+                    if (response.IsValid() == false) {
+                        Job::Set(id, server, service);
 
-#if THUNDER_PERFORMANCE
-                        tracking->Execution();
-#endif
+                        _element = element;
+                        _jsonrpc = isJSONRPC;
+                        _token = token;
+                    }
+
+                    return (response);
+                }
+                void Dispatch() override
+                {
+                    ASSERT(Job::HasService() == true);
+                    ASSERT(_element.IsValid() == true);
+
+                    if (_jsonrpc == true) {
+                        _element = Core::ProxyType<Core::JSON::IElement>(Job::Process(_token, Core::ProxyType<Core::JSONRPC::Message>(_element)));
                     } else {
                         _element = Job::Process(_element);
                     }
@@ -3796,8 +3923,22 @@ namespace PluginHost {
             private:
                 string _text;
             };
+            class JobForwarder {
+            public:
+                JobForwarder(JobForwarder&&) = delete;
+                JobForwarder(const JobForwarder&) = delete;
+                JobForwarder& operator=(JobForwarder&&) = delete;
+                JobForwarder& operator=(const JobForwarder&) = delete;
 
-            using Jobs = std::vector< Core::ProxyType<Core::IDispatch> >;
+                JobForwarder() = default;
+                ~JobForwarder() = default;
+
+            public:
+                inline void Submit(Core::ProxyType<Job>&& job) {
+                    job->GetService().Submit(Core::ProxyType<Core::IDispatch>(job));
+                }
+            };
+            using Jobs = Core::ThrottleQueueType<Core::ProxyType<Job>, JobForwarder>;
 
         public:
             Channel() = delete;
@@ -3868,27 +4009,11 @@ namespace PluginHost {
                     PluginHost::Channel::Submit(entry);
                 }
             }
+            inline void Pop() {
+                _jobs.Pop();
+            }
             inline void RequestClose() {
                 _requestClose = true;
-            }
-            inline void Push(Core::ProxyType<Core::IDispatch>&& job) {
-                _adminLock.Lock();
-                if (_jobs.empty()) {
-                    _parent.Submit(Core::ProxyType<Core::IDispatch>(job));
-                }
-                _jobs.emplace(_jobs.begin(), job);
-                _adminLock.Unlock();
-            }
-            inline void Pop() {
-                _adminLock.Lock();
-                ASSERT(_jobs.empty() == false);
-                if (_jobs.empty() == false) {
-                    _jobs.pop_back();
-                    if (_jobs.empty() == false) {
-                        _parent.Submit(_jobs.back());
-                    }
-                }
-                _adminLock.Unlock();
             }
 
         private:
@@ -4062,8 +4187,14 @@ namespace PluginHost {
 
                         if (job.IsValid() == true) {
                             Core::ProxyType<Web::Request> baseRequest(request);
-                            job->Set(Id(), &_parent, service, baseRequest, _security->Token(), !request->RestfulCall());
-                            Push(Core::ProxyType<Core::IDispatch>(job));
+                            Core::ProxyType<Web::Response> response = job->Set(Id(), &_parent, service, baseRequest, _security->Token(), !request->RestfulCall());
+
+                            if (response.IsValid() == false) {
+                                _jobs.Push(Core::ProxyType<Job>(job));
+                            }
+                            else {
+                                Submit(response);
+                            }
                         }
                     }
                     break;
@@ -4139,8 +4270,13 @@ namespace PluginHost {
                     ASSERT(job.IsValid() == true);
 
                     if ((_service.IsValid() == true) && (job.IsValid() == true)) {
-                        job->Set(Id(), &_parent, _service, element, _security->Token(), ((State() & Channel::JSONRPC) != 0));
-                        Push(Core::ProxyType<Core::IDispatch>(job));
+                        Core::ProxyType<Core::JSON::IElement> response = job->Set(Id(), &_parent, _service, element, _security->Token(), ((State() & Channel::JSONRPC) != 0));
+                        if (response.IsValid() == false) {
+                            _jobs.Push(Core::ProxyType<Job>(job));
+                        }
+                        else {
+                            Submit(response);
+                        }
                     }
                 }
             }
@@ -4158,7 +4294,7 @@ namespace PluginHost {
 
                 if ((_service.IsValid() == true) && (job.IsValid() == true)) {
                     job->Set(Id(), &_parent, _service, value);
-                    Push(Core::ProxyType<Core::IDispatch>(job));
+                    _jobs.Push(Core::ProxyType<Job>(job));
                 }
             }
 
@@ -4271,7 +4407,6 @@ namespace PluginHost {
             }
 
             Server& _parent;
-            Core::CriticalSection _adminLock;
             PluginHost::ISecurity* _security;
             Core::ProxyType<Service> _service;
             bool _requestClose;
@@ -4490,9 +4625,9 @@ namespace PluginHost {
         {
             return (_dispatcher);
         }
-        inline void Submit(const Core::ProxyType<Core::IDispatch>& job)
+        inline void Submit(Core::ProxyType<Core::IDispatch>&& job)
         {
-            _dispatcher.Submit(job);
+            _dispatcher.Submit(std::move(job));
         }
         inline void Schedule(const uint64_t time, const Core::ProxyType<Core::IDispatch>& job)
         {

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -352,6 +352,8 @@ typedef std::string string;
 #undef ERROR_NOT_SUPPORTED
 #undef ERROR_HIBERNATED
 #undef ERROR_INVALID_PARAMETER
+#undef InterlockedIncrement
+#undef InterlockedDecrement
 
 //#if _MSC_VER >= 1600
 //const std::basic_string<char>::size_type std::basic_string<char>::npos = (std::basic_string<char>::size_type) - 1;

--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -548,21 +548,11 @@ POP_WARNING()
                 // Find all "pending" sockets and signal them..
                 index = _resources.begin();
                 size_t capacity = _resources.capacity();
-                uint8_t counter = 0;
+                uint32_t counter = 0;
 
                 ::WSAResetEvent(_action);
 
                 while (index != _resources.end()) {
-                    if (capacity != _resources.capacity()) {
-                        // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
-                        index = _resources.begin();
-
-                        while ((index != _resources.end()) && (counter > 0)) {
-                            index++;
-                            counter--;
-                        }
-                        capacity = _resources.capacity();
-                    }
 
                     RESOURCE* entry = (*index);
 
@@ -582,8 +572,22 @@ POP_WARNING()
 
                         Reset();
                     }
-                    index++;
                     counter++;
+
+                    if (capacity == _resources.capacity()) {
+                        index++;
+                    }
+                    else {
+                        uint32_t current = counter;
+                        // vector's capacity was changed, which means its memory was reallocated and we have to adjust the index
+                        index = _resources.begin();
+
+                        while ((index != _resources.end()) && (current > 0)) {
+                            index++;
+                            current--;
+                        }
+                        capacity = _resources.capacity();
+                    }
                 }
             } else {
                 delay = Core::infinite;

--- a/Source/core/Sync.cpp
+++ b/Source/core/Sync.cpp
@@ -77,28 +77,28 @@ namespace Core {
     InterlockedIncrement(
         volatile uint32_t& a_Number)
     {
-        return (::InterlockedIncrement(&a_Number));
+        return (_InterlockedIncrement(&a_Number));
     }
 
     uint32_t
     InterlockedDecrement(
         volatile uint32_t& a_Number)
     {
-        return (::InterlockedDecrement(&a_Number));
+        return (_InterlockedDecrement(&a_Number));
     }
 
     uint32_t
     InterlockedIncrement(
         volatile int& a_Number)
     {
-        return (::InterlockedIncrement(reinterpret_cast<volatile unsigned int*>(&a_Number)));
+        return (_InterlockedIncrement(reinterpret_cast<volatile unsigned int*>(&a_Number)));
     }
 
     uint32_t
     InterlockedDecrement(
         volatile int& a_Number)
     {
-        return (::InterlockedDecrement(reinterpret_cast<volatile unsigned int*>(&a_Number)));
+        return (_InterlockedDecrement(reinterpret_cast<volatile unsigned int*>(&a_Number)));
     }
 
 #else

--- a/Source/plugins/Configuration.h
+++ b/Source/plugins/Configuration.h
@@ -252,6 +252,7 @@ namespace Plugin {
             , VolatilePathPostfix()
             , SystemRootPath()
             , StartupOrder(50)
+            , MaxRequests(~0)
             , StartMode(PluginHost::IShell::startmode::ACTIVATED)
             , Communicator()
             , Root()
@@ -270,6 +271,7 @@ namespace Plugin {
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("systemrootpath"), &SystemRootPath);
             Add(_T("startuporder"), &StartupOrder);
+            Add(_T("maxrequests"), &MaxRequests);
             Add(_T("startmode"), &StartMode);
             Add(_T("communicator"), &Communicator);
             Add(_T("root"), &Root);
@@ -290,6 +292,7 @@ namespace Plugin {
             , VolatilePathPostfix(copy.VolatilePathPostfix)
             , SystemRootPath(copy.SystemRootPath)
             , StartupOrder(copy.StartupOrder)
+            , MaxRequests(copy.MaxRequests)
             , StartMode(copy.StartMode)
             , Communicator(copy.Communicator)
             , Root(copy.Root)
@@ -308,6 +311,7 @@ namespace Plugin {
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("systemrootpath"), &SystemRootPath);
             Add(_T("startuporder"), &StartupOrder);
+            Add(_T("maxrequests"), &MaxRequests);
             Add(_T("startmode"), &StartMode);
             Add(_T("communicator"), &Communicator);
             Add(_T("root"), &Root);
@@ -328,6 +332,7 @@ namespace Plugin {
             , VolatilePathPostfix(std::move(move.VolatilePathPostfix))
             , SystemRootPath(std::move(move.SystemRootPath))
             , StartupOrder(std::move(move.StartupOrder))
+            , MaxRequests(std::move(move.MaxRequests))
             , StartMode(std::move(move.StartMode))
             , Communicator(std::move(move.Communicator))
             , Root(std::move(move.Root))
@@ -346,6 +351,7 @@ namespace Plugin {
             Add(_T("volatilepathpostfix"), &VolatilePathPostfix);
             Add(_T("systemrootpath"), &SystemRootPath);
             Add(_T("startuporder"), &StartupOrder);
+            Add(_T("maxrequests"), &MaxRequests);
             Add(_T("startmode"), &StartMode);
             Add(_T("communicator"), &Communicator);
             Add(_T("root"), &Root);
@@ -369,6 +375,7 @@ namespace Plugin {
             VolatilePathPostfix = RHS.VolatilePathPostfix;
             SystemRootPath = RHS.SystemRootPath;
             StartupOrder = RHS.StartupOrder;
+            MaxRequests = RHS.MaxRequests;
             StartMode = RHS.StartMode;
             Communicator = RHS.Communicator;
             Root = RHS.Root;
@@ -392,6 +399,7 @@ namespace Plugin {
             VolatilePathPostfix = std::move(move.VolatilePathPostfix);
             SystemRootPath = std::move(move.SystemRootPath);
             StartupOrder = std::move(move.StartupOrder);
+            MaxRequests = std::move(move.MaxRequests);
             StartMode = std::move(move.StartMode);
             Communicator = std::move(move.Communicator);
             Root = std::move(move.Root);
@@ -460,6 +468,7 @@ namespace Plugin {
         Core::JSON::String VolatilePathPostfix;
         Core::JSON::String SystemRootPath;
         Core::JSON::DecUInt32 StartupOrder;
+        Core::JSON::DecUInt32 MaxRequests;
         Core::JSON::EnumType<PluginHost::IShell::startmode> StartMode;
         Core::JSON::String Communicator;
         RootConfig Root;
@@ -474,18 +483,12 @@ namespace Plugin {
     };
 
     class EXTERNAL Setting : public Trace::Text {
-    private:
-        // -------------------------------------------------------------------
-        // This object should not be copied or assigned. Prevent the copy
-        // constructor and assignment constructor from being used. Compiler
-        // generated assignment and copy methods will be blocked by the
-        // following statments.
-        // Define them but do not implement them, compile error/link error.
-        // -------------------------------------------------------------------
-        Setting(const Setting& a_Copy) = delete;
-        Setting& operator=(const Setting& a_RHS) = delete;
-
     public:
+        Setting(Setting&&) = delete;
+        Setting(const Setting&) = delete;
+        Setting& operator=(Setting&&) = delete;
+        Setting& operator=(const Setting&) = delete;
+
         Setting(const string& key, const bool value)
             : Trace::Text()
         {
@@ -503,9 +506,7 @@ namespace Plugin {
             Core::NumberType<NUMBERTYPE, SIGNED, BASETYPE> number(value);
             Trace::Text::Set(_T("Setting: [") + key + _T("] set to value [") + number.Text() + _T("]"));
         }
-        ~Setting()
-        {
-        }
+        ~Setting() = default;
     };
 }
 }


### PR DESCRIPTION
It is observed that some plugins require a lot of chattiness to realize functionality. A good example of this is the PersitentStore plugin from the RDKServices. Also the call duration of each issued JSONRPC call is lengthy. This causes a flood of messages on the Workerpool. The lengthy call duration of each JSONRPC Request is due to the slow backend database where the key values are stored. A lightweight alternative is the Dictonary available in the ThunderNanoServices.

This mechanism introduced here is to throttle down plugins that would consume too much workerpool reources from the framework. To prevent chatty and bloated plugins, like the PersistentStore plugin, to flood the system. With this mechanism in place you can limit the number of JSONRPC requests placed in the workerpool, and issued on a channel.