### PR TITLE
Making sure a job in ServiceMap is properly Revoked

### DIFF
--- a/Source/Thunder/Controller.h
+++ b/Source/Thunder/Controller.h
@@ -68,6 +68,10 @@ namespace Plugin {
                     _parent.SubSystems();
                 }
 
+            string JobIdentifier() const {
+                return(_T("Thunder::Plugin::Controller::Sink::Job"));
+            }
+
             private:
                 Controller& _parent;
             };

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -2449,6 +2449,10 @@ namespace PluginHost {
                     return result;
                 }
 
+                string JobIdentifier() const {
+                    return(_T("Thunder::PluginHost::Server::ServiceMap::CommunicatorServer"));
+                }
+
             private:
                 ServiceMap& _parent;
                 const string _persistentPath;
@@ -2489,7 +2493,7 @@ namespace PluginHost {
                         _parent.Evaluate();
                     }
                     string JobIdentifier() const {
-                        return(_T("PluginServer::SubSystems::Notification"));
+                        return(_T("Thunder::PluginHost::Server::ServiceMap::SubSystems::Job"));
                     }
 
                 private:
@@ -2720,6 +2724,12 @@ namespace PluginHost {
             POP_WARNING()
             ~ServiceMap()
             {
+                Core::ProxyType<Core::IDispatch> job(_job.Revoke());
+
+                if (job.IsValid()) {
+                    WorkerPool().Revoke(job);
+                    _job.Revoked();
+                }
                 // Make sure all services are deactivated before we are killed (call Destroy on this object);
                 ASSERT(_services.size() == 0);
             }
@@ -3429,6 +3439,11 @@ namespace PluginHost {
             }
 
             friend class Core::ThreadPool::JobType<ServiceMap&>;
+
+            string JobIdentifier() const {
+                return(_T("Thunder::PluginHost::Server::ServiceMap"));
+            }
+
             void Dispatch()
             {
                 _adminLock.Lock();
@@ -4525,8 +4540,9 @@ namespace PluginHost {
             friend class Core::ThreadPool::JobType<ChannelMap&>;
 
             string JobIdentifier() const {
-                return (_T("PluginServer::ChannelMap::Cleanup"));
+                return (_T("Thunder::PluginHost::Server::ChannelMap"));
             }
+
             void Dispatch()
             {
                 TRACE(Activity, (string(_T("Cleanup job running..\n"))));

--- a/Source/ThunderPlugin/Process.cpp
+++ b/Source/ThunderPlugin/Process.cpp
@@ -94,6 +94,10 @@ POP_WARNING()
                 }
             }
 
+            string JobIdentifier() const {
+                return(_T("Thunder::Process::WorkerPoolImplmenetation::Sink"));
+            }
+
         private:
             WorkerPoolImplementation& _parent;
             Core::ThreadPool::JobType<Sink&> _job;

--- a/Source/core/ThreadPool.h
+++ b/Source/core/ThreadPool.h
@@ -221,7 +221,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
 POP_WARNING()
             ~JobType()
             {
-                ASSERT (_state == IDLE);
+                static_assert(_state == IDLE, Identifier());
                 _job.CompositRelease();
             }
 

--- a/Source/core/ThreadPool.h
+++ b/Source/core/ThreadPool.h
@@ -221,7 +221,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
 POP_WARNING()
             ~JobType()
             {
-                static_assert(_state == IDLE, Identifier());
+                ASSERT (_state == IDLE);
                 _job.CompositRelease();
             }
 

--- a/Source/core/TypeTraits.h
+++ b/Source/core/TypeTraits.h
@@ -22,6 +22,7 @@
 
 #include "Portability.h"
 #include <functional>
+#include <type_traits>
 
 namespace Thunder {
 
@@ -191,14 +192,14 @@ namespace Core {
 // Args: arguments that func should have, note it will also work if overrides of Func are available on T. Note: passing Args&&... itself is also allowed here to allow for variable parameters
 #define IS_MEMBER_AVAILABLE_INHERITANCE_TREE(func, name)                                                                                             \
     template <bool, typename TT>                                                                                                                     \
-    struct name##_IsMemberAvailableCheck : public TT {                                                                                               \
-      using type = TT;                                                                                                                               \
+    struct name##_IsMemberAvailableCheck : public std::remove_reference<TT>::type {                                                                   \
+      using type = typename std::remove_reference<TT>::type;                                                                                         \
       template <typename TTT, typename... Args2>                                                                                                     \
       auto Verify() -> decltype( (TTT::func(std::declval<Args2>()...)));                                                                             \
     };                                                                                                                                               \
     template <typename TT>                                                                                                                           \
-    struct name##_IsMemberAvailableCheck<true, TT> : public TT {                                                                                     \
-      using type = const TT;                                                                                                                         \
+    struct name##_IsMemberAvailableCheck<true, TT> : public std::remove_reference<TT>::type {                                                         \
+      using type = const typename std::remove_reference<TT>::type;                                                                                   \
       template <typename TTT, typename... Args2>                                                                                                     \
       auto Verify() const -> decltype( (TTT::func(std::declval<Args2>()...)));                                                                       \
     };                                                                                                                                               \
@@ -207,12 +208,12 @@ namespace Core {
         typedef char yes[1];                                                                                                                         \
         typedef char no[2];                                                                                                                          \
         template <typename U,                                                                                                                        \
-                  typename RR = decltype(std::declval<name##_IsMemberAvailableCheck<std::is_const<U>::value, U>>().template Verify<U, Args...>()),   \
+                  typename RR = decltype(std::declval<name##_IsMemberAvailableCheck<std::is_const<typename std::remove_reference<U>::type>::value, U>>().template Verify<U, Args...>()), \
                   typename Z = typename std::enable_if<std::is_same<R, RR>::value>::type>                                                            \
         static yes& chk(int);                                                                                                                        \
         template <typename U>                                                                                                                        \
         static no& chk(...);                                                                                                                         \
-        static bool const value = sizeof(chk<T>(0)) == sizeof(yes);                                                                                  \
+        static bool const value = sizeof(chk<typename std::remove_reference<T>::type>(0)) == sizeof(yes);                                             \
     }
 
 

--- a/Source/extensions/bluetooth/audio/AVDTPSocket.h
+++ b/Source/extensions/bluetooth/audio/AVDTPSocket.h
@@ -484,6 +484,10 @@ namespace AVDTP {
         }
         ~Socket() = default;
 
+        string JobIdentifier() const {
+            return(_T("Thunder::Bluetooth::AVDTP::Socket"));
+        }
+
     public:
         uint16_t OutputMTU() const {
             return (_omtu);

--- a/Source/plugins/Types.h
+++ b/Source/plugins/Types.h
@@ -455,6 +455,10 @@ POP_WARNING()
                 _parent.Register();
             }
 
+            string JobIdentifier() const {
+                return(_T("Thunder::RPC::PluginSmartInterfaceType::RegisterJob"));
+            }
+
         private:
             PluginSmartInterfaceType& _parent;
         };


### PR DESCRIPTION
The ASSERT during shutdown was reported in [this](https://jira.rdkcentral.com/jira/browse/METROL-1080) Jira ticket.
Besides adding a revoking logic to the destructor of `ServiceMap`, there are a few more changes:

- each `JobType` in Thunder has a `JobIdentifier() `method to make it easier to debug in the future
- the `IS_MEMBER_AVAILABLE_INHERITANCE_TREE` macro now also works with reference as in many cases the `JobType` template parameter is passed as a reference