### PR TITLE
[SmartLinkType] Remove deadlock with recursive function

### DIFF
--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -1257,16 +1257,6 @@ namespace Thunder {
                 }
 
             public:
-                template <typename INBOUND, typename METHOD>
-                uint32_t Subscribe(const uint32_t waitTime, const string& eventName, const METHOD& method)
-                {
-                    return Subscribe<INBOUND, METHOD>(waitTime, eventName, method);
-                }
-                template <typename INBOUND, typename METHOD, typename REALOBJECT>
-                uint32_t Subscribe(const uint32_t waitTime, const string& eventName, const METHOD& method, REALOBJECT* objectPtr)
-                {
-                    return Subscribe<INBOUND, METHOD, REALOBJECT>(waitTime, eventName, method, objectPtr);
-                }
                 bool IsActivated()
                 {
                     return (_state == ACTIVATED);


### PR DESCRIPTION
The SmartLinkType class has overridden for Subscribe and Unsubscribe function but they are not calling the base class function & instead its calling itself recursively.

So the SmartLinkType instance cannot be used for subscribing a event. If you use it, it will get into recursive and leads to out-of-memory crash as it reaches the maximum recursion.

The SmartLinkType class does not have to override these two functions. So removing it.

Thanks,
Karunakaran A