### PR TITLE
[Messaging] Make sure to not only validate MessageUnit::Client's buffer, but also its socket

### DIFF
--- a/Source/messaging/MessageDispatcher.h
+++ b/Source/messaging/MessageDispatcher.h
@@ -264,8 +264,8 @@ namespace Messaging {
             return (_dataBuffer.IsValid());
         }
 
-        void Validate() {
-            _dataBuffer.Open();
+        bool Validate() {
+            return (_dataBuffer.Open());
         }
 
         const string& MetadataName() const {

--- a/Source/messaging/MessageUnit.h
+++ b/Source/messaging/MessageUnit.h
@@ -722,6 +722,13 @@ namespace Thunder {
                     return (_channel.IsOpen());
                 }
 
+                void Validate()
+                {
+                    if ((IsValid() == false) && (MessageDataBuffer::Validate() == true)) {
+                        _channel.Open(Core::infinite);
+                    }
+                }
+
                 /**
                  * @brief Exchanges metadata with the server. Reader needs to register for notifications to recevie this message.
                  *        Passed buffer will be filled with data from the other side


### PR DESCRIPTION
That should solve the issue described in [this](https://jira.rdkcentral.com/jira/browse/METROL-1109) Jira ticket.

Some time ago, we noticed an issue with messages from WebKitBrowser Extension not working, and it was fixed with [this](https://github.com/rdkcentral/Thunder/pull/1474) PR, by making sure that the buffer is properly created even in cases when Thunder starts quicker than the other side (and the file is not ready yet).

 However, it looks like we forgot to also validate a socket, which it necessary for the controls to work alongside the messages.. 😄 