### PR TITLE
To handle truncated UTF code on parsing empty null terminated or uninitialized input

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1869,7 +1869,7 @@ namespace Core {
                                     // Oops it is a bad code thingy, Skip it..
                                     // TODO: report an error
                                     if((static_cast<uint32_t>(-codeSize)) <= length) {
-                                    codeSize = -codeSize;
+                                        codeSize = -codeSize;
                                     } else {
                                         codeSize = length;
                                     }

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1868,7 +1868,11 @@ namespace Core {
                                 if (codeSize < 0) {
                                     // Oops it is a bad code thingy, Skip it..
                                     // TODO: report an error
+                                    if((static_cast<uint32_t>(-codeSize)) <= length) {
                                     codeSize = -codeSize;
+                                    } else {
+                                        codeSize = length;
+                                    }
                                 }
 
                                 ASSERT(codeSize <= 7);

--- a/Tests/unit/core/test_jsonparser.cpp
+++ b/Tests/unit/core/test_jsonparser.cpp
@@ -2899,6 +2899,18 @@ namespace Tests {
             printf("output %zd --- = %s \n", output.length(), output.c_str());
 
             EXPECT_STREQ(input.c_str(), output.c_str());
+            
+            uint8_t data[] = { 0xD0, 0x9F, 0x80, 0xFF, 0xFE, 0x41, 0x42, 0x43 };
+            JsonObject response;
+            input = string(reinterpret_cast<const char*>(data), sizeof(data));
+            response["state"] = input;
+            const char expected_output[] = "{\"state\":\"\\u041F\\u0000\\u0020\"}";
+            response.ToString(output);
+            printf("\n\n Case 19: \n");
+            printf("     input  %zd --- = %s \n", input.length(), input.c_str());
+            printf("     output %zd --- = %s \n", output.length(), output.c_str());
+            printf("     expected_output --- = %s \n", expected_output);
+            EXPECT_STREQ(expected_output, output.c_str());
         }
     }
 }


### PR DESCRIPTION
To fix the serialization of a string which has non-printable characters originated from an uninitialized input