### PR TITLE
[Dangling] Improve the offloading of Dangling proxies notification.

### DIFF
--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -270,9 +270,9 @@ namespace PluginHost {
     }
 
 
-    /* static */ Core::ProxyType<Core::IDispatch> Server::ServiceMap::CommunicatorServer::DanglingNotifierJob::Create(Server::ServiceMap::CommunicatorServer* commServer, RPC::Administrator::Proxies& deadProxies)
+    /* static */ Core::ProxyType<Core::IDispatch> Server::ServiceMap::CommunicatorServer::DanglingNotifierJob::Create(Server::ServiceMap::CommunicatorServer* commServer, RPC::Administrator::Proxies&& deadProxies)
     {
-        return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Server::ServiceMap::CommunicatorServer::DanglingNotifierJob>::Create(commServer, deadProxies)));
+        return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Server::ServiceMap::CommunicatorServer::DanglingNotifierJob>::Create(commServer, std::move(deadProxies))));
     }
     
     void* Server::Service::QueryInterface(const uint32_t id) /* override */

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -269,12 +269,6 @@ namespace PluginHost {
         _processAdministrator.Destroy();
     }
 
-
-    /* static */ Core::ProxyType<Core::IDispatch> Server::ServiceMap::CommunicatorServer::DanglingNotifierJob::Create(Server::ServiceMap::CommunicatorServer* commServer, RPC::Administrator::Proxies&& deadProxies)
-    {
-        return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Server::ServiceMap::CommunicatorServer::DanglingNotifierJob>::Create(commServer, std::move(deadProxies))));
-    }
-    
     void* Server::Service::QueryInterface(const uint32_t id) /* override */
     {
         void* result = nullptr;

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -269,6 +269,12 @@ namespace PluginHost {
         _processAdministrator.Destroy();
     }
 
+
+    /* static */ Core::ProxyType<Core::IDispatch> Server::ServiceMap::CommunicatorServer::DanglingNotifierJob::Create(Server::ServiceMap::CommunicatorServer* commServer, RPC::Administrator::Proxies& deadProxies)
+    {
+        return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Server::ServiceMap::CommunicatorServer::DanglingNotifierJob>::Create(commServer, deadProxies)));
+    }
+    
     void* Server::Service::QueryInterface(const uint32_t id) /* override */
     {
         void* result = nullptr;

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -2403,7 +2403,7 @@ namespace PluginHost {
                     // even worse, use the communicator thread..
                     _deadProxiesProtection.Lock();
                     while (_deadProxies.empty() == false) {
-                        std::pair<uint32_t, Core::IUnknown*> entry(std::move(_deadProxies.back()));
+                        std::pair<uint32_t, Core::IUnknown*> entry(_deadProxies.back());
                         _deadProxies.pop_back();
 
                         // Now the communicator thread can continue! In the span of the lock

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -570,7 +570,7 @@ namespace PluginHost {
                     ASSERT(interfaceId >= RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET);
                     return (interfaceId >= RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET ? _plugin->QueryInterface(interfaceId) : nullptr);
                 }
-                void Dangling(Danglings&& proxies) {
+                void Dangling(Danglings&& proxies) override {
                     for (const std::pair<uint32_t, Core::IUnknown*>& entry : proxies) {
                         entry.second->Release();
                     };

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -2403,7 +2403,7 @@ namespace PluginHost {
                     // even worse, use the communicator thread..
                     _deadProxiesProtection.Lock();
                     while (_deadProxies.empty() == false) {
-                        std::pair<uint32_t, Core::IUnknown*> entry(_deadProxies.back());
+                        std::pair<uint32_t, Core::IUnknown*> entry(std::move(_deadProxies.back()));
                         _deadProxies.pop_back();
 
                         // Now the communicator thread can continue! In the span of the lock

--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -413,7 +413,7 @@ namespace RPC {
         return(index != _stubs.end() ? index->second->Convert(rawImplementation) : nullptr);
     }
 
-    void Administrator::DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, Proxies& pendingProxies)
+    void Administrator::DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, Danglings& pendingProxies)
     {
         _adminLock.Lock();
 
@@ -453,7 +453,7 @@ namespace RPC {
                     // Note: If the invalidation succeeds, hence why we are here, 
                     //       a reference has been taken on the interface so it can
                     //       be properly released, once it is reported!
-                    pendingProxies.emplace_back(entry);
+                    pendingProxies.emplace_back(std::move(std::pair<uint32_t,Core::IUnknown*>(entry->InterfaceId(), entry->Parent())));
                 }
                 // The _channelProxyMap does have a reference for each Proxy it
                 // holds, so it is safe to just move the vector from the map to

--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -453,7 +453,7 @@ namespace RPC {
                     // Note: If the invalidation succeeds, hence why we are here, 
                     //       a reference has been taken on the interface so it can
                     //       be properly released, once it is reported!
-                    pendingProxies.emplace_back(std::move(std::pair<uint32_t,Core::IUnknown*>(entry->InterfaceId(), entry->Parent())));
+                    pendingProxies.emplace_back(std::pair<uint32_t,Core::IUnknown*>(entry->InterfaceId(), entry->Parent()));
                 }
                 // The _channelProxyMap does have a reference for each Proxy it
                 // holds, so it is safe to just move the vector from the map to

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -131,6 +131,7 @@ namespace RPC {
         using ReferenceMap = std::unordered_map<uint32_t, std::list< RecoverySet > >;
         using Stubs = std::unordered_map<uint32_t, ProxyStub::UnknownStub*>;
         using Factories = std::unordered_map<uint32_t, IMetadata*>;
+        using Danglings = std::vector<std::pair<uint32_t, Core::IUnknown*>>;
 
     public:
         Administrator(Administrator&&) = delete;
@@ -233,7 +234,7 @@ POP_WARNING()
             return (_factory.Element());
         }
 
-        void DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, Proxies& pendingProxies);
+        void DeleteChannel(const Core::ProxyType<Core::IPCChannel>& channel, Danglings& pendingProxies);
 
         template <typename ACTUALINTERFACE>
         ACTUALINTERFACE* ProxyFind(const Core::ProxyType<Core::IPCChannel>& channel, const Core::instance_id& impl)

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1743,19 +1743,16 @@ POP_WARNING()
             Administrator::Proxies deadProxies;
 
             RPC::Administrator::Instance().DeleteChannel(channel, deadProxies);
-            if(deadProxies.size() > 0)
-            {
-                Dangling(std::move(deadProxies));
 
-                std::vector<ProxyStub::UnknownProxy*>::const_iterator loop(deadProxies.begin());
-                while (loop != deadProxies.end()) {
-                    // To avoid race conditions, the creation of the deadProxies took a reference
-                    // on the interfaces, we presented here. Do not forget to release this reference.
-                    (*loop)->Parent()->Release();
-                    loop++;
-                }
+            std::vector<ProxyStub::UnknownProxy*>::const_iterator loop(deadProxies.begin());
+            while (loop != deadProxies.end()) {
+                Dangling((*loop)->Parent(), (*loop)->InterfaceId());
+
+                // To avoid race conditions, the creation of the deadProxies took a reference
+                // on the interfaces, we presented here. Do not forget to release this reference.
+                (*loop)->Parent()->Release();
+                loop++;
             }
-
         }
         virtual void* Acquire(const string& /* className */, const uint32_t /* interfaceId */, const uint32_t /* version */)
         {
@@ -1765,7 +1762,7 @@ POP_WARNING()
         }
         virtual void Revoke(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
-        virtual void Dangling(Administrator::Proxies&& /* deadProxies*/) {
+        virtual void Dangling(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
 
     private:

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1743,15 +1743,9 @@ POP_WARNING()
             Administrator::Proxies deadProxies;
 
             RPC::Administrator::Instance().DeleteChannel(channel, deadProxies);
-                
-            std::vector<ProxyStub::UnknownProxy*>::const_iterator loop(deadProxies.begin());
-            while (loop != deadProxies.end()) {
-                Dangling((*loop)->Parent(), (*loop)->InterfaceId());
-
-                // To avoid race conditions, the creation of the deadProxies took a reference
-                // on the interfaces, we presented here. Do not forget to release this reference.
-                (*loop)->Parent()->Release();
-                loop++;
+            if(deadProxies.size() > 0)
+            {
+                Dangling(deadProxies);
             }
         }
         virtual void* Acquire(const string& /* className */, const uint32_t /* interfaceId */, const uint32_t /* version */)
@@ -1762,7 +1756,7 @@ POP_WARNING()
         }
         virtual void Revoke(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
-        virtual void Dangling(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
+        virtual void Dangling(Administrator::Proxies& /* deadProxies*/){
         }
 
     private:

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1745,8 +1745,17 @@ POP_WARNING()
             RPC::Administrator::Instance().DeleteChannel(channel, deadProxies);
             if(deadProxies.size() > 0)
             {
-                Dangling(deadProxies);
+                Dangling(std::move(deadProxies));
+
+                std::vector<ProxyStub::UnknownProxy*>::const_iterator loop(deadProxies.begin());
+                while (loop != deadProxies.end()) {
+                    // To avoid race conditions, the creation of the deadProxies took a reference
+                    // on the interfaces, we presented here. Do not forget to release this reference.
+                    (*loop)->Parent()->Release();
+                    loop++;
+                }
             }
+
         }
         virtual void* Acquire(const string& /* className */, const uint32_t /* interfaceId */, const uint32_t /* version */)
         {
@@ -1756,7 +1765,7 @@ POP_WARNING()
         }
         virtual void Revoke(const Core::IUnknown* /* remote */, const uint32_t /* interfaceId */) {
         }
-        virtual void Dangling(Administrator::Proxies& /* deadProxies*/){
+        virtual void Dangling(Administrator::Proxies&& /* deadProxies*/) {
         }
 
     private:


### PR DESCRIPTION
When Communication thread receives a broken pipe, dangling notification is sent to the CommunicationServer. The notification to ICOMLink::INotification subscribers was already offloaded to a Job in CommunicationServer, but removing IPlugin::INotification subscribers was still done in comm thread. This will make the comm thread wait on the notifier lock when activation/deactivation of any plugin is in progress and the notifier lock for IPlugin::INotification was already taken by a workerpool thread. This change makes sure the comm thread completely offloads the notification to a dedicated job.