### PR TITLE
[core] make it more clear ErrorToString now handles hresult correctly

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -1017,7 +1017,7 @@ namespace Core {
         return (code == 0? _Err2Str<0u>() : _Err2Str<~0u>());
     };
 
-    inline const TCHAR* ErrorToString(uint32_t code)
+    inline const TCHAR* ErrorToString(Core::hresult code)
     {
         return _bogus_ErrorToString<>(code & (~COM_ERROR));
     }


### PR DESCRIPTION
BTW explicitly did it only for ErrorToString and not to the _bogus_ErrorToString to indicate there you can potentially have the COMERROR bit set and or the ones with unint32_t is should have been removed