### PR TITLE
[METADATADISCOVERY] Make the Metadata discover configurable.

### DIFF
--- a/Source/Thunder/Config.h
+++ b/Source/Thunder/Config.h
@@ -416,6 +416,7 @@ namespace PluginHost {
                 , DelegatedReleases(true)
                 , Throttle((Process.ThreadPoolCount.Value() > 1) ? (Process.ThreadPoolCount.Value() / 2) : 1)
                 , ChannelThrottle(((Process.ThreadPoolCount.Value() > 1) ? (Process.ThreadPoolCount.Value() / 2) : 1))
+                , MetadataDiscovery(true)
 #ifdef PROCESSCONTAINERS_ENABLED
                 , ProcessContainers()
 #endif
@@ -459,6 +460,7 @@ namespace PluginHost {
                 Add(_T("ccdr"), &DelegatedReleases); /* COMRPC channel delegated releases */
                 Add(_T("throttle"), &Throttle);
                 Add(_T("channel_throttle"), &ChannelThrottle);
+                Add(_T("discovery"), &MetadataDiscovery);
 #ifdef PROCESSCONTAINERS_ENABLED
                 Add(_T("processcontainers"), &ProcessContainers);
 #endif
@@ -506,6 +508,7 @@ namespace PluginHost {
             Core::JSON::Boolean DelegatedReleases;
             Core::JSON::DecUInt8 Throttle;
             Core::JSON::DecUInt8 ChannelThrottle;
+            Core::JSON::Boolean MetadataDiscovery;
 #ifdef PROCESSCONTAINERS_ENABLED
             Core::JSON::String ProcessContainers;
 #endif
@@ -677,6 +680,7 @@ namespace PluginHost {
             , _delegatedReleases(true)
             , _throttle((_threadPoolCount > 1) ? (_threadPoolCount / 2) : 1)
             , _channelThrottle((_threadPoolCount > 1) ? (_threadPoolCount / 2) : 1)
+            , _metadataDiscovery(true)
 #ifdef PROCESSCONTAINERS_ENABLED
             , _processContainersConfig()
 #endif
@@ -733,6 +737,7 @@ namespace PluginHost {
                 _delegatedReleases = config.DelegatedReleases.Value();
                 _throttle = config.Throttle.Value();
                 _channelThrottle = config.ChannelThrottle.Value();
+                _metadataDiscovery = config.MetadataDiscovery.Value();
                 if( config.Latitude.IsSet() || config.Longitude.IsSet() ) {
                     SYSLOG(Logging::Error, (_T("Support for Latitude and Longitude moved from Thunder configuration to plugin providing ILocation support")));
                 }
@@ -958,6 +963,9 @@ namespace PluginHost {
         inline uint8_t ChannelThrottle() const {
             return(_channelThrottle);
         }
+        inline bool MetadataDiscovery() const {
+            return (_metadataDiscovery);
+        }
         inline const InputInfo& Input() const {
             return(_inputInfo);
         }
@@ -1141,6 +1149,7 @@ namespace PluginHost {
         bool _delegatedReleases;
         uint8_t _throttle;
         uint8_t _channelThrottle;
+        bool _metadataDiscovery;
 
 #ifdef PROCESSCONTAINERS_ENABLED
         string _processContainersConfig;

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -922,20 +922,22 @@ namespace PluginHost {
     // -----------------------------------------------------------------------------------------------------------------------------------
     void Server::ServiceMap::Open(std::vector<PluginHost::ISubSystem::subsystem>& externallyControlled) {
         // Load the metadata for the subsystem information..
-        for (auto service : _services)
-        {
-            service.second->LoadMetadata();
-            for (const PluginHost::ISubSystem::subsystem& entry : service.second->SubSystemControl()) {
-                Core::EnumerateType<PluginHost::ISubSystem::subsystem> name(entry);
-                if (std::find(externallyControlled.begin(), externallyControlled.end(), entry) != externallyControlled.end()) {
-                    SYSLOG(Logging::Startup, (Core::Format(_T("Subsystem [%s] controlled by multiple plugins. Second: [%s]. Configuration error!!!"), name.Data(), service.second->Callsign().c_str())));
-                }
-                else if (entry >= PluginHost::ISubSystem::END_LIST) {
-                    SYSLOG(Logging::Startup, (Core::Format(_T("Subsystem [%s] can not be used as a control value in [%s]!!!"), name.Data(), service.second->Callsign().c_str())));
-                }
-                else {
-                    SYSLOG(Logging::Startup, (Core::Format(_T("Subsytem [%s] controlled by plugin [%s]"), name.Data(), service.second->Callsign().c_str())));
-                    externallyControlled.emplace_back(entry);
+        if (Configuration().MetadataDiscovery() == true) {
+            for (auto service : _services)
+            {
+                service.second->LoadMetadata();
+                for (const PluginHost::ISubSystem::subsystem& entry : service.second->SubSystemControl()) {
+                    Core::EnumerateType<PluginHost::ISubSystem::subsystem> name(entry);
+                    if (std::find(externallyControlled.begin(), externallyControlled.end(), entry) != externallyControlled.end()) {
+                        SYSLOG(Logging::Startup, (Core::Format(_T("Subsystem [%s] controlled by multiple plugins. Second: [%s]. Configuration error!!!"), name.Data(), service.second->Callsign().c_str())));
+                    }
+                    else if (entry >= PluginHost::ISubSystem::END_LIST) {
+                        SYSLOG(Logging::Startup, (Core::Format(_T("Subsystem [%s] can not be used as a control value in [%s]!!!"), name.Data(), service.second->Callsign().c_str())));
+                    }
+                    else {
+                        SYSLOG(Logging::Startup, (Core::Format(_T("Subsytem [%s] controlled by plugin [%s]"), name.Data(), service.second->Callsign().c_str())));
+                        externallyControlled.emplace_back(entry);
+                    }
                 }
             }
         }

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -922,7 +922,10 @@ namespace PluginHost {
     // -----------------------------------------------------------------------------------------------------------------------------------
     void Server::ServiceMap::Open(std::vector<PluginHost::ISubSystem::subsystem>& externallyControlled) {
         // Load the metadata for the subsystem information..
-        if (Configuration().MetadataDiscovery() == true) {
+        if (Configuration().MetadataDiscovery() == false) {
+            SYSLOG(Logging::Startup, (_T("Automatic metadata discovery and plugin versioning is DISABLED!!!")));
+        }
+        else {
             for (auto service : _services)
             {
                 service.second->LoadMetadata();


### PR DESCRIPTION
For automatic configuration of the subsystems and plugin version retrieval, thunder loads all plugins into memory at startup without starting them. This allows for a proper build up of the subsystem dependencies (read from the build in code of the plugin) and allows for retrieval of plugin versions, without the plugins being activated. This feature however, moves the additional loading time of each plugin, into the Thunder startup timer. If squash file system (assumption this is the root cause) is used and you have a great deal of plugins that are not activated at startup, increase the Thunder Plugin time by 6 Seconds. Measurements using an ext4 file system show (using 150 reference stack plugins) that the additional loading time is increased by 100mS.

To reduce the startup time of the software it was requested by Comcast to make this feature configurable. With this PR, there is a flag in the config called "discovery". By default it is true Comcast can, in their build, configure this to false. If configured to false, the plugins are no longer pre-loaded to extract the metadata from the plugins, effectively reducing the initial startup time of Thunder.

Note: If disabled, the subsystems functionality, is no longer taken from the plugin and if needed
      must be placed in the plugin config, manual labor, error prone but still available.
      Versions of plugins will not give any output as long as the plugin is not loaded, at least
      once. So the plugin must be at least started once to get this version info.
      The startup time is still required at first startup, so the feature only "moves" the startup
      time from Thunder to whenever the plugin is activated for the first time!

      Bottom line: From Thunder perspective, it is *not* recommended to turn off the "discovery"!