### PR TITLE
Add CustomCode feature

### DIFF
--- a/Source/Thunder/Config.h
+++ b/Source/Thunder/Config.h
@@ -425,6 +425,9 @@ namespace PluginHost {
 #ifdef HIBERNATE_SUPPORT_ENABLED
                 , Hibernate()
 #endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                , CustomCodeLibrary()
+#endif
             {
                 // No IdleTime
                 Add(_T("model"), &Model);
@@ -468,6 +471,9 @@ namespace PluginHost {
                 Add(_T("observe"), &Observe);
 #ifdef HIBERNATE_SUPPORT_ENABLED
                 Add(_T("hibernate"), &Hibernate);
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                Add(_T("customcodelibrary"), &CustomCodeLibrary);
 #endif
             }
             ~JSONConfig() override = default;
@@ -516,6 +522,9 @@ namespace PluginHost {
             Observables Observe;
 #ifdef HIBERNATE_SUPPORT_ENABLED
             HibernateConfig Hibernate;
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+            Core::JSON::String CustomCodeLibrary;
 #endif
         };
 
@@ -688,6 +697,9 @@ namespace PluginHost {
 #ifdef HIBERNATE_SUPPORT_ENABLED
             , _hibernateLocator()
 #endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+            , _customCodeLibrary()
+#endif
         {
             JSONConfig config;
 
@@ -702,6 +714,9 @@ namespace PluginHost {
 #endif
 #ifdef HIBERNATE_SUPPORT_ENABLED
                 _hibernateLocator = config.Hibernate.Locator.Value();
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                _customCodeLibrary = config.CustomCodeLibrary.Value();
 #endif
                 _volatilePath = Core::Directory::Normalize(config.VolatilePath.Value());
                 _persistentPath = Core::Directory::Normalize(config.PersistentPath.Value());
@@ -840,6 +855,12 @@ namespace PluginHost {
 #ifdef HIBERNATE_SUPPORT_ENABLED
         inline const string& HibernateLocator() const {
             return (_hibernateLocator);
+        }
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        inline const string& CustomCodeLibrary() const
+        {
+            return (_customCodeLibrary);
         }
 #endif
         inline const string& VolatilePath() const
@@ -1157,6 +1178,9 @@ namespace PluginHost {
         std::vector<std::string> _linkerPluginPaths;
 #ifdef HIBERNATE_SUPPORT_ENABLED
         string _hibernateLocator;
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        string _customCodeLibrary;
 #endif
     };
 }

--- a/Source/Thunder/PluginHost.cpp
+++ b/Source/Thunder/PluginHost.cpp
@@ -136,6 +136,66 @@ POP_WARNING()
         Core::AdapterObserver _observer;
     };
 
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+    class CustomCodeLibrary {
+    public:
+
+        CustomCodeLibrary(const CustomCodeLibrary&) = delete;
+        CustomCodeLibrary& operator=(const CustomCodeLibrary&) = delete;
+        CustomCodeLibrary(CustomCodeLibrary&&) = delete;
+        CustomCodeLibrary& operator=(CustomCodeLibrary&&) = delete;
+
+        CustomCodeLibrary()
+            : _customCodeLibrary()
+            , _customCodeToStringHandler(nullptr)
+        {
+        }
+        ~CustomCodeLibrary()
+        {
+            ASSERT(_customCodeToStringHandler == nullptr);
+            ASSERT(_customCodeLibrary.IsLoaded() == false);
+        }
+
+        void Open(const string& libraryPath)
+        {
+            ASSERT(_customCodeToStringHandler == nullptr);
+            ASSERT(_customCodeLibrary.IsLoaded() == false);
+
+            _customCodeLibrary = Core::Library(libraryPath.c_str());
+            if (_customCodeLibrary.IsLoaded() == true) {
+                _customCodeToStringHandler = reinterpret_cast<Core::CustomCodeToStringHandler>(_customCodeLibrary.LoadFunction(CustomCodeToStingName));
+                if (_customCodeToStringHandler != nullptr) {
+                    Core::SetCustomCodeToStringHandler(_customCodeToStringHandler);
+                } else {
+                    SYSLOG(Logging::Error, (_T("Could not find CustomCodeToSting function in Custom Error Code library")));
+                    _customCodeLibrary = Core::Library();
+                }
+            } else {
+                SYSLOG(Logging::Error, (_T("Could not load Custom Error Code library")));
+            }
+        }
+
+        void Close()
+        {
+            if (_customCodeToStringHandler != nullptr) {
+                Core::SetCustomCodeToStringHandler(nullptr);
+                _customCodeToStringHandler = nullptr;
+            }
+            if (_customCodeLibrary.IsLoaded() == true) {
+                _customCodeLibrary = Core::Library();
+            }
+        }
+
+    private:
+        static constexpr const TCHAR* CustomCodeToStingName{ _T("CustomCodeToSting") };
+
+        Core::Library _customCodeLibrary;
+        Core::CustomCodeToStringHandler _customCodeToStringHandler;
+    };
+
+#endif
+
     class ExitHandler : public Core::Thread {
     private:
         ExitHandler() = delete;
@@ -596,6 +656,10 @@ POP_WARNING()
             }
         }
 
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        CustomCodeLibrary customcodelibraryhandler;
+#endif
+
         if (_config != nullptr) {
 
             if (_config->Process().IsSet() == true) {
@@ -645,6 +709,12 @@ POP_WARNING()
             if (postMortemPath.Next() != true) {
                 postMortemPath.CreatePath();
             }
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+            if (_config->CustomCodeLibrary().empty() == false) {
+                customcodelibraryhandler.Open(_config->CustomCodeLibrary());
+            }
+#endif
 
             MessagingInitialization(options.configFile, options.flushMode);
 
@@ -1031,6 +1101,10 @@ POP_WARNING()
             fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a 'Q' press in the terminal. Regular shutdown\n");
             fflush(stderr);
         }
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+         customcodelibraryhandler.Close();
+#endif
  
         ExitHandler::Destruct();
         std::set_terminate(nullptr);

--- a/Source/Thunder/PluginHost.cpp
+++ b/Source/Thunder/PluginHost.cpp
@@ -157,7 +157,7 @@ POP_WARNING()
             ASSERT(_customCodeLibrary.IsLoaded() == false);
         }
 
-        void Open(const string& libraryPath)
+        void Load(const string& libraryPath)
         {
             ASSERT(_customCodeToStringHandler == nullptr);
             ASSERT(_customCodeLibrary.IsLoaded() == false);
@@ -176,7 +176,7 @@ POP_WARNING()
             }
         }
 
-        void Close()
+        void Release()
         {
             if (_customCodeToStringHandler != nullptr) {
                 Core::SetCustomCodeToStringHandler(nullptr);
@@ -712,7 +712,7 @@ POP_WARNING()
 
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
             if (_config->CustomCodeLibrary().empty() == false) {
-                customcodelibraryhandler.Open(_config->CustomCodeLibrary());
+                customcodelibraryhandler.Load(_config->CustomCodeLibrary());
             }
 #endif
 
@@ -1103,7 +1103,7 @@ POP_WARNING()
         }
 
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-         customcodelibraryhandler.Close();
+         customcodelibraryhandler.Release();
 #endif
  
         ExitHandler::Destruct();

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -150,6 +150,7 @@ set(PUBLIC_HEADERS
         CallsignTLS.h
         TokenizedStringList.h
         MessageStore.h
+        ICustomErrorCode.h
         ${CMAKE_CURRENT_BINARY_DIR}/generated/core/Version.h
         )
 

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 Metrological
+ * Copyright 2020 Metrological 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -33,8 +33,8 @@ namespace Core {
             // in release in case the length does not fit we do not want to send data at all, then it is more obvious to the recipient something is wrong instead of only sending partial data
             NEW_TYPE length = 0;
 
-            if (input <= std::numeric_limits<NEW_TYPE>::max()) {
-                length = int_cast<NEW_TYPE>(input);
+            if (Core::check_and_cast<NEW_TYPE, ORIGINAL_TYPE>(input, length) == false) {
+                length = 0;            
             }
 
             return (length);

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -27,128 +27,17 @@ namespace Core {
 
     namespace Frame {
 
-        class SInt24 {
-        public:
-            static constexpr uint8_t SizeOf = 3;
-            static constexpr uint32_t Max = 0x7FFFFF;
-            static constexpr int32_t Min = 0xFF800000;
-
-            using InternalType = int32_t;
-
-            SInt24()
-                : _value(0)
-            {
-            }
-            SInt24(const int32_t value)
-                : _value(value | (value & 0x800000? 0xFF000000 : 0))
-            {
-                ASSERT(((static_cast<uint32_t>(value) >> 24) == 0) || ((static_cast<uint32_t>(value) >> 24) == 0xFF));
-            }
-            SInt24(const SInt24&) = default;
-            SInt24(SInt24&&) = default;
-            ~SInt24() = default;
-
-        public:
-            SInt24& operator=(const SInt24& value) = default;
-            SInt24& operator=(SInt24&& value) = default;
-            SInt24& operator=(const int32_t value)
-            {
-                ASSERT(((static_cast<uint32_t>(value) >> 24) == 0) || ((static_cast<uint32_t>(value) >> 24) == 0xFF));
-                _value = (value | (value & 0x800000? 0xFF000000 : 0));
-                return (*this);
-            }
-            operator int32_t() const {
-                return (_value);
-            }
-
-        private:
-            int32_t _value;
-        };
-
-        class UInt24 {
-        public:
-            static constexpr uint8_t SizeOf = 3;
-            static constexpr uint32_t Max = 0xFFFFFF;
-            static constexpr uint32_t Min = 0;
-
-            using InternalType = uint32_t;
-
-            UInt24()
-                : _value(0)
-            {
-            }
-            UInt24(const UInt24& value) = default;
-            UInt24(UInt24&& value) = default;
-            UInt24(const uint32_t value)
-                : _value(value)
-            {
-                ASSERT((value >> 24) == 0);
-            }
-            ~UInt24() = default;
-
-        public:
-            UInt24& operator=(const UInt24& copy) = default;
-            UInt24& operator=(UInt24&& move) = default;
-            UInt24& operator=(const uint32_t value)
-            {
-                ASSERT((value >> 24) == 0);
-                _value = value;
-                return (*this);
-            }
-            operator uint32_t() const {
-                return (_value);
-            }
-
-        private:
-            uint32_t _value;
-        };
-
-        template <typename T, typename std::enable_if<std::is_scalar<T>::value, int>::type = 0>
-        static constexpr uint8_t RealSize() {
-            return (sizeof(T));
-        }
-        template <typename T, typename std::enable_if<T::SizeOf != 0, int>::type = 0>
-        static constexpr uint8_t RealSize() {
-            return (T::SizeOf);
-        }
-
-        template <typename T, typename std::enable_if<std::is_scalar<T>::value, int>::type = 0>
-        static constexpr T Max() {
-            return (std::numeric_limits<T>::max());
-        }
-
-        template <typename T, typename std::enable_if<T::Max != 0, int>::type = 0>
-        static constexpr typename T::InternalType Max()
-        {
-            return (T::Max);
-        }
-
-        template <typename T, typename std::enable_if<std::is_scalar<T>::value, int>::type = 0>
-        static constexpr T Min()
-        {
-            return (std::numeric_limits<T>::min());
-        }
-
-        template <typename T, typename std::enable_if<T::Min <= T::Max, int>::type = 0>
-        static constexpr typename T::InternalType Min()
-        {
-            return (T::Min);
-        }
-
         template <typename NEW_TYPE, typename ORIGINAL_TYPE>
         NEW_TYPE buffer_length_cast(const ORIGINAL_TYPE& input)
         {
-            ASSERT(input <= Frame::Max<NEW_TYPE>());
-            ASSERT(input >= Frame::Min<NEW_TYPE>());
-
             // in release in case the length does not fit we do not want to send data at all, then it is more obvious to the recipient something is wrong instead of only sending partial data
-            ORIGINAL_TYPE length = (input <= Frame::Max<NEW_TYPE>() ? input : 0);
+            NEW_TYPE length = 0;
 
-            PUSH_WARNING(DISABLE_WARNING_CONVERSION_POSSIBLE_LOSS_OF_DATA)
+            if (input <= std::numeric_limits<NEW_TYPE>::max()) {
+                length = int_cast<NEW_TYPE>(input);
+            }
 
-            return (static_cast<NEW_TYPE>(length));
-
-            POP_WARNING()
+            return (length);
         }
 
     }
@@ -347,7 +236,7 @@ namespace Core {
                 result = _container->GetBuffer<TYPENAME>(_offset, maxLength, buffer);
                 _offset += result;
 
-                return (static_cast<TYPENAME>(result - Frame::RealSize<TYPENAME>()));
+                return (static_cast<TYPENAME>(result - Core::RealSize<TYPENAME>()));
             }
             void Copy(const SIZE_CONTEXT length, uint8_t buffer[]) const
             {
@@ -654,9 +543,9 @@ namespace Core {
         template <typename TYPENAME>
         uint32_t SetBuffer(const SIZE_CONTEXT offset, const TYPENAME length, const uint8_t buffer[])
         {
-            SIZE_CONTEXT requiredLength(static_cast<SIZE_CONTEXT>(Frame::RealSize<TYPENAME>() + length));
+            SIZE_CONTEXT requiredLength(static_cast<SIZE_CONTEXT>(Core::RealSize<TYPENAME>() + length));
 
-            static_assert(Frame::RealSize<TYPENAME>() <= sizeof(SIZE_CONTEXT), "Make sure the logic can handle the size (enlarge the SIZE_CONTEXT)");
+            static_assert(Core::RealSize<TYPENAME>() <= sizeof(SIZE_CONTEXT), "Make sure the logic can handle the size (enlarge the SIZE_CONTEXT)");
 
             if ((offset + requiredLength) >= _size) {
                 Size(offset + requiredLength);
@@ -666,7 +555,7 @@ namespace Core {
 
             if (length != 0) {
                 ASSERT(buffer != nullptr);
-                ::memcpy(&(_data[offset + Frame::RealSize<TYPENAME>()]), buffer, length);
+                ::memcpy(&(_data[offset + Core::RealSize<TYPENAME>()]), buffer, length);
             }
 
             return (requiredLength);
@@ -714,42 +603,42 @@ namespace Core {
         {
             TYPENAME textLength;
 
-            ASSERT((offset + Frame::RealSize<TYPENAME>()) <= _size);
-            static_assert(Frame::RealSize<TYPENAME>() <= sizeof(SIZE_CONTEXT), "Make sure the logic can handle the size (enlarge the SIZE_CONTEXT)");
+            ASSERT((offset + Core::RealSize<TYPENAME>()) <= _size);
+            static_assert(Core::RealSize<TYPENAME>() <= sizeof(SIZE_CONTEXT), "Make sure the logic can handle the size (enlarge the SIZE_CONTEXT)");
 
             GetNumber<TYPENAME>(offset, textLength);
 
-            ASSERT((textLength + offset + Frame::RealSize<TYPENAME>()) <= _size);
+            ASSERT((textLength + offset + Core::RealSize<TYPENAME>()) <= _size);
 
-            if ((textLength + offset + Frame::RealSize<TYPENAME>()) > _size) {
-                textLength = (_size - (offset + Frame::RealSize<TYPENAME>()));
+            if ((textLength + offset + Core::RealSize<TYPENAME>()) > _size) {
+                textLength = (_size - (offset + Core::RealSize<TYPENAME>()));
             }
 
-            memcpy(buffer, &(_data[offset + Frame::RealSize<TYPENAME>()]), (textLength > length ? length : textLength));
+            memcpy(buffer, &(_data[offset + Core::RealSize<TYPENAME>()]), (textLength > length ? length : textLength));
 
-            return (static_cast<SIZE_CONTEXT>(Frame::RealSize<TYPENAME>() + textLength));
+            return (static_cast<SIZE_CONTEXT>(Core::RealSize<TYPENAME>() + textLength));
         }
 
         template <typename TYPENAME = uint16_t>
         SIZE_CONTEXT GetText(const SIZE_CONTEXT offset, string& result) const
         {
             TYPENAME textLength;
-            ASSERT((offset + Frame::RealSize<TYPENAME>()) <= _size);
-            static_assert(Frame::RealSize<TYPENAME>() <= sizeof(SIZE_CONTEXT), "Make sure the logic can handle the size (enlarge the SIZE_CONTEXT)");
+            ASSERT((offset + Core::RealSize<TYPENAME>()) <= _size);
+            static_assert(Core::RealSize<TYPENAME>() <= sizeof(SIZE_CONTEXT), "Make sure the logic can handle the size (enlarge the SIZE_CONTEXT)");
 
             GetNumber<TYPENAME>(offset, textLength);
 
-            ASSERT((textLength + offset + Frame::RealSize<TYPENAME>()) <= _size);
+            ASSERT((textLength + offset + Core::RealSize<TYPENAME>()) <= _size);
 
-            if (textLength + offset + Frame::RealSize<TYPENAME>() > _size) {
-                textLength = static_cast<TYPENAME>(_size - (offset + Frame::RealSize<TYPENAME>()));
+            if (textLength + offset + Core::RealSize<TYPENAME>() > _size) {
+                textLength = static_cast<TYPENAME>(_size - (offset + Core::RealSize<TYPENAME>()));
             }
 
-            std::string convertedText(reinterpret_cast<const char*>(&(_data[offset + Frame::RealSize<TYPENAME>()])), textLength);
+            std::string convertedText(reinterpret_cast<const char*>(&(_data[offset + Core::RealSize<TYPENAME>()])), textLength);
 
             result = Core::ToString(convertedText);
 
-            return (static_cast<SIZE_CONTEXT>(Frame::RealSize<TYPENAME>() + textLength));
+            return (static_cast<SIZE_CONTEXT>(Core::RealSize<TYPENAME>() + textLength));
         }
 
         SIZE_CONTEXT GetNullTerminatedText(const SIZE_CONTEXT offset, string& result) const
@@ -785,7 +674,7 @@ namespace Core {
             uint8_t index = 0;
             TYPENAME value = number;
 
-            static_assert(Frame::RealSize<TYPENAME>() <= ((sizeof(bytes) * 7) / 8), "Make sure the size is not too large (not much bigger than uint64_t)");
+            static_assert(Core::RealSize<TYPENAME>() <= ((sizeof(bytes) * 7) / 8), "Make sure the size is not too large (not much bigger than uint64_t)");
 
             do {
                 bytes[index++] = ( static_cast<uint8_t>(value % 128) | 0x80 );
@@ -796,7 +685,7 @@ namespace Core {
             bytes[index - 1] ^= 0x80;
 
             if ((offset + index) >= _size) {
-                Size(offset + Frame::RealSize<TYPENAME>());
+                Size(offset + Core::RealSize<TYPENAME>());
             }
 
             if ( (BIG_ENDIAN_ORDERING == true) && (index > 1) ) {
@@ -847,7 +736,7 @@ namespace Core {
                 index++;
             }
 
-            ASSERT(((index * 7) / 8) <= Frame::RealSize<TYPENAME>());
+            ASSERT(((index * 7) / 8) <= Core::RealSize<TYPENAME>());
 
             ++index;
 
@@ -868,13 +757,13 @@ namespace Core {
         template <typename TYPENAME>
         inline SIZE_CONTEXT SetNumber(const SIZE_CONTEXT offset, const TYPENAME number)
         {
-            return (SetNumber(offset, number, TemplateIntToType<Frame::RealSize<TYPENAME>() == 1>()));
+            return (SetNumber(offset, number, TemplateIntToType<Core::RealSize<TYPENAME>() == 1>()));
         }
 
         template <typename TYPENAME>
         inline SIZE_CONTEXT GetNumber(const SIZE_CONTEXT offset, TYPENAME& number) const
         {
-            return (GetNumber(offset, number, TemplateIntToType<Frame::RealSize<TYPENAME>() == 1>()));
+            return (GetNumber(offset, number, TemplateIntToType<Core::RealSize<TYPENAME>() == 1>()));
         }
 
 #ifdef __DEBUG__
@@ -912,9 +801,9 @@ namespace Core {
         template <typename TYPENAME>
         void SetNumberLittleEndianPlatform(const SIZE_CONTEXT offset, const TYPENAME number) {
             const uint8_t* source = reinterpret_cast<const uint8_t*>(&number);
-            uint8_t* destination = &(_data[offset + Frame::RealSize<TYPENAME>() - 1]);
+            uint8_t* destination = &(_data[offset + Core::RealSize<TYPENAME>() - 1]);
 
-            for (uint8_t index = 0; index < Frame::RealSize<TYPENAME>(); index++) {
+            for (uint8_t index = 0; index < Core::RealSize<TYPENAME>(); index++) {
                 *destination-- = *source++;
             }
         }
@@ -924,7 +813,7 @@ namespace Core {
             const uint8_t* source = reinterpret_cast<const uint8_t*>(&number);
             uint8_t* destination = &(_data[offset]);
 
-            for (uint8_t index = 0; index < Frame::RealSize<TYPENAME>(); index++) {
+            for (uint8_t index = 0; index < Core::RealSize<TYPENAME>(); index++) {
                 *destination++ = *source++;
             }
         }
@@ -933,8 +822,8 @@ namespace Core {
         template <typename TYPENAME>
         SIZE_CONTEXT SetNumber(const SIZE_CONTEXT offset, const TYPENAME number, const TemplateIntToType<false>&)
         {
-            if ((offset + Frame::RealSize<TYPENAME>()) >= _size) {
-                Size(offset + Frame::RealSize<TYPENAME>());
+            if ((offset + Core::RealSize<TYPENAME>()) >= _size) {
+                Size(offset + Core::RealSize<TYPENAME>());
             }
 
             if (BIG_ENDIAN_ORDERING == true) {
@@ -952,14 +841,14 @@ namespace Core {
 #endif
             }
 
-            return (Frame::RealSize<TYPENAME>());
+            return (Core::RealSize<TYPENAME>());
         }
 
         template <typename TYPENAME>
         SIZE_CONTEXT GetNumber(const SIZE_CONTEXT offset, TYPENAME& number, const TemplateIntToType<true>&) const
         {
             // Only on package level allowed to pass the boundaries!!!
-            ASSERT((offset + Frame::RealSize<TYPENAME>()) <= _size);
+            ASSERT((offset + Core::RealSize<TYPENAME>()) <= _size);
 
             number = static_cast<TYPENAME>(_data[offset]);
 
@@ -971,9 +860,9 @@ namespace Core {
         {
             TYPENAME result = static_cast<TYPENAME>(0);
             const uint8_t* source = &(_data[offset]);
-            uint8_t* destination = &(reinterpret_cast<uint8_t*>(&result)[Frame::RealSize<TYPENAME>() - 1]);
+            uint8_t* destination = &(reinterpret_cast<uint8_t*>(&result)[Core::RealSize<TYPENAME>() - 1]);
 
-            for (uint8_t index = 0; index < Frame::RealSize<TYPENAME>(); index++) {
+            for (uint8_t index = 0; index < Core::RealSize<TYPENAME>(); index++) {
                 *destination-- = *source++;
             }
 
@@ -989,7 +878,7 @@ namespace Core {
             const uint8_t* source = &(_data[offset]);
             uint8_t* destination = reinterpret_cast<uint8_t*>(&result);
 
-            for (uint8_t index = 0; index < Frame::RealSize<TYPENAME>(); index++) {
+            for (uint8_t index = 0; index < Core::RealSize<TYPENAME>(); index++) {
                 *destination++ = *source++;
             }
 
@@ -999,7 +888,7 @@ namespace Core {
         template <typename TYPENAME>
         inline SIZE_CONTEXT GetNumber(const SIZE_CONTEXT offset, TYPENAME& value, const TemplateIntToType<false>&) const
         {
-            if ((offset + Frame::RealSize<TYPENAME>()) > _size) {
+            if ((offset + Core::RealSize<TYPENAME>()) > _size) {
                 value = static_cast<TYPENAME>(0);
             }
             else if (BIG_ENDIAN_ORDERING == true) {
@@ -1017,7 +906,7 @@ namespace Core {
 #endif
             }
 
-            return (Frame::RealSize<TYPENAME>());
+            return (Core::RealSize<TYPENAME>());
         }
 
     private:

--- a/Source/core/ICustomErrorCode.h
+++ b/Source/core/ICustomErrorCode.h
@@ -18,7 +18,7 @@
  */
 
 /*
-    This file contains the interface that a library must implement in case the "custom error codes" feature is used in Thunder
+    This file contains the interface that a library can implement in case the "custom error codes" feature is used in Thunder and code to string comversion is desired
 */
 
 #pragma once
@@ -46,7 +46,7 @@ extern "C" {
 #include <stdint.h>
 #endif
 
-EXTERNAL const TCHAR* CustomCodeToSting(int32_t code);
+EXTERNAL const TCHAR* CustomCodeToSting(const int32_t code);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/Source/core/ICustomErrorCode.h
+++ b/Source/core/ICustomErrorCode.h
@@ -1,0 +1,53 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+    This file contains the interface that a library must implement in case the "custom error codes" feature is used in Thunder
+*/
+
+#pragma once
+
+#undef EXTERNAL
+
+#if defined(WIN32) || defined(_WINDOWS) || defined(__CYGWIN__) || defined(_WIN64)
+#define EXTERNAL __declspec(dllexport)
+#else
+#define EXTERNAL __attribute__((visibility("default")))
+#endif
+
+#ifndef TCHAR
+#ifdef _UNICODE
+#define TCHAR wchar_t
+#else
+#define TCHAR char
+#endif
+#endif
+
+#ifdef __cplusplus
+#include <cstdint>
+extern "C" {
+#else
+#include <stdint.h>
+#endif
+
+EXTERNAL const TCHAR* CustomCodeToSting(int32_t code);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif 

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -187,11 +187,17 @@ namespace Core {
                     default:
                         if ((frameworkError & COM_ERROR) != 0) {
                             Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError & 0x7FFFFFFF) - 500;
-                        } else if ((frameworkError & CUSTOM_ERROR) != 0) {
-                            int24_t custumcode(frameworkError & 0xFFFFFF); // remove custom error bit before assigning
-                            Code = custumcode;
                         } else {
-                            Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                            int32_t customcode = IsCustomCode(frameworkError);
+                            if (customcode != 0) {
+                                Code = (customcode == std::numeric_limits<int32_t>::min() ? 0 : customcode);
+                            } else {
+#endif
+                                Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                            }
+#endif
                         }
 
                         if (Text.IsSet() == false) {

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -185,14 +185,17 @@ namespace Core {
                         Text = _T("The operation is not supported.");
                         break;
                     default:
-                        if ((frameworkError & 0x80000000) == 0) {
-                            Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);
-                        } else {
+                        if ((frameworkError & COM_ERROR) != 0) {
                             Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError & 0x7FFFFFFF) - 500;
+                        } else if ((frameworkError & CUSTOM_ERROR) != 0) {
+                            int24_t custumcode(frameworkError & 0xFFFFFF); // remove custom error bit before assigning
+                            Code = custumcode;
+                        } else {
+                            Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);
                         }
 
                         if (Text.IsSet() == false) {
-                            Text = Core::ErrorToString(frameworkError);
+                            Text = Core::ErrorToStringExtended(frameworkError);
                         }
                         break;
                     }

--- a/Source/core/Number.h
+++ b/Source/core/Number.h
@@ -1274,6 +1274,9 @@ public:
 
 } // namespace std
 
+using uint24_t = Thunder::Core::UInt24;
+using int24_t = Thunder::Core::SInt24;
+
 template <typename NEW_TYPE, typename ORIGINAL_TYPE>
 NEW_TYPE int_cast(const ORIGINAL_TYPE& input)
 {

--- a/Source/core/Number.h
+++ b/Source/core/Number.h
@@ -25,6 +25,8 @@
 #include "TextFragment.h"
 #include "TypeTraits.h"
 
+#include <limits>
+
 namespace Thunder {
 namespace Core {
     extern "C" {
@@ -1049,15 +1051,207 @@ namespace Core {
         uint8_t _size;
     };
 
-}
+    class SInt24 {
+    public:
+        static constexpr uint8_t SizeOf = 3;
+        static constexpr uint32_t Max = 0x7FFFFF;
+        static constexpr int32_t Min = 0xFF800000;
+
+        using InternalType = int32_t;
+
+        SInt24()
+            : _value(0)
+        {
+        }
+        SInt24(const int32_t value)
+            : _value(value | (value & 0x800000 ? 0xFF000000 : 0))
+        {
+            ASSERT(((static_cast<uint32_t>(value) >> 24) == 0) || ((static_cast<uint32_t>(value) >> 24) == 0xFF));
+        }
+        SInt24(const SInt24&) = default;
+        SInt24(SInt24&&) = default;
+        ~SInt24() = default;
+
+    public:
+        SInt24& operator=(const SInt24& value) = default;
+        SInt24& operator=(SInt24&& value) = default;
+        SInt24& operator=(const int32_t value)
+        {
+            ASSERT(((static_cast<uint32_t>(value) >> 24) == 0) || ((static_cast<uint32_t>(value) >> 24) == 0xFF));
+            _value = (value | (value & 0x800000 ? 0xFF000000 : 0));
+            return (*this);
+        }
+        operator int32_t() const
+        {
+            return (_value);
+        }
+
+    private:
+        int32_t _value;
+    };
+
+    class UInt24 {
+    public:
+        static constexpr uint8_t SizeOf = 3;
+        static constexpr uint32_t Max = 0xFFFFFF;
+        static constexpr uint32_t Min = 0;
+
+        using InternalType = uint32_t;
+
+        UInt24()
+            : _value(0)
+        {
+        }
+        UInt24(const UInt24& value) = default;
+        UInt24(UInt24&& value) = default;
+        UInt24(const uint32_t value)
+            : _value(value)
+        {
+            ASSERT((value >> 24) == 0);
+        }
+        ~UInt24() = default;
+
+    public:
+        UInt24& operator=(const UInt24& copy) = default;
+        UInt24& operator=(UInt24&& move) = default;
+        UInt24& operator=(const uint32_t value)
+        {
+            ASSERT((value >> 24) == 0);
+            _value = value;
+            return (*this);
+        }
+        operator uint32_t() const
+        {
+            return (_value);
+        }
+
+    private:
+        uint32_t _value;
+    };
+
+    template <typename T, typename std::enable_if<std::is_scalar<T>::value, int>::type = 0>
+    static constexpr uint8_t RealSize()
+    {
+        return (sizeof(T));
+    }
+    template <typename T, typename std::enable_if<T::SizeOf != 0, int>::type = 0>
+    static constexpr uint8_t RealSize()
+    {
+        return (T::SizeOf);
+    }
+
 } // namespace Core
+} // namespace Thunder
+
+namespace std { // seems to be allowed/mandatory to specialize inside the std namespace
+
+template <>
+class numeric_limits<Thunder::Core::SInt24> {
+
+public:
+    static constexpr bool is_specialized = true;
+
+    static constexpr Thunder::Core::SInt24::InternalType min() noexcept { return Thunder::Core::SInt24::Min; }
+    static constexpr Thunder::Core::SInt24::InternalType max() noexcept { return Thunder::Core::SInt24::Max; }
+    static constexpr Thunder::Core::SInt24::InternalType lowest() noexcept { return min(); }
+
+    static constexpr int digits = 23;
+    static constexpr int digits10 = 6;
+    static constexpr int max_digits10 = 0;
+
+    static constexpr bool is_signed = true;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr int radix = 2;
+
+    static constexpr Thunder::Core::SInt24::InternalType epsilon() noexcept { return 0; }
+    static constexpr Thunder::Core::SInt24::InternalType round_error() noexcept { return 0; }
+
+    static constexpr int min_exponent = 0;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 0;
+    static constexpr int max_exponent10 = 0;
+
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
+    static constexpr bool has_denorm_loss = false;
+
+    static constexpr Thunder::Core::SInt24::InternalType infinity() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+    static constexpr Thunder::Core::SInt24::InternalType quiet_NaN() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+    static constexpr Thunder::Core::SInt24::InternalType signaling_NaN() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+    static constexpr Thunder::Core::SInt24::InternalType denorm_min() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
+
+    static constexpr bool traps = true;
+    static constexpr bool tinyness_before = false;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
+};
+
+template <>
+class numeric_limits<Thunder::Core::UInt24> {
+
+public:
+    static constexpr bool is_specialized = true;
+
+    static constexpr Thunder::Core::UInt24::InternalType min() noexcept { return Thunder::Core::UInt24::Min; }
+    static constexpr Thunder::Core::UInt24::InternalType max() noexcept { return Thunder::Core::UInt24::Max; }
+    static constexpr Thunder::Core::UInt24::InternalType lowest() noexcept { return min(); }
+
+    static constexpr int digits = 24;
+    static constexpr int digits10 = 7;
+    static constexpr int max_digits10 = 0;
+
+    static constexpr bool is_signed = false;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr int radix = 2;
+
+    static constexpr Thunder::Core::UInt24::InternalType epsilon() noexcept { return 0; }
+    static constexpr Thunder::Core::UInt24::InternalType round_error() noexcept { return 0; }
+
+    static constexpr int min_exponent = 0;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 0;
+    static constexpr int max_exponent10 = 0;
+
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
+    static constexpr bool has_denorm_loss = false;
+
+    static constexpr Thunder::Core::UInt24::InternalType infinity() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+    static constexpr Thunder::Core::UInt24::InternalType quiet_NaN() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+    static constexpr Thunder::Core::UInt24::InternalType signaling_NaN() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+    static constexpr Thunder::Core::UInt24::InternalType denorm_min() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = true;
+
+    static constexpr bool traps = true;
+    static constexpr bool tinyness_before = false;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
+};
+
+} // namespace std
 
 template <typename NEW_TYPE, typename ORIGINAL_TYPE>
 NEW_TYPE int_cast(const ORIGINAL_TYPE& input)
 {
     ASSERT(input <= std::numeric_limits<NEW_TYPE>::max());
     ASSERT(input >= std::numeric_limits<NEW_TYPE>::min());
+
+    PUSH_WARNING(DISABLE_WARNING_CONVERSION_POSSIBLE_LOSS_OF_DATA)
+
     return (static_cast<NEW_TYPE>(input));
+
+    POP_WARNING()
 }
 
 #endif // __NUMBER_H

--- a/Source/core/Number.h
+++ b/Source/core/Number.h
@@ -1086,6 +1086,11 @@ namespace Core {
             return (_value);
         }
 
+        int32_t AsSInt24() const
+        {
+            return (_value & 0xFFFFFF);
+        }
+
     private:
         int32_t _value;
     };
@@ -1125,6 +1130,11 @@ namespace Core {
             return (_value);
         }
 
+        uint32_t AsUInt24() const // just to be consistent with SInt24
+        {
+            return (_value & 0xFFFFFF); // in debug assert should already have fired on assignment
+        }
+
     private:
         uint32_t _value;
     };
@@ -1138,6 +1148,29 @@ namespace Core {
     static constexpr uint8_t RealSize()
     {
         return (T::SizeOf);
+    }
+        
+    template <typename NEW_TYPE, typename ORIGINAL_TYPE>
+    bool check_and_cast(const ORIGINAL_TYPE& input, NEW_TYPE& output)
+    {
+        ASSERT(input <= std::numeric_limits<NEW_TYPE>::max());
+        ASSERT(input >= std::numeric_limits<NEW_TYPE>::min());
+
+        bool success = false;
+
+        if ((input <= std::numeric_limits<NEW_TYPE>::max()) && (input >= std::numeric_limits<NEW_TYPE>::min())) {
+
+            success = true;
+
+            PUSH_WARNING(DISABLE_WARNING_CONVERSION_POSSIBLE_LOSS_OF_DATA)
+
+            output = static_cast<NEW_TYPE>(input);
+
+            POP_WARNING()
+        }
+
+        return success;
+
     }
 
 } // namespace Core

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -467,7 +467,7 @@ namespace {
 
     static CustomCodeToStringHandler customerrorcodehandler = nullptr;
 
-    const TCHAR* HandleCustomErrorCodeToString(int32_t customcode)
+    const TCHAR* HandleCustomErrorCodeToString(const int32_t customcode)
     {
         const TCHAR* text = nullptr;
 
@@ -480,7 +480,7 @@ namespace {
         return text;
     }
 
-    string HandleCustomErrorCodeToStringExtended(int32_t customcode)
+    string HandleCustomErrorCodeToStringExtended(const int32_t customcode)
     {
         string result;
 
@@ -501,9 +501,9 @@ namespace {
         customerrorcodehandler = handler;
     }
 
-    hresult CustomCode(int32_t customCode) {
+    hresult CustomCode(const int32_t customCode) {
 
-        static_assert(CUSTOM_ERROR == 0x1000000, "Static assert to be assumed 25th bit in code below");
+        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
 
         hresult result = Core::ERROR_NONE;
 
@@ -520,8 +520,8 @@ namespace {
         return result;
     }
 
-    int32_t IsCustomCode(Core::hresult code) {
-        static_assert(CUSTOM_ERROR == 0x1000000, "Static assert to be assumed 25th bit in code below");
+    int32_t IsCustomCode(const Core::hresult code) {
+        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
 
         int32_t result = 0;
 
@@ -538,7 +538,7 @@ namespace {
 
 #endif
 
-    const TCHAR* ErrorToString(Core::hresult code)
+    const TCHAR* ErrorToString(const Core::hresult code)
     {
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
         int32_t customcode = IsCustomCode(code);
@@ -550,7 +550,7 @@ namespace {
         return _bogus_ErrorToString<>(code & (~COM_ERROR));
     }
 
-    string ErrorToStringExtended(Core::hresult code)
+    string ErrorToStringExtended(const Core::hresult code)
     {
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
         int32_t customcode = IsCustomCode(code);

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -559,7 +559,12 @@ namespace {
             return HandleCustomErrorCodeToStringExtended(customcode);
         }
 #endif
-        return _bogus_ErrorToString<>(code & (~COM_ERROR));
+        string result = _bogus_ErrorToString<>(code & (~COM_ERROR));
+
+        if (result.empty() == true) {
+            result = _T("Undefined Thunder error code: ") + Core::NumberType<Core::hresult>(code).Text();
+        }
+        return result;
     }
 
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -1007,8 +1007,6 @@ namespace Core {
 
     #undef ERROR_CODE
 
-    // Convert error enumerations to string
-
     template<uint32_t N>
     inline const TCHAR* _Err2Str()
     {
@@ -1032,10 +1030,16 @@ namespace Core {
         return (code == 0? _Err2Str<0u>() : _Err2Str<~0u>());
     };
 
-    inline const TCHAR* ErrorToString(Core::hresult code)
-    {
-        return _bogus_ErrorToString<>(code & (~COM_ERROR));
-    }
+    EXTERNAL string ErrorToString(Core::hresult code);
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+    using CustomCodeToStringHandler = const TCHAR* (*)(int32_t code);
+
+    // can only set one, not multithreaded safe
+    EXTERNAL void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler);
+
+#endif
 
     #undef ERROR_CODE
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -1030,7 +1030,8 @@ namespace Core {
         return (code == 0? _Err2Str<0u>() : _Err2Str<~0u>());
     };
 
-    EXTERNAL string ErrorToString(Core::hresult code);
+    EXTERNAL const TCHAR* ErrorToString(Core::hresult code);
+    EXTERNAL string ErrorToStringExtended(Core::hresult code);
 
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -931,9 +931,9 @@ namespace Core {
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
 
     // transform a custum code into an hresult
-    EXTERNAL Core::hresult CustomCode(int32_t customCode);
+    EXTERNAL Core::hresult CustomCode(const int32_t customCode);
     // query if the hresult is a custom code and if so extract the value, returns 0 if the hresult was not a custom code
-    EXTERNAL int32_t IsCustomCode(Core::hresult code);
+    EXTERNAL int32_t IsCustomCode(const Core::hresult code);
 
 #endif
 
@@ -1007,6 +1007,8 @@ namespace Core {
 
     #undef ERROR_CODE
 
+    // Convert error enumerations to string
+
     template<uint32_t N>
     inline const TCHAR* _Err2Str()
     {
@@ -1030,12 +1032,12 @@ namespace Core {
         return (code == 0? _Err2Str<0u>() : _Err2Str<~0u>());
     };
 
-    EXTERNAL const TCHAR* ErrorToString(Core::hresult code);
-    EXTERNAL string ErrorToStringExtended(Core::hresult code);
+    EXTERNAL const TCHAR* ErrorToString(const Core::hresult code);
+    EXTERNAL string ErrorToStringExtended(const Core::hresult code);
 
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
 
-    using CustomCodeToStringHandler = const TCHAR* (*)(int32_t code);
+    using CustomCodeToStringHandler = const TCHAR* (*)(const int32_t code);
 
     // can only set one, not multithreaded safe
     EXTERNAL void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler);

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -926,6 +926,16 @@ namespace Core {
     }
 
     #define COM_ERROR (0x80000000)
+    #define CUSTOM_ERROR (0x1000000)
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+    // transform a custum code into an hresult
+    EXTERNAL Core::hresult CustomCode(int32_t customCode);
+    // query if the hresult is a custom code and if so extract the value, returns 0 if the hresult was not a custom code
+    EXTERNAL int32_t IsCustomCode(Core::hresult code);
+
+#endif
 
     #define ERROR_CODES \
         ERROR_CODE(ERROR_NONE, 0) \


### PR DESCRIPTION
[DependsOn=ThunderTools:development/MoveSomeFrameCodeToNumbers]

Add support for Custom (Error) Codes next to the Thunder predefined ones

Note: will be in COMPLEMENTARY_CODE_SET section

Fully backwards compatible.
Tested both on Linux and Windows
Example of feature added to ThunderNanoServices ()

Note related ThunderTools PR: https://github.com/rdkcentral/ThunderTools/pull/210