### PR TITLE
Potential fix for code scanning alert no. 2: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/Deploy Documentation Preview.yml
+++ b/.github/workflows/Deploy Documentation Preview.yml
@@ -42,11 +42,11 @@ jobs:
       # Get PR number
       - if: ${{ env.mode == 'deploy' }}
         name: Get PR number (deploy)
-        run: echo "pr_number=$(cat ./artifacts/preview_site/pr_number)" >> "$GITHUB_ENV"
+        run: echo "pr_number=$(tr -d '\n' < ./artifacts/preview_site/pr_number)" >> "$GITHUB_ENV"
 
       - if: ${{ env.mode == 'clean' }}
         name: Get PR number (clean)
-        run: echo "pr_number=$(cat ./artifacts/closed_pr_number/pr_number)" >> "$GITHUB_ENV"
+        run: echo "pr_number=$(tr -d '\n' < ./artifacts/closed_pr_number/pr_number)" >> "$GITHUB_ENV"
 
       # Run deployment
       - if: ${{ env.mode == 'deploy' }}


### PR DESCRIPTION
Potential fix for [https://github.com/rdkcentral/Thunder/security/code-scanning/2](https://github.com/rdkcentral/Thunder/security/code-scanning/2)

To fix this problem, we need to ensure that the value written to `$GITHUB_ENV` is sanitized so that it cannot inject newlines or other special characters that could break the environment variable assignment or inject additional variables. The best way to do this is to strip newlines and any other potentially dangerous characters from the value before writing it to `$GITHUB_ENV`. For a PR number, we expect it to be a simple integer, so we can use a command like `tr -d '\n'` to remove newlines, and optionally use a regular expression to ensure only digits are present.

Specifically, in the affected lines (44-49), we should change the `echo` command to sanitize the value. For example:
```bash
pr_number=$(cat ./artifacts/closed_pr_number/pr_number | tr -d '\n' | grep -Eo '^[0-9]+')
echo "pr_number=$pr_number" >> "$GITHUB_ENV"
```
Or, more simply, if we just want to strip newlines:
```bash
echo "pr_number=$(tr -d '\n' < ./artifacts/closed_pr_number/pr_number)" >> "$GITHUB_ENV"
```
This should be done for both the "deploy" and "clean" cases for consistency and safety.

No new imports or dependencies are needed, as these are standard Unix utilities available in the GitHub Actions runner environment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
