### PR TITLE
Potential fix for code scanning alert no. 1: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/Deploy Documentation Preview.yml
+++ b/.github/workflows/Deploy Documentation Preview.yml
@@ -42,11 +42,19 @@ jobs:
       # Get PR number
       - if: ${{ env.mode == 'deploy' }}
         name: Get PR number (deploy)
-        run: echo "pr_number=$(cat ./artifacts/preview_site/pr_number)" >> "$GITHUB_ENV"
+        run: |
+          PR_NUMBER=$(cat ./artifacts/preview_site/pr_number | tr -d '\n\r')
+          # Optionally, ensure PR_NUMBER is numeric (uncomment next line if desired)
+          # if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then echo "Invalid PR number"; exit 1; fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_ENV"
 
       - if: ${{ env.mode == 'clean' }}
         name: Get PR number (clean)
-        run: echo "pr_number=$(cat ./artifacts/closed_pr_number/pr_number)" >> "$GITHUB_ENV"
+        run: |
+          PR_NUMBER=$(cat ./artifacts/closed_pr_number/pr_number | tr -d '\n\r')
+          # Optionally, ensure PR_NUMBER is numeric (uncomment next line if desired)
+          # if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then echo "Invalid PR number"; exit 1; fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_ENV"
 
       # Run deployment
       - if: ${{ env.mode == 'deploy' }}


### PR DESCRIPTION
Potential fix for [https://github.com/rdkcentral/Thunder/security/code-scanning/1](https://github.com/rdkcentral/Thunder/security/code-scanning/1)

To fix the problem, we must ensure that the value written to `$GITHUB_ENV` cannot be used to inject additional environment variables or otherwise break the environment. The best way to do this is to sanitize the contents of the `pr_number` file before writing it to `$GITHUB_ENV`. Since the value should be a single line (the PR number), we should strip all newlines and any characters that could be used for injection (such as `=`). The recommended approach is to use `tr -d '\n\r'` to remove newlines and possibly use a regular expression to ensure the value is numeric (if PR numbers are always numbers), or at least restrict to a safe character set.

Specifically, in the lines:
```yaml
45:         run: echo "pr_number=$(cat ./artifacts/preview_site/pr_number)" >> "$GITHUB_ENV"
```
and
```yaml
49:         run: echo "pr_number=$(cat ./artifacts/closed_pr_number/pr_number)" >> "$GITHUB_ENV"
```
We should replace them with a version that strips newlines and (optionally) validates the value.

**What is needed:**
- Replace the `echo` command with one that strips newlines (e.g., `tr -d '\n\r'`).
- Optionally, validate that the value is numeric using a shell pattern or `grep`.
- No new imports or external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
