### PR TITLE
[Actions] Fixing the documentation preview not displaying due to a missing PR number

### DIFF
--- a/.github/workflows/Build Documentation Preview.yml
+++ b/.github/workflows/Build Documentation Preview.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: mkdocs build
-      - run: echo "${{ github.event.number }}" >> ./site/.pr_number
+      - run: echo "${{ github.event.number }}" >> ./site/pr_number
       - name : Upload preview site artifact
         uses : actions/upload-artifact@v4
         with:
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: mkdir pr_tmp
-      - run: echo "${{ github.event.number }}" >> ./pr_tmp/.pr_number
+      - run: echo "${{ github.event.number }}" >> ./pr_tmp/pr_number
       - uses : actions/upload-artifact@v4
         with:
           name: closed_pr_number

--- a/.github/workflows/Deploy Documentation Preview.yml
+++ b/.github/workflows/Deploy Documentation Preview.yml
@@ -42,11 +42,11 @@ jobs:
       # Get PR number
       - if: ${{ env.mode == 'deploy' }}
         name: Get PR number (deploy)
-        run: echo "pr_number=$(cat ./artifacts/preview_site/.pr_number)" >> "$GITHUB_ENV"
+        run: echo "pr_number=$(cat ./artifacts/preview_site/pr_number)" >> "$GITHUB_ENV"
 
       - if: ${{ env.mode == 'clean' }}
         name: Get PR number (clean)
-        run: echo "pr_number=$(cat ./artifacts/closed_pr_number/.pr_number)" >> "$GITHUB_ENV"
+        run: echo "pr_number=$(cat ./artifacts/closed_pr_number/pr_number)" >> "$GITHUB_ENV"
 
       # Run deployment
       - if: ${{ env.mode == 'deploy' }}


### PR DESCRIPTION
There was a [change](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) not so long ago in the GitHub's action for artifacts upload, which caused all hidden files to be excluded by default. And since we were storing the PR number in a file starting with a dot, it was treated as a hidden file and thus excluded, causing the deployment workflow to fail