### PR TITLE
[COMRPC] Close the socket when a COMRPC call timesout

### DIFF
--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -108,6 +108,18 @@ namespace ProxyStub {
         return (id);
     }
 
+    void UnknownProxy::Shutdown() const
+    {
+        _adminLock.Lock();
+        if (_channel.IsValid() == true) {
+            RPC::Communicator::Client* comchannel = dynamic_cast<RPC::Communicator::Client*>(_channel.operator->());
+            if (comchannel != nullptr) {
+                comchannel->Source().Close(0);
+            }
+        }
+        _adminLock.Unlock();
+    }
+
     static class UnknownInstantiation {
     public:
         UnknownInstantiation()

--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -114,6 +114,7 @@ namespace ProxyStub {
         if (_channel.IsValid() == true) {
             RPC::Communicator::Client* comchannel = dynamic_cast<RPC::Communicator::Client*>(_channel.operator->());
             if (comchannel != nullptr) {
+                SYSLOG(Logging::Error, (_T("Shutting down the socket to avoid side-effects likely because an IPC method Invoke failed due to timeout. Execution of code may or may not have happened.")));
                 comchannel->Source().Close(0);
             }
         }

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -224,6 +224,10 @@ namespace ProxyStub {
                         result = _channel->Invoke(message, RPC::CommunicationTimeOut);
 
                         if (result != Core::ERROR_NONE) {
+                            if (result == Core::ERROR_TIMEDOUT) {
+                                SYSLOG(Logging::Error, (_T("IPC method Invoke failed due to timeout (Interface ID 0x%X, Method ID 0x%X). Execution of code may or may not have happened. Side effects are to be expected after this message"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
+                                Shutdown();
+                            }
                             TRACE_L1("Could not remote release the Proxy.");
                             result |= COM_ERROR;
                         }
@@ -332,6 +336,7 @@ namespace ProxyStub {
 
                     if (result == Core::ERROR_TIMEDOUT) {
                         SYSLOG(Logging::Error, (_T("IPC method Invoke failed due to timeout (Interface ID 0x%X, Method ID 0x%X). Execution of code may or may not have happened. Side effects are to be expected after this message"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
+                        Shutdown();
                     }
 
                     result |= COM_ERROR;
@@ -464,7 +469,9 @@ namespace ProxyStub {
             _adminLock.Unlock();
             return(succeeded);
         }
- 
+
+        void Shutdown() const;
+
     private:
         mutable Core::CriticalSection _adminLock;
         mutable uint32_t _refCount;

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -225,10 +225,9 @@ namespace ProxyStub {
 
                         if (result != Core::ERROR_NONE) {
                             if (result == Core::ERROR_TIMEDOUT) {
-                                SYSLOG(Logging::Error, (_T("IPC method Invoke failed due to timeout (Interface ID 0x%X, Method ID 0x%X). Execution of code may or may not have happened. Side effects are to be expected after this message"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
                                 Shutdown();
                             }
-                            TRACE_L1("Could not remote release the Proxy.");
+                            TRACE_L1("Could not remote release the Proxy for Interface [0x%X]", message->Parameters().InterfaceId());
                             result |= COM_ERROR;
                         }
                         else {
@@ -335,14 +334,13 @@ namespace ProxyStub {
                 if (result != Core::ERROR_NONE) {
 
                     if (result == Core::ERROR_TIMEDOUT) {
-                        SYSLOG(Logging::Error, (_T("IPC method Invoke failed due to timeout (Interface ID 0x%X, Method ID 0x%X). Execution of code may or may not have happened. Side effects are to be expected after this message"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
                         Shutdown();
                     }
 
                     result |= COM_ERROR;
 
                     // Oops something failed on the communication. Report it.
-                    TRACE_L1("IPC method invocation failed for 0x%X, error: %d", message->Parameters().InterfaceId(), result);
+                    TRACE_L1("IPC method invocation failed for 0x%X, Method ID 0x%X error: %d", message->Parameters().InterfaceId(), message->Parameters().MethodId(), result);
                 }
             }
 


### PR DESCRIPTION
When a COMRPC call times out, on a channel, most of the times the caller gives up and continues without handling the error. But the other side may still send a response when its not expected. This causes the response message to be processed for a different outbound method from Thunder on the wrong time resulting in a memory corruption and crash. This change closes the SocketPort when there is a COMRPC timeout thereby avoiding subsequent outbound messages on the channel and also triggering fault tolerance code on the communication thread to kick-in and gracefully shudown the plugin.