### PR TITLE
[Actions] Explicitly state the Ubuntu version

### DIFF
--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Thunder:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Seems like the `ubuntu-latest` for some reason can reference to different Ubuntu versions between workflow calls from different repositories (which is not mentioned anywhere in Actions docs and seems to be a bug)... causing serious compatibility issues, e.g. with installing some packages like `GCC mutilib`