### PR TITLE
[JSONRPC] Facilitate status-listener in lookup objects

### DIFF
--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -649,13 +649,13 @@ namespace PluginHost {
             if (method.empty() == false) {
 
                 string callsign;
-                string ;
+                string prefix;
                 string instanceId;
                 string methodName;
 
-                Core::JSONRPC::Message::Split(method, &callsign, nullptr, &, &instanceId, &methodName, nullptr);
+                Core::JSONRPC::Message::Split(method, &callsign, nullptr, &prefix, &instanceId, &methodName, nullptr);
 
-                const string realMethod = Core::JSONRPC::Message::Join(, methodName);
+                const string realMethod = Core::JSONRPC::Message::Join(prefix, methodName);
 
                 ASSERT((callsign.empty() == true) || (callsign == _callsign));
 
@@ -691,7 +691,7 @@ namespace PluginHost {
                     else if (methodName == _T("register")) {
                         Registration info;  info.FromString(parameters);
 
-                        result = Subscribe(channelId, Core::JSONRPC::Message::Join(, instanceId, info.Event.Value()), info.Id.Value());
+                        result = Subscribe(channelId, Core::JSONRPC::Message::Join(prefix, instanceId, info.Event.Value()), info.Id.Value());
                         if (result == Core::ERROR_NONE) {
                             response = _T("0");
                         }
@@ -702,7 +702,7 @@ namespace PluginHost {
                     else if (methodName == _T("unregister")) {
                         Registration info;  info.FromString(parameters);
 
-                        result = Unsubscribe(channelId, Core::JSONRPC::Message::Join(, instanceId, info.Event.Value()), info.Id.Value());
+                        result = Unsubscribe(channelId, Core::JSONRPC::Message::Join(prefix, instanceId, info.Event.Value()), info.Id.Value());
                         if (result == Core::ERROR_NONE) {
                             response = _T("0");
                         }
@@ -1026,7 +1026,7 @@ namespace PluginHost {
 
             ASSERT(_observers.find(event) == _observers.end());
 
-            // Expect event (or prefix+event) without instance id
+            // Expect event (or prefix+event) without instance id.
             _observers[event] = method;
 
             _adminLock.Unlock();

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -649,13 +649,13 @@ namespace PluginHost {
             if (method.empty() == false) {
 
                 string callsign;
-                string prefix;
+                string ;
                 string instanceId;
                 string methodName;
 
-                Core::JSONRPC::Message::Split(method, &callsign, nullptr, &prefix, &instanceId, &methodName, nullptr);
+                Core::JSONRPC::Message::Split(method, &callsign, nullptr, &, &instanceId, &methodName, nullptr);
 
-                const string realMethod = Core::JSONRPC::Message::Join(prefix, methodName);
+                const string realMethod = Core::JSONRPC::Message::Join(, methodName);
 
                 ASSERT((callsign.empty() == true) || (callsign == _callsign));
 
@@ -691,7 +691,7 @@ namespace PluginHost {
                     else if (methodName == _T("register")) {
                         Registration info;  info.FromString(parameters);
 
-                        result = Subscribe(channelId, Core::JSONRPC::Message::Join(prefix, instanceId, info.Event.Value()), info.Id.Value());
+                        result = Subscribe(channelId, Core::JSONRPC::Message::Join(, instanceId, info.Event.Value()), info.Id.Value());
                         if (result == Core::ERROR_NONE) {
                             response = _T("0");
                         }
@@ -702,7 +702,7 @@ namespace PluginHost {
                     else if (methodName == _T("unregister")) {
                         Registration info;  info.FromString(parameters);
 
-                        result = Unsubscribe(channelId, Core::JSONRPC::Message::Join(prefix, instanceId, info.Event.Value()), info.Id.Value());
+                        result = Unsubscribe(channelId, Core::JSONRPC::Message::Join(, instanceId, info.Event.Value()), info.Id.Value());
                         if (result == Core::ERROR_NONE) {
                             response = _T("0");
                         }
@@ -1026,7 +1026,7 @@ namespace PluginHost {
 
             ASSERT(_observers.find(event) == _observers.end());
 
-            // Expect event (or prefix+event) without instance id.
+            // Expect event (or prefix+event) without instance id
             _observers[event] = method;
 
             _adminLock.Unlock();

--- a/Tests/unit/core/test_rpc.cpp
+++ b/Tests/unit/core/test_rpc.cpp
@@ -156,7 +156,7 @@ namespace Exchange {
 
         uint32_t GetValue() override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(0));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(static_cast<const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(0));
 
             // invoke the method handler
             uint32_t output{};
@@ -171,7 +171,7 @@ namespace Exchange {
 
         void Add(uint32_t param0) override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(1));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(static_cast<const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(1));
 
             // write parameters
             ::Thunder::RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
@@ -183,7 +183,7 @@ namespace Exchange {
 
         uint32_t GetPid() override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(2));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(static_cast<const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(2));
 
             // invoke the method handler
             uint32_t output{};

--- a/Tests/unit/core/test_rpc.cpp
+++ b/Tests/unit/core/test_rpc.cpp
@@ -156,7 +156,7 @@ namespace Exchange {
 
         uint32_t GetValue() override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(:const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(0));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(0));
 
             // invoke the method handler
             uint32_t output{};
@@ -171,7 +171,7 @@ namespace Exchange {
 
         void Add(uint32_t param0) override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(:const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(1));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(1));
 
             // write parameters
             ::Thunder::RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
@@ -183,7 +183,7 @@ namespace Exchange {
 
         uint32_t GetPid() override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(:const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(2));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(2));
 
             // invoke the method handler
             uint32_t output{};

--- a/Tests/unit/core/test_rpc.cpp
+++ b/Tests/unit/core/test_rpc.cpp
@@ -156,7 +156,7 @@ namespace Exchange {
 
         uint32_t GetValue() override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::BaseClass::Message(0));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(:const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(0));
 
             // invoke the method handler
             uint32_t output{};
@@ -171,7 +171,7 @@ namespace Exchange {
 
         void Add(uint32_t param0) override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::BaseClass::Message(1));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(:const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(1));
 
             // write parameters
             ::Thunder::RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
@@ -183,7 +183,7 @@ namespace Exchange {
 
         uint32_t GetPid() override
         {
-            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::BaseClass::Message(2));
+            ::Thunder::ProxyStub::UnknownProxyType<Thunder::Tests::Core::Exchange::IAdder>::IPCMessage newMessage(:const ::Thunder::ProxyStub::UnknownProxy&>(*this).Message(2));
 
             // invoke the method handler
             uint32_t output{};


### PR DESCRIPTION
Status-listener tech also needs to carry channel and instance ids for the glue code to locate the object to call the (un)registration events for.

[DependsOn=ThunderTools:development/statuslistener-in-lookup]