### PR TITLE
[SINGLETON] Add a UniqueType, whihc is a ref counted singleton.

### DIFF
--- a/Source/extensions/privilegedrequest/example/main.cpp
+++ b/Source/extensions/privilegedrequest/example/main.cpp
@@ -100,10 +100,10 @@ private:
     public:
         void Request(const uint32_t id, Container& descriptors) override {
             _parent.Request(id, descriptors);
-            printf("Request descriptors for [%d]: Amount: [%d]\n", id, descriptors.size());
+            printf("Request descriptors for [%d]: Amount: [%d]\n", id, static_cast<uint32_t>(descriptors.size()));
         }
         void Offer(const uint32_t id, Container&& descriptors) override {
-            printf("Offered descriptors for [%d]: Amount: [%d]\n", id, descriptors.size());
+            printf("Offered descriptors for [%d]: Amount: [%d]\n", id, static_cast<uint32_t>(descriptors.size()));
             _parent.Offer(id, std::move(descriptors));
         }
 
@@ -215,7 +215,7 @@ int main(int argc, char** argv)
 
                     channel.Request(1000, identifier, id, fds);
 
-                    printf ("Received: %d descriptors.\n", fds.size());
+                    printf ("Received: %d descriptors.\n", static_cast<uint32_t>(fds.size()));
 
                     for (const auto& fd : fds) {
                         if (fd > 0) {
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
 
                     uint32_t result = channel.Offer(1000, identifier, id, fds);
 
-                    printf ("Offer: %d descriptors, resulted in %d.\n", fds.size(), result);
+                    printf ("Offer: %d descriptors, resulted in %d.\n", static_cast<uint32_t>(fds.size()), result);
 
                     break;
                 }


### PR DESCRIPTION
If the lifetme of singleton should be limited by its lifetime, there is a new template in town that will generate a singleton *only* if there is a user for it. If there is no user, it will be destructed and recreated if it is needed later in time.

Maybe we could call this a ref counted singleton! Use case is the Backend to render surfaces (in the compositor). As soon as there is a client, each client requires a Backend. The backend must be a singleton over all existing clients but once there is no client anymore, the backend should be destructed as well. The template in this PR relaizes that functionality.