### PR TITLE
[RDKDEV-1144] Thunder leaking sockets

### DIFF
--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -4443,6 +4443,11 @@ namespace PluginHost {
 
                         _service.Release();
                     }
+                    if (!IsSuspended()) {
+                        // need to close our side as well, to avoid sockets
+                        // staying indefinetely in CLOSE_WAIT
+                        Close(0);
+                    }
 
                     State(CLOSED, false);
 

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1240,7 +1240,9 @@ namespace Thunder {
 
                 if (l_Size == 0) {
                     if ((m_State & SocketPort::LINK) != 0) {
-                        m_State = ((m_State & (~SocketPort::OPEN)) | SocketPort::EXCEPTION);
+                        // peer has performed an orderly shutdown
+                        m_State &= (~SocketPort::OPEN);
+                        StateChange();
                     }
                 }
                 else if (l_Size != static_cast<uint32_t>(SOCKET_ERROR)) {


### PR DESCRIPTION
It was observed that when calling WebKit plugin URL endpoint with curl, the socket on wpeframework side stays in CLOSE_WAIT state indefinetely, which may lead to running out of file descriptors and crash. The reason
seems to be that on Thunder side, the socket was never closed.

reproduction/test scenario:

- assuming Thunder is listening on port 9998
- tested with WebKitBrowser API, but other APIs behave similarly

the script:

    while true; do
    curl http://127.0.0.1:9998/Service/WebKitBrowser/URL -d '{"url":"https://widgets.metrological.com/lightning/liberty/017b288dfb351c11eb33754fc76c12fc#boot"}'
    netstat -tnp 2>&1 | grep :9998 | grep CLOSE_WAIT | wc -l
    done

The above script will show the number of sockets in CLOSE_WAIT state growing. The solution is to Close() the socket on Thunder side as well when Channel is going into CLOSED state.

On SocketPort side, the case where number of bytes read is 0 is 'orderly shutdown', so also 'ERROR' flag in such case (https://man7.org/linux/man-pages/man2/recv.2.html)