### PR TITLE
 R2: Fix JSONRPC Version() bug

### DIFF
--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -205,7 +205,7 @@ namespace Core {
                         index = pos;
                     }
 
-                    if (index < pos) {
+                    if (index < pos && isdigit(designator[index])) {
                         result = static_cast<uint8_t>(atoi(designator.substr(index, pos - index).c_str()));
                     }
                 }


### PR DESCRIPTION
**Problem:**
    
When following the example code described here:
https://rdkcentral.github.io/rdkservices/#/userguide/native?id=creating-native-clients
    
If I perform the "DeviceInfo.defaultresolution" request with callsign "DeviceInfo", I'm getting an error:
"Requested version is not supported".
    
But I also get this when trying other rdkservices APIs (for example: org.rdk.Bluetooth.getApiVersionNumber)
    
**Root cause:**
    
WPEFramework sends out the request like this:
    
{"jsonrpc":"2.0","id":1,"method":"DeviceInfo.0.defaultresolution","params":{}}

    
As you can see, it added a versionnumber '0' to the method parameter.
    
**Bug:**
When the example scenario is triggered as described above, WPEFramework::Core::JSONRPC::Version() is called with "DeviceInfo." as designator.

At the if-statement with the atoi statement, index remains at pos - 1 and therefore points to the 'o' character. Because index < pos, result would be set to the result of the atoi() call.
    
But as described here: https://cplusplus.com/reference/cstdlib/atoi/#google_vignette
    
If the string starts with an invalid integral number, atoi() will return 0.
    
Because the result of WPEFramework::Core::JSONRPC::Version() is no longer 0xFF, the _versionstring field of JONRPCLink gets set to ".0". This in turn causes it to get appended to the method field of the jsonrpc request.
    
**Fix:**
    
Make sure to add an isdigit() check before trying the atoi() call. If !isdigit(), the atoi() call is now being avoided.
    
The WPEFramework::Core::JSONRPC::Version() code has been changed in the master branch. But for RDK 6.0.0, the R2 branch of Thunder is still being used by default.
    
I therefore think it's likely this fix will only be needed for R2-based versions.

