### PR TITLE
[IController] Rename JSON-RPC method version to framework

### DIFF
--- a/Source/plugins/IController.h
+++ b/Source/plugins/IController.h
@@ -378,6 +378,7 @@ namespace Controller {
         virtual Core::hresult Proxies(const Core::OptionalType<string>& linkID /* @index */, Data::IProxiesIterator*& proxies /* @out */) const = 0;
 
         // @property
+        // @text:framework @alt-deprecated:version
         // @brief Framework version
         virtual Core::hresult Version(Data::Version& version /* @out */) const = 0;
 


### PR DESCRIPTION
To avoid confusion with built-in "versions", which return JSON-RPC interface version, not framework version. For sake of bw compatibility old "version" method is kept as deprecated.