### PR TITLE
[PluginHost] Return 200 instead of 202 for jsonrpc over HTTP on error

### DIFF
--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -3717,12 +3717,15 @@ namespace PluginHost {
                         else {
                             response = IFactories::Instance().Response();
                             response->Body(body);
+                            // although there is no definitife approved RFC for this consensus is also on failure we should send a status OK (200)
+                            // e.g. see here:
+                            // https://www.simple-is-better.org/json-rpc/transport_http.html
+                            // https://json-rpc.readthedocs.io/en/latest/exceptions.html
+                            response->ErrorCode = Web::STATUS_OK;
                             if (body->Error.IsSet() == false) {
-                                response->ErrorCode = Web::STATUS_OK;
                                 response->Message = _T("JSONRPC executed succesfully");
                             }
                             else {
-                                response->ErrorCode = Web::STATUS_ACCEPTED;
                                 response->Message = _T("Failure on JSONRPC: ") + Core::NumberType<int32_t>(body->Error.Code).Text();
                             }
                         }

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -3717,7 +3717,7 @@ namespace PluginHost {
                         else {
                             response = IFactories::Instance().Response();
                             response->Body(body);
-                            // although there is no definitife approved RFC for this consensus is also on failure we should return a status OK (200)
+                            // although there is no definitive approved RFC for this consensus is also on failure we should return a status OK (200)
                             // e.g. see here:
                             // https://www.simple-is-better.org/json-rpc/transport_http.html
                             // https://json-rpc.readthedocs.io/en/latest/exceptions.html

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -3717,7 +3717,7 @@ namespace PluginHost {
                         else {
                             response = IFactories::Instance().Response();
                             response->Body(body);
-                            // although there is no definitife approved RFC for this consensus is also on failure we should send a status OK (200)
+                            // although there is no definitife approved RFC for this consensus is also on failure we should return a status OK (200)
                             // e.g. see here:
                             // https://www.simple-is-better.org/json-rpc/transport_http.html
                             // https://json-rpc.readthedocs.io/en/latest/exceptions.html


### PR DESCRIPTION
METROL-1039 make jsonrpc over http return 200 on error instead of 202