### PR TITLE
[JSONRPC] Unify automatic and custom lookup code

### DIFF
--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -1507,6 +1507,7 @@ namespace PluginHost {
             JSONRPCSupportsObjectLookup::Clear();
 
             for (auto& entry : _interfaces) {
+                DEBUG_VARIABLE(entry);
                 ASSERT(entry.second.empty() == true);
             }
 

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -1414,6 +1414,7 @@ namespace PluginHost {
             : JSONRPCSupportsObjectLookup()
             , _lock()
             , _interfaces()
+            , _callback()
             , _nextId(1)
         {
         }
@@ -1421,6 +1422,7 @@ namespace PluginHost {
             : JSONRPCSupportsObjectLookup(validation)
             , _lock()
             , _interfaces()
+            , _callback()
             , _nextId(1)
         {
         }
@@ -1428,6 +1430,7 @@ namespace PluginHost {
             : JSONRPCSupportsObjectLookup(versions)
             , _lock()
             , _interfaces()
+            , _callback()
             , _nextId(1)
         {
         }
@@ -1435,6 +1438,7 @@ namespace PluginHost {
             : JSONRPCSupportsObjectLookup(versions, validation)
             , _lock()
             , _interfaces()
+            , _callback()
             , _nextId(1)
         {
         }


### PR DESCRIPTION
AutoObjectLookup is now a special case of ObjectLookup. This is more flexible as almost all implementation code is in C++. Also simplifies tools (same code for auto and custom lookup) and client code (no need for client to cater for storage space for lookup tables).