### PR TITLE
[FIX] for issue https://github.com/rdkcentral/Thunder/issues/1948

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -2020,7 +2020,7 @@ namespace Core {
                             // We are assumed to be opaque, but all quoted string stuff is enclosed between quotes
                             // and should be considered for scope counting.
                             // Check if we are entering or leaving a quoted area in the opaque object
-                            if ((current == '\"') && ((_value.empty() == true) || IsEscaped(_value))) {
+                            if ((current == '\"') && (IsEscaped(_value) == false)) {
                                 // This is not an "escaped" quote, so it should be considered a real quote. It means
                                 // we are now entering or leaving a quoted area within the opaque struct...
                                 _flagsAndCounters ^= QuotedAreaBit;
@@ -2219,17 +2219,28 @@ namespace Core {
 
         private:
             bool IsEscaped(const string& value) const {
-                // This code determines if a lot of back slashes to esscape the backslash
-                // Is odd or even, so does it escape the last character..
-                // e.g. 'Test \\\\\\\\\\"' is not the escaping of the quote (")
-                //      'Test \\\\\\\\\" continued"'  is the escaping of th quote..
-                //      'Test \" and \" and than \\\"' are all escaped quotes 
-                uint32_t index = static_cast<uint32_t>(value.length() - 1);
-                uint32_t start = index;
-                while ( (index != static_cast<uint32_t>(~0)) && (value[index] == '\\') ) {
-                    index--;
+                bool escaped(false);
+
+                if (_value.empty() == false) {
+                    // This code determines if a lot of back slashes to esscape the backslash
+                    // Is odd or even, so does it escape the last character..
+                    // e.g. 'Test \\\\\\\\\\"' is not the escaping of the quote (")
+                    //      'Test \\\\\\\\\" continued"'  is the escaping of th quote..
+                    //      'Test \" and \" and than \\\"' are all escaped quotes
+                    // Subtracting 2 here, because the length is always counted by 
+                    // starting @1, so to a zero based buffer, i need to substract 1 
+                    // however that will give us the last character. This is the character
+                    // for which we would like to know if is is escaped, so I need to go 
+                    // even one position before that one, hence -2
+                    uint32_t index = static_cast<uint32_t>(value.length() - 2);
+                    uint32_t count = 0;
+                    while ((index != static_cast<uint32_t>(~0)) && (value[index] == '\\')) {
+                        index--;
+                        count++;
+                    }
+                    escaped =  ((count % 2) != 0);
                 }
-                return (((start - index) % 2) == 0);
+                return (escaped);
             }
             bool InScope(const ScopeBracket mode) {
                 bool added = false;


### PR DESCRIPTION
Replaces: https://github.com/rdkcentral/Thunder/pull/1973

The comment was right, the code was incorrect. If the quote is escaped, we do *not* want to toggle that we are in or out of a textual area. Aligned the code according to the comment.

Next issue was in the IsEscaped() itself. A one of problem. The last character is the character added, for which we want to know if it is escaped. The functionality is to "count" the number of backslashes in front of the last charcater and than depening on odd or even we determine if it is escaped or not. However the starting point of the first backslash we want to count is in front of the character we would like to check, hence why the index should be -2 i.s.o. -1 for the starting to check for backslash position.

The reason why we probably did not discover this in the testcases is because we are only "positively" testing. Also add test cases that *must* result in an error as it is not valid json e.g. { "test": "What a string \\\\" should fail" } should trigger an error. A FromString() of this json *must* retunr an error on [\\\\"] and the following s, as this closes the string too early.

Test cases I used in my journey:
```cpp
    std::string json_single_begin  = R"({"model":"\"This is the single"})";
    std::string json_single_middle = R"({"model":"This is the \" single"})";
    std::string json_single_end    = R"({"model":"This is the single\""})";
    std::string json_multi_begin   = R"({"model":"\\\\\\\"This is the multi"})";
    std::string json_multi_middle  = R"({"model":"This is the \\\\\\\" multi"})";
    std::string json_multi_end     = R"({"model":"This is the multi\\\\\\\""})";
    std::string json_multi_faulthy = R"({"model":"This is \\\\\\" the failure"})";

    Core::OptionalType<Core::JSON::Error> result;
    std::string textIn = R"json({   "payload"   :    "This is test\" message"})json";
    std::string textOut = "";
    Core::JSON::String json;
    Core::JSON::String opaque;

    // Text Conversion
    json.FromString(textIn, result);
    json.ToString(textOut);

    printf("------------------------------------------------------------------------------------------------\n");
    // Print the strings
    printf("String  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", textIn.c_str());
    printf("Reverse      => [%s]\n", textOut.c_str());

    printf("------------------------------------------------------------------------------------------------\n");
    opaque.FromString(textIn, result);
    opaque.ToString(textOut);
    printf("String  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", textIn.c_str());
    printf("Reverse      => [%s]\n", textOut.c_str());

    Core::JSON::VariantContainer testVariant;
	TestObjectString testObject;
    TestOpaqueString testOpaque;

    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.FromString(json_single_begin, result);
    printf("Variant [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testVariant[_T("model")].Value().c_str());
    testObject.FromString(json_single_begin, result);
    printf("Object  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
    testOpaque.FromString(json_single_begin, result);
    printf("Opaque  <%s> => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testOpaque.Model.Value().c_str());

    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.Clear();
    testOpaque.Clear();
    testObject.Clear();
    testVariant.FromString(json_single_middle, result);
    testObject.FromString(json_single_middle, result);
    printf("Object  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
    testOpaque.FromString(json_single_middle, result);
    printf("Opaque  <%s> => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testOpaque.Model.Value().c_str());

    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.Clear();
    testOpaque.Clear();
    testObject.Clear();
    testVariant.FromString(json_single_end, result);
    printf("Variant [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testVariant[_T("model")].Value().c_str());
    testObject.FromString(json_single_end, result);
    printf("Object  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
    testOpaque.FromString(json_single_end, result);
    printf("Opaque  <%s> => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testOpaque.Model.Value().c_str());

    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.Clear();
    testOpaque.Clear();
    testObject.Clear();
    testVariant.FromString(json_multi_begin, result);
    printf("Variant [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testVariant[_T("model")].Value().c_str());
    testObject.FromString(json_multi_begin, result);
    printf("Object  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
    testOpaque.FromString(json_multi_begin, result);
    printf("Opaque  <%s> => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testOpaque.Model.Value().c_str());

    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.Clear();
    testOpaque.Clear();
    testObject.Clear();
    testVariant.FromString(json_multi_middle, result);
    printf("Variant [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testVariant[_T("model")].Value().c_str());
    testObject.FromString(json_multi_middle, result);
    printf("Object  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
    testOpaque.FromString(json_multi_middle, result);
    printf("Opaque  <%s> => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testOpaque.Model.Value().c_str());

    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.Clear();
    testOpaque.Clear();
    testObject.Clear();
    testVariant.FromString(json_multi_end, result);
    printf("Variant [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testVariant[_T("model")].Value().c_str());
    testObject.FromString(json_multi_end, result);
    printf("Object  [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
    testOpaque.FromString(json_multi_end, result);
    printf("Opaque  <%s> => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testOpaque.Model.Value().c_str());

	// The following should fail
    printf("------------------------------------------------------------------------------------------------\n");
    testVariant.Clear();
    testOpaque.Clear();
    testObject.Clear();
    testObject.FromString(json_multi_faulthy);
    printf("Result [%s] => [%s]\n", result.IsSet() ? result.Value().Message().c_str() : "No Error", testObject.Model.Value().c_str());
```    