### PR TITLE
Potential fix for code scanning alert no. 22: Unsigned difference expression compared to zero

### DIFF
--- a/Source/websocket/WebRequest.h
+++ b/Source/websocket/WebRequest.h
@@ -698,7 +698,7 @@ POP_WARNING()
             string strValue = Core::EnumerateType<SCANVALUE>(value).Data();
             do {
                 end = buffer.find_first_of(DELIMETERS, start);
-                if (end - start > 0) {
+                if (end > start) {
                     string word = string(buffer, start, end - start);
                     std::transform(word.begin(), word.end(), word.begin(), [](TCHAR c){ return std::toupper(c); } );
                     if (word == strValue) {


### PR DESCRIPTION
Potential fix for [https://github.com/rdkcentral/Thunder/security/code-scanning/22](https://github.com/rdkcentral/Thunder/security/code-scanning/22)

To fix the problem, we should avoid subtracting two unsigned values and comparing the result to zero using a relational operator. The best way to do this is to replace the condition `end - start > 0` with `end > start`, which is equivalent but does not risk unsigned underflow. This change preserves the intended logic: we only want to process the substring if `end` is strictly greater than `start`. The fix should be applied to line 701 in `Source/websocket/WebRequest.h`, within the `ScanForKeyword` template function. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
