### PR TITLE
[json]: Improve Handling of Empty JSON Arrays in JSON::ArrayType

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -2945,6 +2945,7 @@ namespace Core {
                         if (loaded < maxLength) {
                             switch (stream[loaded]) {
                             case ']':
+                                _state |= (modus::SET);
                                 offset = FIND_MARKER;
                                 loaded++;
                                 break;

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -2511,6 +2511,7 @@ namespace Core {
         private:
             enum modus : uint8_t {
                 ERROR = 0x80,
+                SET = 0x20,
                 UNDEFINED = 0x40
             };
 
@@ -2751,13 +2752,23 @@ namespace Core {
             // IElement and IMessagePack iface:
             bool IsSet() const override
             {
-                return (Length() > 0);
+                return ( (Length() > 0) || ((_state & modus::SET) != 0) );
             }
 
             bool IsNull() const override
             {
                 //TODO: Implement null for Arrays
                 return ((_state & UNDEFINED) != 0);
+            }
+
+            void Set(const bool enabled)
+            {
+                if (enabled == true) {
+                    _state |= (modus::SET);
+                }
+                else {
+                    _state &= (~modus::SET);
+                }
             }
 
             void Clear() override


### PR DESCRIPTION
This PR refines JSON::ArrayType to ensure consistent handling of empty JSON arrays during both serialization and deserialization. The first enhancement introduces a Set method to serialize an empty array as "fieldName": [], indicating that a field is explicitly set, even if it contains no data. Additionally, this PR addresses an issue in deserialization where an empty array (someArray: []) was previously interpreted as null. With the new changes, the deserialization process now correctly identifies and preserves empty arrays, maintaining a clear distinction from null values. These improvements standardize empty array handling in JSON::ArrayType