### PR TITLE
[JSON-RPC] Improve version handling

### DIFF
--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -1370,11 +1370,6 @@ namespace PluginHost {
                 return (_reason);
             }
 
-            bool HasVersionSupport(const string& number) const
-            {
-                return (number.length() > 0) && (std::all_of(number.begin(), number.end(), [](TCHAR item) { return std::isdigit(item); })) && (Service::IsSupported(static_cast<uint8_t>(atoi(number.c_str()))));
-            }
-
             void LoadMetadata() {
                 const string locator(PluginHost::Service::Configuration().Locator.Value());
                 if (locator.empty() == false) {
@@ -3304,54 +3299,45 @@ namespace PluginHost {
                 _adminLock.Unlock();
             }
 
-            uint32_t FromIdentifier(const string& callSign, Core::ProxyType<IShell>& service)
+            uint32_t FromIdentifier(const string& composite, const string& callsign, Core::ProxyType<IShell>& service)
             {
-                size_t pos = callSign.find_first_of(PluginHost::ICompositPlugin::Delimiter);
-                // This can be a Composite plugin identifier..
-                string baseName = (pos == string::npos ? callSign : callSign.substr(0, pos));
-                size_t versionDot = baseName.find('.');
-                string namePart = (versionDot == string::npos ? baseName : baseName.substr(0, versionDot));
-                string versionPart;
-
-                if (versionDot != string::npos) {
-                    versionPart = baseName.substr(versionDot + 1);
-                }
-
-                Core::ProxyType<Service> selected;
                 uint32_t result = Core::ERROR_NOT_EXIST;
 
                 _adminLock.Lock();
 
-                auto it = _services.find(namePart);
+                auto it = _services.find(composite);
 
                 if (it != _services.end()) {
+                    ASSERT(it->second != nullptr);
 
-                    if (versionPart.empty() == true) {
-                        // Service found, did not requested specific version
-                        selected = it->second;
+                    service = it->second->Composits().Source(callsign);
+
+                    if (service.IsValid() == true) {
                         result = Core::ERROR_NONE;
-                    }
-                    else if (it->second->HasVersionSupport(versionPart) == true) {
-                        // Requested specific version of a plugin, and this version is supported!
-                        selected = it->second;
-                        result = Core::ERROR_NONE;
-                    }
-                    else {
-                        // Requested version is not supported
-                        result = Core::ERROR_INVALID_SIGNATURE;
                     }
                 }
+
                 _adminLock.Unlock();
 
-                if (selected.IsValid() == true) {
-                    if (pos == string::npos) {
-                        service = Core::ProxyType<IShell>(selected);
-                    }
-                    else {
-                        service = selected->Composits().Source(callSign.substr(pos + 1));
-                        result = (service.IsValid() == false ? Core::ERROR_UNKNOWN_KEY : Core::ERROR_NONE);
-                    }
+                return (result);
+            }
+
+            uint32_t FromIdentifier(const string& callsign, Core::ProxyType<IShell>& service)
+            {
+                uint32_t result = Core::ERROR_NOT_EXIST;
+
+                _adminLock.Lock();
+
+                auto it = _services.find(callsign);
+
+                if (it != _services.end()) {
+                    ASSERT(it->second != nullptr);
+
+                    service = Core::ProxyType<IShell>(it->second);
+                    result = Core::ERROR_NONE;
                 }
+
+                _adminLock.Unlock();
 
                 return (result);
             }

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -198,9 +198,6 @@ namespace PluginHost {
         //! ClassName: Name of the class to be instantiated for this IShell
         virtual string ClassName() const = 0;
 
-        //! Versions: Returns a JSON Array of versions (JSONRPC interfaces) supported by this plugin.
-        virtual string Versions() const = 0;
-
         //! Callsign: Instantiation name of this specific plugin. It is the name given in the config for the classname.
         virtual string Callsign() const = 0;
 
@@ -245,9 +242,6 @@ namespace PluginHost {
         virtual string ConfigLine() const = 0;
         virtual Core::hresult ConfigLine(const string& config) = 0;
         virtual Core::hresult Metadata(string& info /* @out */) const = 0;
-
-        //! Return whether the given version is supported by this IShell instance.
-        virtual bool IsSupported(const uint8_t version) const = 0;
 
         // Get access to the SubSystems and their corrresponding information. Information can be set or get to see what the
         // status of the sub systems is.

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -29,7 +29,7 @@ namespace Thunder {
 
 namespace PluginHost {
 
-    static const std::array<const char*,4> builtIns = { _T("versions"), _T("exists"), _T("register"), _T("unregister") };
+    static const std::array<const TCHAR*,4> builtIns = { _T("versions"), _T("exists"), _T("register"), _T("unregister") };
 
     namespace {
 

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -29,6 +29,8 @@ namespace Thunder {
 
 namespace PluginHost {
 
+    static const std::array<const char*,4> builtIns = { _T("versions"), _T("exists"), _T("register"), _T("unregister") };
+
     namespace {
 
         template<typename JSONRPCERRORASSESSORTYPE>
@@ -701,8 +703,6 @@ namespace PluginHost {
                 }
 
                 if (result == Core::ERROR_NONE) {
-
-                    static const std::array<const char*,4> builtIns = { _T("versions"), _T("exists"), _T("register"), _T("unregister") };
 
                     // Seems we are on the right handler..
                     // now see if someone supports this version

--- a/Source/plugins/Service.h
+++ b/Source/plugins/Service.h
@@ -59,10 +59,6 @@ namespace PluginHost {
             ~Config() = default;
 
         public:
-            inline bool IsSupported(const uint8_t number) const
-            {
-                return (std::find(_versions.begin(), _versions.end(), number) != _versions.end());
-            }
             inline void Configuration(const string& value)
             {
                 _config.Configuration = value;
@@ -115,26 +111,6 @@ namespace PluginHost {
             inline void Update(const Plugin::Config& config)
             {
                 _config = config;
-
-                _versions.clear();
-
-                // Extract the version list from the config
-                Core::JSON::ArrayType<Core::JSON::DecUInt8> versions;
-                Core::OptionalType<Core::JSON::Error> error;
-                versions.FromString(config.Versions.Value(), error);
-                if (error.IsSet() == true) {
-                    SYSLOG(Logging::ParsingError, (_T("Parsing failed with %s"), ErrorDisplayMessage(error.Value()).c_str()));
-                }
-                Core::JSON::ArrayType<Core::JSON::DecUInt8>::Iterator index(versions.Elements());
-
-                while (index.Next() == true) {
-                    _versions.push_back(index.Current().Value());
-                }
-
-                // If no versions are give, lets assume this is version 1, and we support it :-)
-                if (_versions.empty() == true) {
-                    _versions.push_back(1);
-                }
             }
 
         private:
@@ -145,7 +121,6 @@ namespace PluginHost {
             string _volatilePath;
             string _dataPath;
             string _accessor;
-            std::list<uint8_t> _versions;
         };
 
     public:
@@ -173,10 +148,6 @@ namespace PluginHost {
         ~Service() override = default;
 
     public:
-        string Versions() const override
-        {
-            return (_config.Configuration().Versions.Value());
-        }
         string Locator() const override
         {
             return (_config.Configuration().Locator.Value());
@@ -262,10 +233,6 @@ namespace PluginHost {
             _config.StartMode(value);
 
             return (Core::ERROR_NONE);
-        }
-        bool IsSupported(const uint8_t number) const override
-        {
-            return (_config.IsSupported(number));
         }
 
         // As a service, the plugin could act like a WebService. The Webservice hosts files from a location over the


### PR DESCRIPTION
All combinations now work:
BridgeLink/Controller.1.services
BridgeLink/1.services
BridgeLink/services
BridgeLink.1/Controller.1.services
BridgeLink.1/1.services
BridgeLink.1/services
and version is checked against what was regiestered, not from a config entry.

Additionally:
- Versions and IsSupported have been removed from IShell
- config parsing for versions has been removed
- doubled versions storage have been removed
- Register/Unregister are now checked for bad params
- exists returns true when checked for builtin methods