### PR TITLE
[core] Fix CoreErrorToString For ComError

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -1019,7 +1019,7 @@ namespace Core {
 
     inline const TCHAR* ErrorToString(uint32_t code)
     {
-        return _bogus_ErrorToString<>(code);
+        return _bogus_ErrorToString<>(code & (~COM_ERROR));
     }
 
     #undef ERROR_CODE


### PR DESCRIPTION
Make CoreErrorToString also work when the error has the COMERROR bit set