### PR TITLE
[com] Fix DefaultInvokeServer for Windows (and SingletonProxyType improvements)

### DIFF
--- a/Source/com/ConnectorType.cpp
+++ b/Source/com/ConnectorType.cpp
@@ -24,7 +24,7 @@ namespace RPC {
 
 Core::ProxyType<RPC::IIPCServer> DefaultInvokeServer()
 {
-        class Engine : public RPC::InvokeServerType<1, 0, 8> {
+    class Engine : public RPC::InvokeServerType<1, 0, 8> {
     public:
         Engine() = default;
         ~Engine() override = default;

--- a/Source/com/ConnectorType.cpp
+++ b/Source/com/ConnectorType.cpp
@@ -24,7 +24,7 @@ namespace RPC {
 
 Core::ProxyType<RPC::IIPCServer> DefaultInvokeServer()
 {
-    class Engine : public RPC::InvokeServerType<1, 0, 8> {
+        class Engine : public RPC::InvokeServerType<1, 0, 8> {
     public:
         Engine() = default;
         ~Engine() override = default;
@@ -37,8 +37,10 @@ Core::ProxyType<RPC::IIPCServer> DefaultInvokeServer()
             RPC::InvokeServerType<1, 0, 8>::Stop();
         }
     };
-    static Core::ProxyType<Engine> engine = Core::ProxyType<Engine>::Create();
-    return Core::ProxyType<RPC::IIPCServer>(engine);
+
+    static Core::ProxyType<Engine>& instance = Core::SingletonProxyType<Engine>::Instance();
+
+    return Core::ProxyType<RPC::IIPCServer>(instance);
 }
 
 Core::ProxyType<RPC::IIPCServer> WorkerPoolInvokeServer()

--- a/Source/core/Singleton.h
+++ b/Source/core/Singleton.h
@@ -225,17 +225,21 @@ namespace Core {
             : _wrapped(ProxyType<PROXYTYPE>::Create(std::forward<Args>(args)...))
         {
         }
+        ~SingletonProxyType()
+        {
+            ASSERT(ProxyType<PROXYTYPE>::LastRefAccessor::LastRef(_wrapped) == true);
+        }
 
     public:
         SingletonProxyType(const SingletonProxyType<PROXYTYPE>&) = delete;
         SingletonProxyType& operator=(const SingletonProxyType<PROXYTYPE>&) = delete;
 
-        static ProxyType<PROXYTYPE> Instance()
+        static ProxyType<PROXYTYPE>& Instance()
         {
             return (SingletonType<SingletonProxyType<PROXYTYPE>>::Instance()._wrapped);
         }
         template <typename... Args>
-        DEPRECATED static ProxyType<PROXYTYPE> Instance(Args&&... args)
+        DEPRECATED static ProxyType<PROXYTYPE>& Instance(Args&&... args)
         {
             return (SingletonType<SingletonProxyType<PROXYTYPE>>::Instance(std::forward<Args>(args)...)._wrapped);
         }


### PR DESCRIPTION
- DefaultInvokeServer is no longer kept in static. Although it did work for Linux this does not work for OS'es where the worker threads are killed before static deinitialization (the DefaultInvoke server holds  minions and therefore tries to stop them when destroyed which does not work on an OS where the threads where destroyed before the static de-init is executed if the DefaultInvokeServer itself is destroyed during static dei-nit).
- Improvement to SingletonProxyType
  - Assert to check if when disposing it has the last reference
  - Make it possible to store the instance result in a static for performance reasons