### PR TITLE
Use ServiceAdministrator::LoadLibrary to load any libraries

### DIFF
--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -45,9 +45,9 @@ namespace PluginHost
                 string element;
                 while (all_paths->Next(element) == true) {
                     Core::File file(element.c_str());
-                    if (file.Exists())
-                    {
-                        Core::Library resource(element.c_str());
+                    if (file.Exists()) {
+
+                        Core::Library resource = Core::ServiceAdministrator::Instance().LoadLibrary(element.c_str());
                         if (resource.IsLoaded())
                             result = Core::ServiceAdministrator::Instance().Instantiate(
                                 resource,


### PR DESCRIPTION
dlopen is essential in Thunder to manage shared libraries during plugin activation. dlopen has a process wide lock and hence must be managed as a singleton. This change helps streamline all dlopens are done through the ServiceAdministrator. 