### PR TITLE
Reduce scope of adminlock to fix deadlock

### DIFF
--- a/Source/websocket/JSONRPCLink.h
+++ b/Source/websocket/JSONRPCLink.h
@@ -226,10 +226,10 @@ namespace WPEFramework {
 					_adminLock.Lock();
 					ASSERT(std::find(_observers.begin(), _observers.end(), &client) == _observers.end());
 					_observers.push_back(&client);
+					_adminLock.Unlock();
 					if (_channel.IsOpen() == true) {
 						client.Opened();
 					}
-					_adminLock.Unlock();
 				}
 				void Unregister(LinkType<INTERFACE>& client)
 				{
@@ -238,8 +238,8 @@ namespace WPEFramework {
 					if (index != _observers.end()) {
 						_observers.erase(index);
 					}
-					FactoryImpl::Instance().Revoke(&client);
 					_adminLock.Unlock();
+					FactoryImpl::Instance().Revoke(&client);
 				}
 				void Submit(const Core::ProxyType<INTERFACE>& message)
 				{


### PR DESCRIPTION
Signalling Client.Opened will trigger accessing SocketPort methods which may trigger a reentry. The adminlock is primarily to protect the list of observers. 