### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Build Thunder on Linux.yml
+++ b/.github/workflows/Build Thunder on Linux.yml
@@ -1,4 +1,6 @@
 name: Build Thunder on Linux
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/rdkcentral/Thunder/security/code-scanning/15](https://github.com/rdkcentral/Thunder/security/code-scanning/15)

To fix the problem, add a `permissions` block at the top level of the workflow YAML file, immediately after the `name:` field and before the `on:` field. This block should specify the least privileges required for the workflow to function. As a minimal starting point, set `contents: read`, which allows the workflow to read repository contents but not write to them. If the workflow requires additional permissions (e.g., to create pull requests or issues), those can be added as needed. For now, the safest default is `contents: read`. No changes to the jobs themselves are required unless more granular permissions are needed for specific jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
