### PR TITLE
[GCC13]  Warnings end up as errors. Fixed. (#1801)

### DIFF
--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -804,7 +804,7 @@ namespace PluginHost
             _security = nullptr;
         }
 
-        Close(0);
+        Close(Core::infinite);
     }
 
 PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)

--- a/Source/cryptalgo/SecureSocketPort.cpp
+++ b/Source/cryptalgo/SecureSocketPort.cpp
@@ -88,7 +88,7 @@ uint32_t SecureSocketPort::Handler::Close(const uint32_t waitTime) {
 
 void SecureSocketPort::Handler::Update() {
     if (IsOpen() == true) {
-        int result;
+        int result = 1;
 
         if (_handShaking == IDLE) {
             result = SSL_connect(static_cast<SSL*>(_ssl));


### PR DESCRIPTION
Cherrypicking fix for RDKTV-31859 