### PR TITLE
[Core] Add build option for Forgiving JSON RPC method handling

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -47,6 +47,8 @@ option(DEADLOCK_DETECTION
         "Enable deadlock detection tooling." OFF)
 option(DISABLE_USE_COMPLEMENTARY_CODE_SET
         "Disable the complementary code set" OFF)
+option(ENABLE_JSONRPC_FORGIVING_METHOD_CASE_HANDLING
+        "Enable json rpc forgiving camel and pascal case method handling" OFF)
 
 
 if(HIDE_NON_EXTERNAL_SYMBOLS)

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -207,6 +207,11 @@ if (INSTANCE_ID_BITS)
     message(STATUS "COMRPC instanceid defined as ${INSTANCE_ID_BITS} bits.")
 endif()
 
+if (ENABLE_JSONRPC_FORGIVING_METHOD_CASE_HANDLING)
+    target_compile_definitions(${TARGET} PUBLIC __ENABLE_JSONRPC_FORGIVING_METHOD_CASE_HANDLING__=${ENABLE_JSONRPC_FORGIVING_METHOD_CASE_HANDLING})
+    message(STATUS "json rpc forgiving method handling enabled")
+endif()
+
 if(BLUETOOTH_SUPPORT)
     target_compile_definitions(${TARGET} PUBLIC __CORE_BLUETOOTH_SUPPORT__)
 

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -406,11 +406,13 @@ namespace Core {
                 }
                 return (pos == string::npos ? EMPTY_STRING : designator.substr(0, pos));
             }
-            static void Formalize(string& method)
+            static void Formalize(VARIABLE_IS_NOT_USED string& method)
             {
+#ifdef __ENABLE_JSONRPC_FORGIVING_METHOD_CASE_HANDLING__                
 PUSH_WARNING(DISABLE_WARNING_DEPRECATED_USE) // Support pascal casing during the transition period
                 ToCamelCase(method);
 POP_WARNING()
+#endif
             }
             static string Formalize(const string& method)
             {


### PR DESCRIPTION
Make it possible to enable json rpc forgiving method handling as a build option (OFF by default)