### PR TITLE
Development/secure socket port

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -496,9 +496,15 @@ namespace Thunder {
             m_SendOffset = 0;
 
             if ((m_State.load(Core::memory_order::memory_order_relaxed) & (SocketPort::LINK | SocketPort::OPEN | SocketPort::MONITOR)) == (SocketPort::LINK | SocketPort::OPEN)) {
-                // Open up an accepted socket, but not yet added to the monitor.
-                m_State.fetch_or(SocketPort::UPDATE, Core::memory_order::memory_order_relaxed);
-                nStatus = Core::ERROR_NONE;
+
+                if (Initialize() != Core::ERROR_NONE) {
+                    nStatus = Core::ERROR_ABORTED;
+                }
+                else {
+                    // Open up an accepted socket, but not yet added to the monitor.
+                    m_State.fetch_or(SocketPort::UPDATE, Core::memory_order::memory_order_relaxed);
+                    nStatus = Core::ERROR_INPROGRESS;
+                }
             }
             else {
                 ASSERT((m_Socket == INVALID_SOCKET) && (m_State.load(Core::memory_order::memory_order_relaxed) == 0));

--- a/Source/cryptalgo/SecureSocketPort.cpp
+++ b/Source/cryptalgo/SecureSocketPort.cpp
@@ -122,27 +122,35 @@ bool SecureSocketPort::Certificate::Verify(string& errorMsg) const {
 
 
 SecureSocketPort::Handler::~Handler() {
-    if(_ssl != nullptr) {
-        SSL_free(static_cast<SSL*>(_ssl));
-    }
-    if(_context != nullptr) {
-        SSL_CTX_free(static_cast<SSL_CTX*>(_context));
-    }
+    ASSERT(IsClosed() == true);
+    Close(0);
 }
 
 uint32_t SecureSocketPort::Handler::Initialize() {
     uint32_t success = Core::ERROR_NONE;
 
-    _context = SSL_CTX_new(TLS_method());
+    if (IsOpen() == true) {
+        _context = SSL_CTX_new(TLS_server_method());
+        _handShaking = ACCEPTING;
+    }
+    else {
+        _context = SSL_CTX_new(TLS_method());
+        _handShaking = CONNECTING;
+    }
 
     _ssl = SSL_new(static_cast<SSL_CTX*>(_context));
     SSL_set_fd(static_cast<SSL*>(_ssl), static_cast<Core::IResource&>(*this).Descriptor());
-    SSL_CTX_set_options(static_cast<SSL_CTX*>(_context), SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+    SSL_CTX_set_options(static_cast<SSL_CTX*>(_context), SSL_OP_ALL | SSL_OP_NO_SSLv2);
 
     // Trust the same certificates as any other application
     if (SSL_CTX_set_default_verify_paths(static_cast<SSL_CTX*>(_context)) == 1) {
         success = Core::SocketPort::Initialize();
-    } else {
+
+        if (success == Core::ERROR_NONE) {
+            SSL_set_tlsext_host_name(static_cast<SSL*>(_ssl), RemoteNode().HostName().c_str());
+        }
+    }
+    else {
         TRACE_L1("OpenSSL failed to load certificate store");
         success = Core::ERROR_GENERAL;
     }
@@ -151,12 +159,10 @@ uint32_t SecureSocketPort::Handler::Initialize() {
 }
 
 int32_t SecureSocketPort::Handler::Read(uint8_t buffer[], const uint16_t length) const {
-    int32_t result = SSL_read(static_cast<SSL*>(_ssl), buffer, length);
-
     if (_handShaking != CONNECTED) {
         const_cast<Handler&>(*this).Update();
     }
-    return (result);
+    return (SSL_read(static_cast<SSL*>(_ssl), buffer, length));
 }
 
 int32_t SecureSocketPort::Handler::Write(const uint8_t buffer[], const uint16_t length) {
@@ -171,8 +177,14 @@ uint32_t SecureSocketPort::Handler::Open(const uint32_t waitTime) {
 uint32_t SecureSocketPort::Handler::Close(const uint32_t waitTime) {
     if (_ssl != nullptr) {
         SSL_shutdown(static_cast<SSL*>(_ssl));
+        SSL_free(static_cast<SSL*>(_ssl));
+        _ssl = nullptr;
     }
-    _handShaking = IDLE;
+    if (_context != nullptr) {
+        SSL_CTX_free(static_cast<SSL_CTX*>(_context));
+        _context = nullptr;
+    }
+
     return(Core::SocketPort::Close(waitTime));
 }
 
@@ -199,43 +211,53 @@ void SecureSocketPort::Handler::ValidateHandShake() {
             if (!validationError.empty()) {
                 TRACE_L1("OpenSSL certificate validation error for %s: %s", certificate.Subject().c_str(), validationError.c_str());
             }
-            _handShaking = IDLE;
+            _handShaking = ERROR;
             Core::SocketPort::Unlock();
             SetError();
         }
 
         X509_free(x509cert);
     } else {
-        _handShaking = IDLE;
+        _handShaking = ERROR;
         SetError();
     }
 }
 
 void SecureSocketPort::Handler::Update() {
+
     if (IsOpen() == true) {
         int result;
 
-        if (_handShaking == IDLE) {
-            SSL_set_tlsext_host_name(static_cast<SSL*>(_ssl), RemoteNode().HostName().c_str());
-            result = SSL_connect(static_cast<SSL*>(_ssl));
-            if (result == 1) {
-                ValidateHandShake();
-            }
-            else {
-                result = SSL_get_error(static_cast<SSL*>(_ssl), result);
-                if ((result == SSL_ERROR_WANT_READ) || (result == SSL_ERROR_WANT_WRITE)) {
-                    _handShaking = EXCHANGE;
-                }
+        ASSERT(_ssl != nullptr);
+
+        if (_handShaking == CONNECTING) {
+            if ((result = SSL_connect(static_cast<SSL*>(_ssl))) == 1) {
+                _handShaking = EXCHANGE;
             }
         }
-        else if (_handShaking == EXCHANGE) {
-            if (SSL_do_handshake(static_cast<SSL*>(_ssl)) == 1) {
+        else if (_handShaking == ACCEPTING) {
+            if ((result = SSL_accept(static_cast<SSL*>(_ssl))) == 1) {
+                _handShaking = EXCHANGE;
+            }
+        }
+        
+        if (_handShaking == EXCHANGE) {
+            if ((result = SSL_do_handshake(static_cast<SSL*>(_ssl))) == 1) {
                 ValidateHandShake();
+            }
+        }
+
+        if (result != 1) {
+            result = SSL_get_error(static_cast<SSL*>(_ssl), result);
+            if ((result != SSL_ERROR_WANT_READ) && (result != SSL_ERROR_WANT_WRITE)) {
+                _handShaking = ERROR;
+            }
+            else if (result == SSL_ERROR_WANT_WRITE) {
+                Trigger();
             }
         }
     }
-    else if (_ssl != nullptr) {
-        _handShaking = IDLE;
+    else {
         _parent.StateChange();
     }
 }

--- a/Source/cryptalgo/SecureSocketPort.h
+++ b/Source/cryptalgo/SecureSocketPort.h
@@ -64,9 +64,11 @@ namespace Crypto {
         class EXTERNAL Handler : public Core::SocketPort {
         private:
             enum state : uint8_t {
-                IDLE,
+                ACCEPTING,
+                CONNECTING,
                 EXCHANGE,
-                CONNECTED
+                CONNECTED,
+                ERROR
             };
 
         public:
@@ -81,7 +83,7 @@ namespace Crypto {
                 , _context(nullptr)
                 , _ssl(nullptr)
                 , _callback(nullptr)
-                , _handShaking(IDLE) {
+                , _handShaking(CONNECTING) {
             }
             ~Handler();
 
@@ -105,8 +107,6 @@ namespace Crypto {
 
             // Signal a state change, Opened, Closed or Accepted
             void StateChange() override {
-
-                ASSERT(_context != nullptr);
                 Update();
             };
             inline uint32_t Callback(IValidator* callback) {

--- a/Source/websocket/WebSocketLink.h
+++ b/Source/websocket/WebSocketLink.h
@@ -409,6 +409,10 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             }
 POP_WARNING()
             ~HandlerType() override {
+                // If this assert fires, it means the socket was not closed
+                // by the one who opened it. That is unexpected. The creater
+                // of this link, should (besides opening it) also close it.
+                ASSERT(ACTUALLINK::IsClosed() == true);
                 ACTUALLINK::Close(Core::infinite);
             }
 


### PR DESCRIPTION
Sofar Thunder supported SecureSocket clients where the intiative to enable secure connections was only based on creating a socket as a client. Tests are being written that require a secure socket server. This requires a sifferent set of calls and revealed an issue in the SocketPort.

The server accepts the incoming socket. The bug was that the incoming socket, as it is already open and connected would not call the "Initialize()" method before it was added to the Resource Monitor. This has been fixed in SocketPort.cpp.

Than this new incoming connection must follow a different path in the interaction with the
opensll library. Already added new states like, ACCEPTING and CONNECTING, in stead of EXCHANGE.

However, testing it with a server build using the Thunder functionality still fails. It is
probably due to the functionality/initialization that has to take place in the Initialize()
method of the SecureScketPort where the SSL context is being created. The differentiation
between a client socket and a server socket is already added to the Initialize, I guess it
has to be tweaked.

The client functionality of the SecureSocketPort has been tested with a server on the internet
and is still working oke, so Client functionality has not been broken with these changes!