### PR TITLE
Remove template keyword from known template context

### DIFF
--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -1479,7 +1479,7 @@ POP_WARNING()
                 for (uint32_t index = 0; index < initialQueueSize; index++) {
                     Core::ProxyType<ContainerElement> newElement;
 
-                    Core::ProxyType<ContainerElement>::template CreateMove(newElement, 0, *this, std::forward<Args>(args)...);
+                    Core::ProxyType<ContainerElement>::CreateMove(newElement, 0, *this, std::forward<Args>(args)...);
                     _queue.emplace_back(std::move(newElement));
                     ASSERT(_queue.back().IsValid() == true);
                 }
@@ -1531,7 +1531,7 @@ POP_WARNING()
 
                     _lock.Unlock();
 
-                    Core::ProxyType<ContainerElement>::template CreateMove(element, 0, *this, std::forward<Args>(args)...);
+                    Core::ProxyType<ContainerElement>::CreateMove(element, 0, *this, std::forward<Args>(args)...);
 
                     result = Core::ProxyType<PROXYELEMENT>(element);
                 }
@@ -1649,7 +1649,7 @@ POP_WARNING()
                 if (index == _map.end()) {
                     // Oops we do not have such an element, create it...
                     Core::ProxyType<ActualElement> newItem;
-                    Core::ProxyType<ActualElement>::template CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
+                    Core::ProxyType<ActualElement>::CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
 
                     if (newItem.IsValid() == true) {
 
@@ -1810,7 +1810,7 @@ POP_WARNING()
                 Core::ProxyType<ACTUALOBJECT> result;
 
                 Core::ProxyType<ActualElement> newItem;
-                Core::ProxyType<ActualElement>::template CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
+                Core::ProxyType<ActualElement>::CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
 
                 if (newItem.IsValid() == true) {
 


### PR DESCRIPTION
clang on macos complains that template keyword is only allowed when the preceding name is dependent, meaning it depends on a template parameter of the enclosing template. Because CreateMove method is static and the compiler sees the deduction as not dependent, there is no need for the template keyword. GCC allows it but clang is more strict about this.