### PR TITLE
Use ServiceAdministrator::LoadLibrary to load any libraries

### DIFF
--- a/Source/plugins/Shell.cpp
+++ b/Source/plugins/Shell.cpp
@@ -78,9 +78,9 @@ namespace PluginHost
                 std::vector<string>::const_iterator index = all_paths.begin();
                 while ((result == nullptr) && (index != all_paths.end())) {
                     Core::File file(index->c_str());
-                    if (file.Exists())
-                    {
-                        Core::Library resource(index->c_str());
+                    if (file.Exists()) {
+
+                        Core::Library resource = Core::ServiceAdministrator::Instance().LoadLibrary(index->c_str());
                         if (resource.IsLoaded())
                             result = Core::ServiceAdministrator::Instance().Instantiate(
                                 resource,


### PR DESCRIPTION
dlopen is essential in Thunder to manage shared libraries during plugin activation. dlopen has a process wide lock and hence must be managed as a singleton. This change helps streamline all dlopens are done through the ServiceAdministrator.