### PR TITLE
[PluginServer] Correct the order of Detach() and Notify() in Deactivate()

### DIFF
--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -581,26 +581,28 @@ namespace PluginHost {
 
                 Lock();
 
-                if (_jsonrpc != nullptr) {
-                    PluginHost::IShell::IConnectionServer::INotification* sink = nullptr;
-                    _jsonrpc->Detach(sink);
-                    if (sink != nullptr) {
-                        Unregister(sink);
-                        sink->Release();
-                    }
+                if (currentState != IShell::state::ACTIVATION) {
+                    SYSLOG(Logging::Shutdown, (_T("Deactivated plugin [%s]:[%s]"), className.c_str(), callSign.c_str()));
+
+#ifdef THUNDER_RESTFULL_API
+                    Notify(EMPTY_STRING, string(_T("{\"state\":\"deactivated\",\"reason\":\"")) + textReason.Data() + _T("\"}"));
+#endif
+                    Notify(_T("statechange"), string(_T("{\"state\":\"deactivated\",\"reason\":\"")) + textReason.Data() + _T("\"}"));
                 }
 
                 if (_external.Connector().empty() == false) {
                     _external.Close(0);
                 }
 
-                if (currentState != IShell::state::ACTIVATION) {
-                    SYSLOG(Logging::Shutdown, (_T("Deactivated plugin [%s]:[%s]"), className.c_str(), callSign.c_str()));
+                if (_jsonrpc != nullptr) {
+                    PluginHost::IShell::IConnectionServer::INotification* sink = nullptr;
 
-                    #ifdef THUNDER_RESTFULL_API
-                    Notify(EMPTY_STRING, string(_T("{\"state\":\"deactivated\",\"reason\":\"")) + textReason.Data() + _T("\"}"));
-                    #endif
-                    Notify(_T("statechange"), string(_T("{\"state\":\"deactivated\",\"reason\":\"")) + textReason.Data() + _T("\"}"));
+                    _jsonrpc->Detach(sink);
+
+                    if (sink != nullptr) {
+                        Unregister(sink);
+                        sink->Release();
+                    }
                 }
             }
 


### PR DESCRIPTION
These changes fix the problem observed by @volkan-aslan and reported in [this](https://jira.rdkcentral.com/jira/browse/METROL-1054) Jira ticket. It has also been reported by @msieben [here](https://jira.rdkcentral.com/jira/browse/METROL-1053).

With these changes, the order of `Deactivate()` is now symmetrical with `Activate()`. Before the changes, due to the `Detach()` being called prior to the last `Notify()`, there was a situation at shutdown where [this](https://github.com/rdkcentral/Thunder/blob/master/Source/Thunder/PluginServer.cpp#L1199) condition in `Server::Notification()` wasn't protecting us when `callsign` was set to `Controller`, because Controller's `callsign` had already been cleared [here](https://github.com/rdkcentral/Thunder/blob/master/Source/plugins/JSONRPC.h#L731).