### PR TITLE
[com] Make ConnectorType channel operations timeout configurable

### DIFF
--- a/Source/com/ConnectorType.h
+++ b/Source/com/ConnectorType.h
@@ -100,15 +100,15 @@ namespace RPC {
         public:
             uint32_t Initialize()
             {
-                return (CommunicatorClient::Open(Core::infinite));
+                return (CommunicatorClient::Open(_parent._channelWaitTime));
             }
             void Deintialize()
             {
-                CommunicatorClient::Close(Core::infinite);
+                CommunicatorClient::Close(_parent._channelWaitTime);
             }
             void Unlink()
             {
-                CommunicatorClient::Close(Core::infinite);
+                CommunicatorClient::Close(_parent._channelWaitTime);
             }
             void StateChange() override {
                 CommunicatorClient::StateChange();
@@ -123,9 +123,12 @@ namespace RPC {
         ConnectorType(ConnectorType<ENGINE>&&) = delete;
         ConnectorType(const ConnectorType<ENGINE>&) = delete;
         ConnectorType<ENGINE>& operator=(const ConnectorType<ENGINE>&) = delete;
+        ConnectorType<ENGINE>& operator=(ConnectorType<ENGINE>&&) = delete;
 
-        ConnectorType()
-            : _comChannels() {
+        explicit ConnectorType(const uint32_t channelWaitTime = Core::infinite)
+            : _comChannels()
+            , _channelWaitTime(channelWaitTime)
+        {
         }
         virtual ~ConnectorType() = default;
 
@@ -155,6 +158,7 @@ namespace RPC {
 
     private:
         Core::ProxyMapType<Core::NodeId, Channel> _comChannels;
+        const uint32_t _channelWaitTime; // const to make sure it threadsafe to access
     };
 
 } // namespace RPC

--- a/Source/plugins/Types.h
+++ b/Source/plugins/Types.h
@@ -279,9 +279,9 @@ namespace RPC {
         SmartInterfaceType<INTERFACE, ENGINE>& operator=(SmartInterfaceType<INTERFACE, ENGINE>&&) = delete;
 
         PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
-        SmartInterfaceType()
+        explicit SmartInterfaceType(const uint32_t channelWaitTime = Core::infinite)
             : _controller(nullptr)
-            , _administrator()
+            , _administrator(channelWaitTime)
             , _monitor(*this)
             , _connectionId(~0)
         {
@@ -293,7 +293,8 @@ POP_WARNING()
         }
 
     public:
-        uint32_t ConnectionId() const {
+        DEPRECATED uint32_t ConnectionId() const
+        {
             return (_connectionId);
         }
         bool IsOperational() const
@@ -557,9 +558,9 @@ POP_WARNING()
         SmartControllerInterfaceType(const SmartControllerInterfaceType<INTERFACE, ENGINE>&) = delete;
         SmartControllerInterfaceType<INTERFACE, ENGINE>& operator=(const SmartControllerInterfaceType<INTERFACE, ENGINE>&) = delete;
 
-        SmartControllerInterfaceType()
+        explicit SmartControllerInterfaceType(const uint32_t channelWaitTime = Core::infinite)
             : _controller(nullptr)
-            , _administrator()
+            , _administrator(channelWaitTime)
             , _connectionId(~0)
         {
         }
@@ -570,7 +571,8 @@ POP_WARNING()
         }
 
     public:
-        uint32_t ConnectionId() const {
+        DEPRECATED uint32_t ConnectionId() const
+        {
             return (_connectionId);
         }
         bool IsOperational() const


### PR DESCRIPTION
- make it possible to specify a timeout for the ConnectorType channel operations
- make the SmartInterfaceTypes ConnectionID deprecated