### PR TITLE
[Core] Ensure inline toupper/tolower

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -396,6 +396,8 @@ struct SEMAPHORE_BASIC_INFORMATION {
 #endif
 
 #ifdef __LINUX__
+#include <ctype.h> // must be first for inline ::tolower() etc.
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
Some standard lib headers (e.g. stdlib.h) end up setting __NO_CTYPE. When ctype.h is processed with this flag different code is compiled, amongst others making toupper/tolower and some isxxx() not inline but calling extern functions (which is slower). Because of include guards to ensure the inlining, ctype.h must be the first header file included for a module.