### PR TITLE
[WebSocket] Add a new warning reporting category and use it for WebSocket

### DIFF
--- a/Source/core/WarningReportingCategories.h
+++ b/Source/core/WarningReportingCategories.h
@@ -254,5 +254,33 @@ namespace WarningReporting {
         static constexpr uint32_t DefaultReportBound = { 15000 };
     };
 
+    class EXTERNAL SocketOperationTooLong {
+        public:
+            SocketOperationTooLong(const SocketOperationTooLong&) = delete;
+            SocketOperationTooLong& operator=(const SocketOperationTooLong&) = delete;
+            SocketOperationTooLong() = default;
+            ~SocketOperationTooLong() = default;
+
+            // Nothing to serialize/deserialize here
+            uint16_t Serialize(uint8_t[], const uint16_t) const
+            {
+                return 0;
+            }
+
+            uint16_t Deserialize(const uint8_t[], const uint16_t)
+            {
+                return 0;
+            }
+
+            void ToString(string& visitor, const int64_t actualValue, const int64_t maxValue) const
+            {
+                visitor = (_T("Socket operation took too long"));
+                visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
+            };
+
+            static constexpr uint32_t DefaultWarningBound = { 1 };
+            static constexpr uint32_t DefaultReportBound = { 1 };
+        };
+
 }
 }

--- a/Source/core/WarningReportingCategories.h
+++ b/Source/core/WarningReportingCategories.h
@@ -278,8 +278,8 @@ namespace WarningReporting {
                 visitor += Core::Format(_T(", value %" PRId64 " [ms], max allowed %" PRId64 " [ms]"), actualValue, maxValue);
             };
 
-            static constexpr uint32_t DefaultWarningBound = { 1 };
-            static constexpr uint32_t DefaultReportBound = { 1 };
+            static constexpr uint32_t DefaultWarningBound = { 1000 };
+            static constexpr uint32_t DefaultReportBound = { 1000 };
         };
 
 }

--- a/Source/websocket/WebSocketLink.h
+++ b/Source/websocket/WebSocketLink.h
@@ -1088,13 +1088,19 @@ POP_WARNING()
         }
         uint32_t Open(const uint32_t waitTime)
         {
-            _channel.Open(0);
+            uint32_t result;
 
-            return WaitForLink(waitTime);
+            REPORT_DURATION_WARNING( { _channel.Open(0); result = WaitForLink(waitTime); }, WarningReporting::SocketOperationTooLong)
+
+            return (result);
         }
         uint32_t Close(const uint32_t waitTime)
         {
-            return (_channel.Close(waitTime));
+            uint32_t result;
+
+            REPORT_DURATION_WARNING( { result = _channel.Close(waitTime); }, WarningReporting::SocketOperationTooLong)
+
+            return (result);
         }
         void Ping()
         {


### PR DESCRIPTION
The issue was raised in [this](https://jira.rdkcentral.com/jira/browse/METROL-828) Jira ticket.

So far, I added the warning reporting to the Open and Close methods of `WebSocketLinkType`, which are the ones firing multiple times during the startup as well as when reloading the ThunderUI.

It usually takes just about 0.01 ms to Open and even less time to Close when done locally, but it can be much longer in a real use case, so what exactly would we consider "too long"?