### PR TITLE
[Core] prevent threadpool job from allowing to be (partially) moved

### DIFF
--- a/Source/core/ThreadPool.h
+++ b/Source/core/ThreadPool.h
@@ -207,10 +207,13 @@ namespace Core {
         public:
             JobType(const JobType<IMPLEMENTATION>& copy) = delete;
             JobType<IMPLEMENTATION>& operator=(const JobType<IMPLEMENTATION>& RHS) = delete;
+            // deleting the move operators here is important as the varargs c'tor icw the casting operator allowed it to behave as a move operator
+            JobType(JobType<IMPLEMENTATION>&&) = delete;
+            JobType<IMPLEMENTATION>& operator=(JobType<IMPLEMENTATION>&&) = delete;
 
-PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
+            PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             template <typename... Args>
-            JobType(Args&&... args)
+            explicit JobType(Args&&... args)
                 : _implementation(args...)
                 , _state(IDLE)
                 , _job(*this)

--- a/Source/core/WorkerPool.h
+++ b/Source/core/WorkerPool.h
@@ -35,9 +35,11 @@ namespace Core {
         public:
             JobType(const JobType<IMPLEMENTATION>&) = delete;
             JobType<IMPLEMENTATION>& operator=(const JobType<IMPLEMENTATION>&) = delete;
+            JobType(JobType<IMPLEMENTATION>&&) = delete;
+            JobType<IMPLEMENTATION>& operator=(JobType<IMPLEMENTATION>&&) = delete;
 
             template <typename... Args>
-            JobType(Args&&... args)
+            explicit JobType(Args&&... args)
                 : ThreadPool::JobType<IMPLEMENTATION>(std::forward<Args>(args)...)
             {
             }


### PR DESCRIPTION
Due to the ThreadPool jobs var args constructor and casting operators and not explicitly deleting the move constructor it would allow it to be used in moving only leading to a partial copy (so the code abusing this looked correct but only got a partial move where it probably expected a full move).
By now deleting the move c'tor and move operator this will no longer compile.
For details see this example code which shows what was happening: https://onlinegdb.com/Jpke3HW9o