### PR TITLE
[Messaging] No message types should be missed even before the messaging is fully initialized

### DIFF
--- a/Source/core/AssertionControl.cpp
+++ b/Source/core/AssertionControl.cpp
@@ -68,7 +68,8 @@ namespace Assertion {
             _handler->AssertionEvent(metadata, message);
         }
         else {
-            fprintf(stderr, "%s%s\n", metadata.ToString(Core::Messaging::MessageInfo::abbreviate::FULL).c_str(), message.Data().c_str());
+            ::fprintf(stderr, "%s%s\n", metadata.ToString(Core::Messaging::MessageInfo::abbreviate::FULL).c_str(), message.Data().c_str());
+            ::fflush(stderr);
         }
 
         _adminLock->Unlock();

--- a/Source/core/AssertionControl.cpp
+++ b/Source/core/AssertionControl.cpp
@@ -60,9 +60,17 @@ namespace Assertion {
     void AssertionUnitProxy::AssertionEvent(Core::Messaging::IStore::Assert& metadata, const Core::Messaging::TextMessage& message)
     {
         _adminLock->Lock();
+
+        metadata.TimeStamp(Thunder::Core::Time::Now().Ticks());
+
+        // print the ASSERT to stderr if handler is not set, possibly due to the messaging engine not being fully initialized yet
         if (_handler != nullptr) {
             _handler->AssertionEvent(metadata, message);
         }
+        else {
+            fprintf(stderr, "%s%s\n", metadata.ToString(Core::Messaging::MessageInfo::abbreviate::FULL).c_str(), message.Data().c_str());
+        }
+
         _adminLock->Unlock();
     }
 

--- a/Source/core/AssertionControl.cpp
+++ b/Source/core/AssertionControl.cpp
@@ -69,7 +69,9 @@ namespace Assertion {
             _adminLock->Unlock();
         }
         else {
-            fprintf(stderr, "%s%s\n", metadata.ToString(Core::Messaging::MessageInfo::abbreviate::FULL).c_str(), message.Data().c_str());
+            _adminLock->Unlock();
+            ::fprintf(stderr, "%s%s\n", metadata.ToString(Core::Messaging::MessageInfo::abbreviate::FULL).c_str(), message.Data().c_str());
+            ::fflush(stderr);
         }
     }
 

--- a/Source/core/AssertionControl.cpp
+++ b/Source/core/AssertionControl.cpp
@@ -66,12 +66,12 @@ namespace Assertion {
         // print the ASSERT to stderr if handler is not set, possibly due to the messaging engine not being fully initialized yet
         if (_handler != nullptr) {
             _handler->AssertionEvent(metadata, message);
+            _adminLock->Unlock();
         }
         else {
+            _adminLock->Unlock();
             fprintf(stderr, "%s%s\n", metadata.ToString(Core::Messaging::MessageInfo::abbreviate::FULL).c_str(), message.Data().c_str());
         }
-
-        _adminLock->Unlock();
     }
 
     void AssertionUnitProxy::Handle(IAssertionUnit* handler)

--- a/Source/messaging/AssertionUnit.cpp
+++ b/Source/messaging/AssertionUnit.cpp
@@ -39,7 +39,6 @@ namespace Assertion {
 
     void AssertionUnit::AssertionEvent(Core::Messaging::IStore::Assert& metadata, const Core::Messaging::TextMessage& message)
     {
-        metadata.TimeStamp(Thunder::Core::Time::Now().Ticks());
         Thunder::Messaging::MessageUnit::Instance().Push(metadata, &message);
     }
 }

--- a/Source/messaging/MessageUnit.cpp
+++ b/Source/messaging/MessageUnit.cpp
@@ -331,7 +331,7 @@ namespace Thunder {
         {
             //logging messages can happen in Core, meaning, otherside plugin can be not started yet
             //those should be just printed
-            if (_settings.IsDirect() == true) {
+            if ((_settings.IsDirect() == true) || (_dispatcher == nullptr)) {
                 _direct.Output(messageInfo, message);
             } else if (_dispatcher != nullptr) {
                 uint8_t serializationBuffer[TempDataBufferSize];


### PR DESCRIPTION
Question: do we also want to make sure the same applies to `WarningReporting`, or by design it should not be used prior to the `messaging engine` being up and running (in [this](https://github.com/rdkcentral/Thunder/blob/master/Source/Thunder/PluginHost.cpp#L649) line of `main()` - do not confuse with the `MessageControl plugin`, as it can start way later and no messages should ever be lost, since they will be waiting in the buffer)?