### PR TITLE
[SOCKETSERVER] Allow the LocalNode of the ocketServer to be exposed.

### DIFF
--- a/Source/Thunder/ExampleConfigWindows.json
+++ b/Source/Thunder/ExampleConfigWindows.json
@@ -477,8 +477,18 @@
       "startmode": "Activated",
       "communicator": "127.0.0.1:2349",
       "configuration": {
-        "port": 8080,
-        "binding": "0.0.0.0",
+        "access": {
+          "binding": "0.0.0.0:8080",
+          "certificate": "websecurity.crt",
+          "key2": "websecurity.key"
+        },
+        "domains": [
+          {
+            "domain": "localhost.lan",
+            "path": "Service/Controller/UI",
+            "redirect": "https://www.googlw.com/forwarded"
+          }
+        ],
         "root": {
           "mode": "Local"
         }

--- a/Source/core/NodeId.cpp
+++ b/Source/core/NodeId.cpp
@@ -68,7 +68,7 @@ static bool IsIPv4Address(const TCHAR hostname[]) {
     }
 
     // last entry a dot and than no digit is not an IPv4 :-)
-    return (result && (isdigit(hostname[index-1])));
+    return (result && (index > 0) && (isdigit(hostname[index-1])));
 }
 
 static bool IsIPv6Address(const TCHAR hostname[]) {

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -48,15 +48,6 @@
 namespace Thunder {
     namespace Core {
         class EXTERNAL SocketPort : public IResource {
-        private:
-            // -------------------------------------------------------------------------
-            // This object should not be copied, assigned or created with a default
-            // constructor. Prevent them from being used, generatoed by the compiler.
-            // define them but do not implement them. Compile error and/or link error.
-            // -------------------------------------------------------------------------
-            SocketPort(const SocketPort& a_RHS) = delete;
-            SocketPort& operator=(const SocketPort& a_RHS) = delete;
-
         public:
             typedef enum {
                 READ = 0x001,
@@ -83,6 +74,11 @@ namespace Thunder {
             } enumType;
 
         public:
+            SocketPort(SocketPort&& a_RHS) = delete;
+            SocketPort(const SocketPort& a_RHS) = delete;
+            SocketPort& operator=(SocketPort&& a_RHS) = delete;
+            SocketPort& operator=(const SocketPort& a_RHS) = delete;
+
             SocketPort(const enumType socketType,
                 const NodeId& localNode,
                 const NodeId& remoteNode,
@@ -314,12 +310,13 @@ POP_WARNING()
         };
 
         class EXTERNAL SocketStream : public SocketPort {
-        private:
+        public:
             SocketStream() = delete;
+            SocketStream(SocketStream&&) = delete;
             SocketStream(const SocketStream&) = delete;
+            SocketStream& operator=(SocketStream&&) = delete;
             SocketStream& operator=(const SocketStream&) = delete;
 
-        public:
             SocketStream(const bool rawSocket,
                 const NodeId& localNode,
                 const NodeId& remoteNode,
@@ -328,7 +325,6 @@ POP_WARNING()
                 : SocketStream(rawSocket, localNode, remoteNode, sendBufferSize, receiveBufferSize, sendBufferSize, receiveBufferSize)
             {
             }
-
             SocketStream(const bool rawSocket,
                 const NodeId& localNode,
                 const NodeId& remoteNode,
@@ -339,7 +335,6 @@ POP_WARNING()
                 : SocketPort((rawSocket ? SocketPort::RAW : SocketPort::STREAM), localNode, remoteNode, sendBufferSize, receiveBufferSize, socketSendBufferSize, socketReceiveBufferSize)
             {
             }
-
             SocketStream(const bool rawSocket,
                 const SOCKET& connector,
                 const NodeId& remoteNode,
@@ -348,7 +343,6 @@ POP_WARNING()
                 : SocketStream(rawSocket, connector, remoteNode, sendBufferSize, receiveBufferSize, sendBufferSize, receiveBufferSize)
             {
             }
-
             SocketStream(const bool rawSocket,
                 const SOCKET& connector,
                 const NodeId& remoteNode,
@@ -359,17 +353,17 @@ POP_WARNING()
                 : SocketPort((rawSocket ? SocketPort::RAW : SocketPort::STREAM), connector, remoteNode, sendBufferSize, receiveBufferSize, socketSendBufferSize, socketReceiveBufferSize)
             {
             }
-
             ~SocketStream() override = default;
         };
 
         class EXTERNAL SocketDatagram : public SocketPort {
-        private:
+        public:
             SocketDatagram() = delete;
+            SocketDatagram(SocketDatagram&&) = delete;
             SocketDatagram(const SocketDatagram&) = delete;
+            SocketDatagram& operator=(SocketDatagram&&) = delete;
             SocketDatagram& operator=(const SocketDatagram&) = delete;
 
-        public:
             SocketDatagram(const bool rawSocket,
                 const NodeId& localNode,
                 const NodeId& remoteNode,
@@ -378,7 +372,6 @@ POP_WARNING()
                 : SocketDatagram(rawSocket, localNode, remoteNode, sendBufferSize, receiveBufferSize, sendBufferSize, receiveBufferSize)
             {
             }
-
             SocketDatagram(const bool rawSocket,
                 const NodeId& localNode,
                 const NodeId& remoteNode,
@@ -389,21 +382,18 @@ POP_WARNING()
                 : SocketPort((rawSocket ? SocketPort::RAW : SocketPort::DATAGRAM), localNode, remoteNode, sendBufferSize, receiveBufferSize, socketSendBufferSize, socketReceiveBufferSize)
             {
             }
-
-            ~SocketDatagram() override
-            {
-            }
+            ~SocketDatagram() override = default;
         };
 
         class EXTERNAL SocketListner {
         private:
             class EXTERNAL Handler : public SocketPort {
-            private:
-                Handler() = delete;
-                Handler(const Handler&) = delete;
-                Handler& operator=(const Handler&) = delete;
-
             public:
+                Handler() = delete;
+                Handler(Handler&&) = delete;
+                Handler(const Handler&) = delete;
+                Handler& operator=(Handler&&) = delete;
+                Handler& operator=(const Handler&) = delete;
                 Handler(SocketListner& parent)
                     : SocketPort(SocketPort::LISTEN, Core::NodeId(), Core::NodeId(), 0, 0)
                     , _parent(parent)
@@ -414,14 +404,16 @@ POP_WARNING()
                     , _parent(parent)
                 {
                 }
-                ~Handler()
-                {
-                }
+                ~Handler() override = default;
 
             public:
                 inline void LocalNode(const Core::NodeId& localNode)
                 {
                     SocketPort::LocalNode(localNode);
+                }
+                inline const Core::NodeId& LocalNode() const
+                {
+                    return (SocketPort::LocalNode());
                 }
                 uint16_t SendData(uint8_t* /* dataFrame */, const uint16_t /* maxSendSize */) override
                 {
@@ -475,7 +467,7 @@ POP_WARNING()
             }
             POP_WARNING()
 
-                virtual ~SocketListner()
+            virtual ~SocketListner()
             {
                 TRACE_L5("Destructor SocketListner <%p>", (this));
 
@@ -483,6 +475,10 @@ POP_WARNING()
             }
 
         public:
+            inline const Core::NodeId& LocalNode() const
+            {
+                return (_socket.LocalNode());
+            }
             inline bool IsListening() const
             {
                 return (_socket.IsListening());
@@ -509,7 +505,6 @@ POP_WARNING()
         protected:
             inline void LocalNode(const Core::NodeId& localNode)
             {
-
                 ASSERT(_socket.IsClosed() == true);
 
                 _socket.LocalNode(localNode);

--- a/Source/core/SocketServer.h
+++ b/Source/core/SocketServer.h
@@ -220,6 +220,10 @@ namespace Core {
             {
                 SocketListner::LocalNode(localNode);
             }
+            inline const Core::NodeId& LocalNode() const
+            {
+                return (SocketListner::LocalNode());
+            }
             inline Core::ProxyType<HANDLECLIENT> Client(const uint32_t ID)
             {
                 Core::ProxyType<HANDLECLIENT> result;
@@ -392,6 +396,10 @@ namespace Core {
         inline void LocalNode(const Core::NodeId& localNode)
         {
             _handler.LocalNode(localNode);
+        }
+        inline const Core::NodeId& LocalNode() const
+        {
+            return (_handler.LocalNode());
         }
         template <typename PACKAGE>
         inline uint32_t Submit(const uint32_t ID, PACKAGE package)


### PR DESCRIPTION
As we are going through the sources, also update the source to the latests specs. Implement or delete the move constructor and the move assinment operator.