### PR TITLE
Development/custom codes2

### DIFF
--- a/Source/core/AccessControl.h
+++ b/Source/core/AccessControl.h
@@ -22,6 +22,7 @@
 #include "Module.h"
 #include "NodeId.h"
 #include "Portability.h"
+#include "Errors.h"
 
 #ifdef __POSIX__
 #include <grp.h>

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(${TARGET}
         WorkerPool.cpp
         XGetopt.cpp
         ResourceMonitor.cpp
+        Errors.cpp
         )
 
 #TODO: Remove all non public headers from this list,
@@ -151,6 +152,8 @@ set(PUBLIC_HEADERS
         TokenizedStringList.h
         MessageStore.h
         ICustomErrorCode.h
+        Errors.h
+        ExtraNumberDefinitions.h
         ${CMAKE_CURRENT_BINARY_DIR}/generated/core/Version.h
         )
 

--- a/Source/core/Errors.cpp
+++ b/Source/core/Errors.cpp
@@ -1,0 +1,135 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+#include "Errors.h"
+#include "Number.h"
+
+namespace Thunder {
+
+namespace Core {
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+namespace {
+
+    static CustomCodeToStringHandler customerrorcodehandler = nullptr;
+
+    const TCHAR* HandleCustomErrorCodeToString(const int32_t customcode)
+    {
+        const TCHAR* text = nullptr;
+
+        if (customcode == std::numeric_limits<int32_t>::max()) {
+            text = _T("Invalid Custom ErrorCode set");
+        } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
+            text = _T("Undefined Custom Error");
+        } 
+
+        return text;
+    }
+
+    string HandleCustomErrorCodeToStringExtended(const int32_t customcode)
+    {
+        string result;
+
+        const TCHAR* text = nullptr;
+        if (customcode == std::numeric_limits<int32_t>::max()) {
+            result = _T("Invalid Custom ErrorCode set");
+        } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
+            result = _T("Undefined Custom Error: ") + Core::NumberType<int32_t>(customcode).Text();
+        } else {
+            result = text;
+        }
+
+        return result;
+    }
+
+}
+    void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler) {
+        customerrorcodehandler = handler;
+    }
+
+    hresult CustomCode(const int24_t customCode)
+    {
+        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
+
+        hresult result = Core::ERROR_NONE;
+
+        if (customCode != 0) {
+            if (Core::Overflowed(customCode) == false) {
+                result = static_cast<hresult>(customCode.AsSInt24());
+            } else {
+                result = 0; // set invalid customCode result;
+            }
+            result |= CUSTOM_ERROR; // set custom code bit
+        }
+
+        return result;
+    }
+
+    int24_t IsCustomCode(const Core::hresult code)
+    {
+        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
+
+        int24_t result = 0;
+
+        if ((code & CUSTOM_ERROR) != 0) {
+            result = static_cast<uint32_t>(code & 0xFFFFFF); // remove custom error bit before assigning
+            if (result == 0) {
+                result = std::numeric_limits<int32_t>::max(); // this will assert in debug, but if that happens one managed to fill an hresult with an overflowed core result, that should have asserted already when using CustomCode to fill it, os this is probably caused by either manually incorrectly filling the hresult or memory corruption
+            }
+        }
+
+        return result;
+    }
+
+#endif
+
+    const TCHAR* ErrorToString(const Core::hresult code)
+    {
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        int24_t customcode = IsCustomCode(code);
+
+        if (customcode != 0) {
+            return HandleCustomErrorCodeToString(customcode);
+        }
+#endif
+        return _bogus_ErrorToString<>(code & (~COM_ERROR));
+    }
+
+    string ErrorToStringExtended(const Core::hresult code)
+    {
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        int24_t customcode = IsCustomCode(code);
+
+        if (customcode != 0) {
+            return HandleCustomErrorCodeToStringExtended(customcode);
+        }
+#endif
+        string result = _bogus_ErrorToString<>(code & (~COM_ERROR));
+
+        if (result.empty() == true) {
+            result = _T("Undefined Thunder error code: ") + Core::NumberType<Core::hresult>(code).Text();
+        }
+        return result;
+    }
+
+
+} // namespace Core
+} // namespace Thunder

--- a/Source/core/Errors.h
+++ b/Source/core/Errors.h
@@ -1,0 +1,152 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+#include "ExtraNumberDefinitions.h"
+
+#define COM_ERROR (0x80000000)
+#define CUSTOM_ERROR (0x1000000)
+
+namespace Thunder {
+namespace Core {
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+    // transform a custum code into an hresult
+    EXTERNAL Core::hresult CustomCode(const int24_t customCode);
+    // query if the hresult is a custom code and if so extract the value, returns 0 if the hresult was not a custom code
+    EXTERNAL int24_t IsCustomCode(const Core::hresult code);
+
+#endif
+
+    #define ERROR_CODES \
+        ERROR_CODE(ERROR_NONE, 0) \
+        ERROR_CODE(ERROR_GENERAL, 1) \
+        ERROR_CODE(ERROR_UNAVAILABLE, 2) \
+        ERROR_CODE(ERROR_ASYNC_FAILED, 3) \
+        ERROR_CODE(ERROR_ASYNC_ABORTED, 4) \
+        ERROR_CODE(ERROR_ILLEGAL_STATE, 5) \
+        ERROR_CODE(ERROR_OPENING_FAILED, 6) \
+        ERROR_CODE(ERROR_ACCEPT_FAILED, 7) \
+        ERROR_CODE(ERROR_PENDING_SHUTDOWN, 8) \
+        ERROR_CODE(ERROR_ALREADY_CONNECTED, 9) \
+        ERROR_CODE(ERROR_CONNECTION_CLOSED, 10) \
+        ERROR_CODE(ERROR_TIMEDOUT, 11) \
+        ERROR_CODE(ERROR_INPROGRESS, 12) \
+        ERROR_CODE(ERROR_COULD_NOT_SET_ADDRESS, 13) \
+        ERROR_CODE(ERROR_INCORRECT_HASH, 14) \
+        ERROR_CODE(ERROR_INCORRECT_URL, 15) \
+        ERROR_CODE(ERROR_INVALID_INPUT_LENGTH, 16) \
+        ERROR_CODE(ERROR_DESTRUCTION_SUCCEEDED, 17) \
+        ERROR_CODE(ERROR_DESTRUCTION_FAILED, 18) \
+        ERROR_CODE(ERROR_CLOSING_FAILED, 19) \
+        ERROR_CODE(ERROR_PROCESS_TERMINATED, 20) \
+        ERROR_CODE(ERROR_PROCESS_KILLED, 21) \
+        ERROR_CODE(ERROR_UNKNOWN_KEY, 22) \
+        ERROR_CODE(ERROR_INCOMPLETE_CONFIG, 23) \
+        ERROR_CODE(ERROR_PRIVILIGED_REQUEST, 24) \
+        ERROR_CODE(ERROR_RPC_CALL_FAILED, 25) \
+        ERROR_CODE(ERROR_UNREACHABLE_NETWORK, 26) \
+        ERROR_CODE(ERROR_REQUEST_SUBMITTED, 27) \
+        ERROR_CODE(ERROR_UNKNOWN_TABLE, 28) \
+        ERROR_CODE(ERROR_DUPLICATE_KEY, 29) \
+        ERROR_CODE(ERROR_BAD_REQUEST, 30) \
+        ERROR_CODE(ERROR_PENDING_CONDITIONS, 31) \
+        ERROR_CODE(ERROR_SURFACE_UNAVAILABLE, 32) \
+        ERROR_CODE(ERROR_PLAYER_UNAVAILABLE, 33) \
+        ERROR_CODE(ERROR_FIRST_RESOURCE_NOT_FOUND, 34) \
+        ERROR_CODE(ERROR_SECOND_RESOURCE_NOT_FOUND, 35) \
+        ERROR_CODE(ERROR_ALREADY_RELEASED, 36) \
+        ERROR_CODE(ERROR_NEGATIVE_ACKNOWLEDGE, 37) \
+        ERROR_CODE(ERROR_INVALID_SIGNATURE, 38) \
+        ERROR_CODE(ERROR_READ_ERROR, 39) \
+        ERROR_CODE(ERROR_WRITE_ERROR, 40) \
+        ERROR_CODE(ERROR_INVALID_DESIGNATOR, 41) \
+        ERROR_CODE(ERROR_UNAUTHENTICATED, 42) \
+        ERROR_CODE(ERROR_NOT_EXIST, 43) \
+        ERROR_CODE(ERROR_NOT_SUPPORTED, 44) \
+        ERROR_CODE(ERROR_INVALID_RANGE, 45) \
+        ERROR_CODE(ERROR_HIBERNATED, 46) \
+        ERROR_CODE(ERROR_INPROC, 47) \
+        ERROR_CODE(ERROR_FAILED_REGISTERED, 48) \
+        ERROR_CODE(ERROR_FAILED_UNREGISTERED, 49) \
+        ERROR_CODE(ERROR_PARSE_FAILURE, 50) \
+        ERROR_CODE(ERROR_PRIVILIGED_DEFERRED, 51) \
+        ERROR_CODE(ERROR_INVALID_ENVELOPPE, 52) \
+        ERROR_CODE(ERROR_UNKNOWN_METHOD, 53) \
+        ERROR_CODE(ERROR_INVALID_PARAMETER, 54) \
+        ERROR_CODE(ERROR_INTERNAL_JSONRPC, 55) \
+        ERROR_CODE(ERROR_PARSING_ENVELOPPE, 56) \
+        ERROR_CODE(ERROR_COMPOSIT_OBJECT, 57) \
+        ERROR_CODE(ERROR_ABORTED, 58)
+
+    #define ERROR_CODE(CODE, VALUE) CODE = VALUE,
+
+    enum ErrorCodes {
+        ERROR_CODES
+        ERROR_COUNT
+    };
+
+    #undef ERROR_CODE
+
+    // Convert error enumerations to string
+
+    template<uint32_t N>
+    inline const TCHAR* _Err2Str()
+    {
+        return _T("");
+    };
+
+    #define ERROR_CODE(CODE, VALUE) \
+        template<> inline const TCHAR* _Err2Str<VALUE>() { return _T(#CODE); }
+
+    ERROR_CODES;
+
+    #undef ERROR_CODE
+
+    template<uint32_t N = (ERROR_COUNT - 1)>
+    inline const TCHAR* _bogus_ErrorToString(uint32_t code)
+    {
+        return (code == N? _Err2Str<N>() : _bogus_ErrorToString<N-1>(code));
+    };
+
+    template<>
+    inline const TCHAR* _bogus_ErrorToString<0u>(uint32_t code)
+    {
+        return (code == 0? _Err2Str<0u>() : _Err2Str<~0u>());
+    };
+
+    EXTERNAL const TCHAR* ErrorToString(const Core::hresult code);
+    EXTERNAL string ErrorToStringExtended(const Core::hresult code);
+
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+    using CustomCodeToStringHandler = const TCHAR* (*)(const int32_t code);
+
+    // can only set one, not multithreaded safe
+    EXTERNAL void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler);
+
+#endif
+
+    
+}
+}
+

--- a/Source/core/ExtraNumberDefinitions.h
+++ b/Source/core/ExtraNumberDefinitions.h
@@ -1,0 +1,249 @@
+ /*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#pragma once
+
+// note does not include Module.h for now as that also would drag in Portability.h (and we do not need Module.h here for now)
+
+#include "Module.h"
+#include "Trace.h"
+
+#include <limits>
+
+namespace Thunder {
+namespace Core {
+
+    class SInt24 {
+    public:
+        static constexpr uint8_t SizeOf = 3;
+        static constexpr uint32_t Max = 0x7FFFFF;
+        static constexpr int32_t Min = 0xFF800000;
+
+        using InternalType = int32_t;
+
+        SInt24()
+            : _value(0)
+        {
+        }
+        SInt24(const int32_t value)
+            : _value(value | (value & 0x800000 ? 0xFF000000 : 0))
+        {
+            bool overflow = ((static_cast<uint32_t>(value) >> 24) != 0) && ((static_cast<uint32_t>(value) >> 24) != 0xFF);
+            ASSERT(overflow == false);
+            if (overflow == true) {
+                _value = std::numeric_limits<int32_t>::max();
+            }
+        }
+        SInt24(const SInt24&) = default;
+        SInt24(SInt24&&) = default;
+        ~SInt24() = default;
+
+    public:
+        SInt24& operator=(const SInt24& value) = default;
+        SInt24& operator=(SInt24&& value) = default;
+        SInt24& operator=(const int32_t value)
+        {
+            _value = (value | (value & 0x800000 ? 0xFF000000 : 0));
+            bool overflow = ((static_cast<uint32_t>(value) >> 24) != 0) && ((static_cast<uint32_t>(value) >> 24) != 0xFF);
+            ASSERT(overflow == false);
+            if (overflow == true) {
+                _value = std::numeric_limits<int32_t>::max();
+            }
+            return (*this);
+        }
+        operator int32_t() const
+        {
+            return (_value);
+        }
+
+        int32_t AsSInt24() const
+        {
+            return (_value & 0xFFFFFF);
+        }
+
+        bool Overflowed() const {
+            return (_value == std::numeric_limits<int32_t>::max());
+        }
+
+    private:
+        int32_t _value;
+    };
+
+    class UInt24 {
+    public:
+        static constexpr uint8_t SizeOf = 3;
+        static constexpr uint32_t Max = 0xFFFFFF;
+        static constexpr uint32_t Min = 0;
+
+        using InternalType = uint32_t;
+
+        UInt24()
+            : _value(0)
+        {
+        }
+        UInt24(const UInt24& value) = default;
+        UInt24(UInt24&& value) = default;
+        UInt24(const uint32_t value)
+            : _value(value)
+        {
+            bool overflow = ((value >> 24) != 0);
+            ASSERT(overflow == false);
+            if (overflow == true) {
+                _value = std::numeric_limits<int32_t>::max();
+            }
+        }
+        ~UInt24() = default;
+
+    public:
+        UInt24& operator=(const UInt24& copy) = default;
+        UInt24& operator=(UInt24&& move) = default;
+        UInt24& operator=(const uint32_t value)
+        {
+            bool overflow = ((value >> 24) != 0);
+            ASSERT(overflow == false);
+            if (overflow == false) {
+                _value = value;
+            } else {
+                _value = std::numeric_limits<int32_t>::max();
+            }
+            return (*this);
+        }
+        operator uint32_t() const
+        {
+            return (_value);
+        }
+
+        uint32_t AsUInt24() const // just to be consistent with SInt24
+        {
+            return (_value & 0xFFFFFF); // in debug assert should already have fired on assignment
+        }
+
+        bool Overflowed() const
+        {
+            return (_value == std::numeric_limits<int32_t>::max());
+        }
+
+    private:
+        uint32_t _value;
+    };
+
+} // namespace Core
+} // namespace Thunder
+
+namespace std { // seems to be allowed/mandatory to specialize inside the std namespace
+
+template <>
+class numeric_limits<Thunder::Core::SInt24> {
+
+public:
+    static constexpr bool is_specialized = true;
+
+    static constexpr Thunder::Core::SInt24::InternalType min() noexcept { return Thunder::Core::SInt24::Min; }
+    static constexpr Thunder::Core::SInt24::InternalType max() noexcept { return Thunder::Core::SInt24::Max; }
+    static constexpr Thunder::Core::SInt24::InternalType lowest() noexcept { return min(); }
+
+    static constexpr int digits = 23;
+    static constexpr int digits10 = 6;
+    static constexpr int max_digits10 = 0;
+
+    static constexpr bool is_signed = true;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr int radix = 2;
+
+    static constexpr Thunder::Core::SInt24::InternalType epsilon() noexcept { return 0; }
+    static constexpr Thunder::Core::SInt24::InternalType round_error() noexcept { return 0; }
+
+    static constexpr int min_exponent = 0;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 0;
+    static constexpr int max_exponent10 = 0;
+
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
+    static constexpr bool has_denorm_loss = false;
+
+    static constexpr Thunder::Core::SInt24::InternalType infinity() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+    static constexpr Thunder::Core::SInt24::InternalType quiet_NaN() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+    static constexpr Thunder::Core::SInt24::InternalType signaling_NaN() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+    static constexpr Thunder::Core::SInt24::InternalType denorm_min() noexcept { return static_cast<Thunder::Core::SInt24::InternalType>(0); }
+
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
+
+    static constexpr bool traps = true;
+    static constexpr bool tinyness_before = false;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
+};
+
+template <>
+class numeric_limits<Thunder::Core::UInt24> {
+
+public:
+    static constexpr bool is_specialized = true;
+
+    static constexpr Thunder::Core::UInt24::InternalType min() noexcept { return Thunder::Core::UInt24::Min; }
+    static constexpr Thunder::Core::UInt24::InternalType max() noexcept { return Thunder::Core::UInt24::Max; }
+    static constexpr Thunder::Core::UInt24::InternalType lowest() noexcept { return min(); }
+
+    static constexpr int digits = 24;
+    static constexpr int digits10 = 7;
+    static constexpr int max_digits10 = 0;
+
+    static constexpr bool is_signed = false;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr int radix = 2;
+
+    static constexpr Thunder::Core::UInt24::InternalType epsilon() noexcept { return 0; }
+    static constexpr Thunder::Core::UInt24::InternalType round_error() noexcept { return 0; }
+
+    static constexpr int min_exponent = 0;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 0;
+    static constexpr int max_exponent10 = 0;
+
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
+    static constexpr bool has_denorm_loss = false;
+
+    static constexpr Thunder::Core::UInt24::InternalType infinity() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+    static constexpr Thunder::Core::UInt24::InternalType quiet_NaN() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+    static constexpr Thunder::Core::UInt24::InternalType signaling_NaN() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+    static constexpr Thunder::Core::UInt24::InternalType denorm_min() noexcept { return static_cast<Thunder::Core::UInt24::InternalType>(0); }
+
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = true;
+
+    static constexpr bool traps = true;
+    static constexpr bool tinyness_before = false;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
+};
+
+} // namespace std
+
+//using uint24_t = Thunder::Core::UInt24;
+//using int24_t = Thunder::Core::SInt24;
+

--- a/Source/core/ExtraNumberDefinitions.h
+++ b/Source/core/ExtraNumberDefinitions.h
@@ -42,9 +42,19 @@ namespace Core {
         {
         }
         SInt24(const int32_t value)
+            : _value(value)
+        {
+            bool overflow = ((static_cast<uint32_t>(value) >> 23) != 0) && ((static_cast<uint32_t>(value) >> 23) != 0x1FF);
+            ASSERT(overflow == false);
+            if (overflow == true) {
+                _value = std::numeric_limits<int32_t>::max();
+            }
+        }
+        // if it is an uint32_t it considered a 24 bit only filled value
+        SInt24(const uint32_t value)
             : _value(value | (value & 0x800000 ? 0xFF000000 : 0))
         {
-            bool overflow = ((static_cast<uint32_t>(value) >> 24) != 0) && ((static_cast<uint32_t>(value) >> 24) != 0xFF);
+            bool overflow = ((static_cast<uint32_t>(value) >> 23) != 0) && ((static_cast<uint32_t>(value) >> 23) != 0x1);
             ASSERT(overflow == false);
             if (overflow == true) {
                 _value = std::numeric_limits<int32_t>::max();
@@ -59,8 +69,19 @@ namespace Core {
         SInt24& operator=(SInt24&& value) = default;
         SInt24& operator=(const int32_t value)
         {
+            _value = value;
+            bool overflow = ((static_cast<uint32_t>(value) >> 23) != 0) && ((static_cast<uint32_t>(value) >> 23) != 0x1FF);
+            ASSERT(overflow == false);
+            if (overflow == true) {
+                _value = std::numeric_limits<int32_t>::max();
+            }
+            return (*this);
+        }
+        // if it is an uint32_t it considered a 24 bit only filled value
+        SInt24& operator=(const uint32_t value)
+        {
             _value = (value | (value & 0x800000 ? 0xFF000000 : 0));
-            bool overflow = ((static_cast<uint32_t>(value) >> 24) != 0) && ((static_cast<uint32_t>(value) >> 24) != 0xFF);
+            bool overflow = ((static_cast<uint32_t>(value) >> 23) != 0) && ((static_cast<uint32_t>(value) >> 23) != 0x1);
             ASSERT(overflow == false);
             if (overflow == true) {
                 _value = std::numeric_limits<int32_t>::max();
@@ -244,6 +265,6 @@ public:
 
 } // namespace std
 
-//using uint24_t = Thunder::Core::UInt24;
-//using int24_t = Thunder::Core::SInt24;
+using uint24_t = Thunder::Core::UInt24;
+using int24_t = Thunder::Core::SInt24;
 

--- a/Source/core/ICustomErrorCode.h
+++ b/Source/core/ICustomErrorCode.h
@@ -46,6 +46,9 @@ extern "C" {
 #include <stdint.h>
 #endif
 
+// called from within Thunder to get the string representation for a custom code
+// note parameter code is the pure (signed) Custom Code passed to Thunder. no additional bits set (so for signed numbers 32th bit used as sign bit). 
+// in case no special string representation is needed return nullptr (NULL), in that case Thunder will convert the Custom Code to a generic message itself
 EXTERNAL const TCHAR* CustomCodeToSting(const int32_t code);
 
 #ifdef __cplusplus

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -22,6 +22,8 @@
 #include "JSON.h"
 #include "Module.h"
 #include "TypeTraits.h"
+#include "Errors.h"
+#include "Number.h"
 
 #include <cctype>
 #include <functional>
@@ -189,9 +191,9 @@ namespace Core {
                             Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError & 0x7FFFFFFF) - 500;
                         } else {
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-                            int32_t customcode = IsCustomCode(frameworkError);
+                            int24_t customcode = IsCustomCode(frameworkError);
                             if (customcode != 0) {
-                                Code = (customcode == std::numeric_limits<int32_t>::max() ? 0 : customcode);
+                                Code = (Core::Overflowed(customcode) == true ? 0 : static_cast<int32_t>(customcode));
                             } else {
 #endif
                                 Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -191,7 +191,7 @@ namespace Core {
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
                             int32_t customcode = IsCustomCode(frameworkError);
                             if (customcode != 0) {
-                                Code = (customcode == std::numeric_limits<int32_t>::min() ? 0 : customcode);
+                                Code = (customcode == std::numeric_limits<int32_t>::max() ? 0 : customcode);
                             } else {
 #endif
                                 Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);

--- a/Source/core/NetworkInfo.h
+++ b/Source/core/NetworkInfo.h
@@ -23,7 +23,6 @@
 #include "Portability.h"
 #include "Netlink.h"
 #include "NodeId.h"
-#include "Portability.h"
 #include "SocketPort.h"
 
 namespace Thunder {

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -25,8 +25,7 @@
 #include "Sync.h"
 #include "SystemInfo.h"
 #include "Serialization.h"
-#include "Number.h"
-#include "ExtraNumberDefinitions.h"
+//#include "Number.h"
 
 #ifdef __LINUX__
 #include <atomic>
@@ -460,112 +459,6 @@ namespace Core {
         }
 
         return (lastIndex < (index - 1) ? TextFragment(result, lastIndex + 1, result.Length() - (lastIndex + 1)) : result);
-    }
-
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-
-namespace {
-
-    static CustomCodeToStringHandler customerrorcodehandler = nullptr;
-
-    const TCHAR* HandleCustomErrorCodeToString(const int32_t customcode)
-    {
-        const TCHAR* text = nullptr;
-
-        if (customcode == std::numeric_limits<int32_t>::max()) {
-            text = _T("Invalid Custom ErrorCode set");
-        } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
-            text = _T("Undefined Custom Error");
-        } 
-
-        return text;
-    }
-
-    string HandleCustomErrorCodeToStringExtended(const int32_t customcode)
-    {
-        string result;
-
-        const TCHAR* text = nullptr;
-        if (customcode == std::numeric_limits<int32_t>::max()) {
-            result = _T("Invalid Custom ErrorCode set");
-        } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
-            result = _T("Undefined Custom Error: ") + Core::NumberType<int32_t>(customcode).Text();
-        } else {
-            result = text;
-        }
-
-        return result;
-    }
-
-}
-    void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler) {
-        customerrorcodehandler = handler;
-    }
-
-    hresult CustomCode(const int32_t customCode) {
-
-        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
-
-        hresult result = Core::ERROR_NONE;
-
-        if (customCode != 0) {
-            Core::SInt24 code; 
-            if (Core::check_and_cast<Core::SInt24, int32_t>(customCode, code) == true) {
-                result = static_cast<hresult>(code.AsSInt24());
-            } else {
-                result = 0; // set invalid customCode result;
-            }
-            result |= CUSTOM_ERROR; // set custom code bit
-        }
-
-        return result;
-    }
-
-    int32_t IsCustomCode(const Core::hresult code) {
-        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
-
-        int32_t result = 0;
-
-        if ((code & CUSTOM_ERROR) != 0) {
-            Core::SInt24 custumcode(code & 0xFFFFFF); // remove custom error bit before assigning
-            result = custumcode;
-            if (result == 0) {
-                result = std::numeric_limits<int32_t>::max();
-            }
-        }
-
-        return result;
-    }
-
-#endif
-
-    const TCHAR* ErrorToString(const Core::hresult code)
-    {
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-        int32_t customcode = IsCustomCode(code);
-
-        if (customcode != 0) {
-            return HandleCustomErrorCodeToString(customcode);
-        }
-#endif
-        return _bogus_ErrorToString<>(code & (~COM_ERROR));
-    }
-
-    string ErrorToStringExtended(const Core::hresult code)
-    {
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-        int32_t customcode = IsCustomCode(code);
-
-        if (customcode != 0) {
-            return HandleCustomErrorCodeToStringExtended(customcode);
-        }
-#endif
-        string result = _bogus_ErrorToString<>(code & (~COM_ERROR));
-
-        if (result.empty() == true) {
-            result = _T("Undefined Thunder error code: ") + Core::NumberType<Core::hresult>(code).Text();
-        }
-        return result;
     }
 
 

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -26,6 +26,7 @@
 #include "SystemInfo.h"
 #include "Serialization.h"
 #include "Number.h"
+#include "ExtraNumberDefinitions.h"
 
 #ifdef __LINUX__
 #include <atomic>
@@ -471,7 +472,7 @@ namespace {
     {
         const TCHAR* text = nullptr;
 
-        if (customcode == std::numeric_limits<int32_t>::min()) {
+        if (customcode == std::numeric_limits<int32_t>::max()) {
             text = _T("Invalid Custom ErrorCode set");
         } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
             text = _T("Undefined Custom Error");
@@ -485,7 +486,7 @@ namespace {
         string result;
 
         const TCHAR* text = nullptr;
-        if (customcode == std::numeric_limits<int32_t>::min()) {
+        if (customcode == std::numeric_limits<int32_t>::max()) {
             result = _T("Invalid Custom ErrorCode set");
         } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
             result = _T("Undefined Custom Error: ") + Core::NumberType<int32_t>(customcode).Text();
@@ -508,8 +509,8 @@ namespace {
         hresult result = Core::ERROR_NONE;
 
         if (customCode != 0) {
-            int24_t code; 
-            if (Core::check_and_cast<int24_t, int32_t>(customCode, code) == true) {
+            Core::SInt24 code; 
+            if (Core::check_and_cast<Core::SInt24, int32_t>(customCode, code) == true) {
                 result = static_cast<hresult>(code.AsSInt24());
             } else {
                 result = 0; // set invalid customCode result;
@@ -526,10 +527,10 @@ namespace {
         int32_t result = 0;
 
         if ((code & CUSTOM_ERROR) != 0) {
-            int24_t custumcode(code & 0xFFFFFF); // remove custom error bit before assigning
+            Core::SInt24 custumcode(code & 0xFFFFFF); // remove custom error bit before assigning
             result = custumcode;
             if (result == 0) {
-                result = std::numeric_limits<int32_t>::min();
+                result = std::numeric_limits<int32_t>::max();
             }
         }
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -753,187 +753,198 @@ typedef std::string string;
 #endif
 
 namespace Thunder {
-namespace Core {
+    namespace Core {
 
-    class TextFragment;
+        class TextFragment;
 
-    #if defined(__CORE_INSTANCE_BITS__) && (__CORE_INSTANCE_BITS__ != 0)
-    #if __CORE_INSTANCE_BITS__ <= 8
-    typedef uint8_t instance_id;
-    #elif __CORE_INSTANCE_BITS__ <= 16
-    typedef uint16_t instance_id;
-    #elif __CORE_INSTANCE_BITS__ <= 32 
-    typedef uint32_t instance_id;
-    #elif __CORE_INSTANCE_BITS__ <= 64
+#if defined(__CORE_INSTANCE_BITS__) && (__CORE_INSTANCE_BITS__ != 0)
+#if __CORE_INSTANCE_BITS__ <= 8
+        typedef uint8_t instance_id;
+#elif __CORE_INSTANCE_BITS__ <= 16
+        typedef uint16_t instance_id;
+#elif __CORE_INSTANCE_BITS__ <= 32
+        typedef uint32_t instance_id;
+#elif __CORE_INSTANCE_BITS__ <= 64
+        typedef uint64_t instance_id;
+#endif
+#else
+#if defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8)
     typedef uint64_t instance_id;
-    #endif
-    #else
-    #if defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ == 8) 
-    typedef uint64_t instance_id;
-    #else
+#else
     typedef uint32_t instance_id;
-    #endif
-    #endif
+#endif
+#endif
 
-    #ifdef __LINUX__
-    typedef pthread_t thread_id;
-    #else
+#ifdef __LINUX__
+        typedef pthread_t thread_id;
+#else
     typedef DWORD thread_id;
-    #endif
+#endif
 
-    typedef uint32_t hresult;
+        typedef uint32_t hresult;
 
-    struct callstack_info {
-        void*    address;
-        string   module;
-        string   function;
-        uint32_t line;
-    };
+        struct callstack_info {
+            void*    address;
+            string   module;
+            string   function;
+            uint32_t line;
+        };
 
 
-    inline void* Alignment(size_t alignment, void* incoming)
-    {
-        const auto basePtr = reinterpret_cast<uintptr_t>(incoming);
-        return reinterpret_cast<void*>((basePtr - 1u + alignment) & ~(alignment - 1));
-    }
+        inline void* Alignment(size_t alignment, void* incoming)
+        {
+            const auto basePtr = reinterpret_cast<uintptr_t>(incoming);
+            return reinterpret_cast<void*>((basePtr - 1u + alignment) & ~(alignment - 1));
+        }
 
-    inline uint8_t* PointerAlign(uint8_t* pointer)
-    {
-        uintptr_t addr = reinterpret_cast<uintptr_t>(pointer);
-        addr = (addr + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1); // Round up to align-byte boundary
-        return reinterpret_cast<uint8_t*>(addr);
-    }
+        inline uint8_t* PointerAlign(uint8_t* pointer)
+        {
+            uintptr_t addr = reinterpret_cast<uintptr_t>(pointer);
+            addr = (addr + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1); // Round up to align-byte boundary
+            return reinterpret_cast<uint8_t*>(addr);
+        }
 
-    inline const uint8_t* PointerAlign(const uint8_t* pointer)
-    {
-        uintptr_t addr = reinterpret_cast<uintptr_t>(pointer);
-        addr = (addr + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1); // Round up to align-byte boundary
-        return reinterpret_cast<const uint8_t*>(addr);
-    }
+        inline const uint8_t* PointerAlign(const uint8_t* pointer)
+        {
+            uintptr_t addr = reinterpret_cast<uintptr_t>(pointer);
+            addr = (addr + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1); // Round up to align-byte boundary
+            return reinterpret_cast<const uint8_t*>(addr);
+        }
 
 #ifdef _UNICODE
-    typedef std::wstring string;
+        typedef std::wstring string;
 #endif
 
 #ifndef _UNICODE
-    typedef std::string string;
+        typedef std::string string;
 #endif
 
-    inline void ToUpper(const string& input, string& output)
-    {
-        // Copy string to output, so we know memory is allocated.
-        output = input;
+        inline void ToUpper(const string& input, string& output)
+        {
+            // Copy string to output, so we know memory is allocated.
+            output = input;
 
-        std::transform(input.begin(), input.end(), output.begin(), ::toupper);
-    }
+            std::transform(input.begin(), input.end(), output.begin(), ::toupper);
+        }
 
-    inline void ToUpper(string& inplace)
-    {
-        std::transform(inplace.begin(), inplace.end(), inplace.begin(), ::toupper);
-    }
+        inline void ToUpper(string& inplace)
+        {
+            std::transform(inplace.begin(), inplace.end(), inplace.begin(), ::toupper);
+        }
 
-    inline void ToLower(const string& input, string& output)
-    {
-        output = input;
+        inline void ToLower(const string& input, string& output)
+        {
+            output = input;
 
-        std::transform(input.begin(), input.end(), output.begin(), ::tolower);
-    }
+            std::transform(input.begin(), input.end(), output.begin(), ::tolower);
+        }
 
-    inline void ToLower(string& inplace)
-    {
-        std::transform(inplace.begin(), inplace.end(), inplace.begin(), ::tolower);
-    }
+        inline void ToLower(string& inplace)
+        {
+            std::transform(inplace.begin(), inplace.end(), inplace.begin(), ::tolower);
+        }
 
-    EXTERNAL extern string Format(const TCHAR formatter[], ...) PRINTF_FORMAT(1, 2);
-    EXTERNAL extern void Format(string& dst, const TCHAR format[], ...) PRINTF_FORMAT(2, 3);
-    EXTERNAL extern void Format(string& dst, const TCHAR format[], va_list ap);
+        EXTERNAL extern string Format(const TCHAR formatter[], ...) PRINTF_FORMAT(1, 2);
+        EXTERNAL extern void Format(string& dst, const TCHAR format[], ...) PRINTF_FORMAT(2, 3);
+        EXTERNAL extern void Format(string& dst, const TCHAR format[], va_list ap);
 
-    const uint32_t infinite = -1;
-    static const string emptyString;
+        const uint32_t infinite = -1;
+        static const string emptyString;
 
-    class Void {
-    public:
-        template <typename... Args>
-        inline Void(Args&&...) {}
-        inline Void(const Void&) = default;
-        inline Void(Void&&) = default;
-        inline ~Void() = default;
+        class Void {
+        public:
+            template <typename... Args>
+            inline Void(Args&&...) {}
+            inline Void(const Void&) = default;
+            inline Void(Void&&) = default;
+            inline ~Void() = default;
 
-        inline Void& operator=(const Void&) = default;
-    };
+            inline Void& operator=(const Void&) = default;
+        };
 
-    struct EXTERNAL IReferenceCounted {
-        virtual ~IReferenceCounted() = default;
-        virtual uint32_t AddRef() const = 0;
-        virtual uint32_t Release() const = 0;
-    };
+        struct EXTERNAL IReferenceCounted {
+            virtual ~IReferenceCounted() = default;
+            virtual uint32_t AddRef() const = 0;
+            virtual uint32_t Release() const = 0;
+        };
 
     struct EXTERNAL IUnknown : public IReferenceCounted  {
 
-        enum : uint32_t {
+            enum : uint32_t {
             ID_OFFSET_INTERNAL  = 0x00000000,
             ID_OFFSET_PUBLIC    = 0x00000040,
             ID_OFFSET_CUSTOM    = 0x80000000
+            };
+
+            enum { ID = (ID_OFFSET_INTERNAL + 0x0000) };
+
+            ~IUnknown() override = default;
+
+            virtual void* QueryInterface(const uint32_t interfaceNumber) = 0;
+
+            template <typename REQUESTEDINTERFACE>
+            REQUESTEDINTERFACE* QueryInterface()
+            {
+                void* baseInterface(QueryInterface(REQUESTEDINTERFACE::ID));
+
+                if (baseInterface != nullptr) {
+                    return (reinterpret_cast<REQUESTEDINTERFACE*>(baseInterface));
+                }
+
+                return (nullptr);
+            }
+
+            template <typename REQUESTEDINTERFACE>
+            const REQUESTEDINTERFACE* QueryInterface() const
+            {
+                const void* baseInterface(const_cast<IUnknown*>(this)->QueryInterface(REQUESTEDINTERFACE::ID));
+
+                if (baseInterface != nullptr) {
+                    return (reinterpret_cast<const REQUESTEDINTERFACE*>(baseInterface));
+                }
+
+                return (nullptr);
+            }
         };
 
-        enum { ID = (ID_OFFSET_INTERNAL + 0x0000) };
-
-        ~IUnknown() override = default;
-
-        virtual void* QueryInterface(const uint32_t interfaceNumber) = 0;
-
-        template <typename REQUESTEDINTERFACE>
-        REQUESTEDINTERFACE* QueryInterface()
-        {
-            void* baseInterface(QueryInterface(REQUESTEDINTERFACE::ID));
-
-            if (baseInterface != nullptr) {
-                return (reinterpret_cast<REQUESTEDINTERFACE*>(baseInterface));
-            }
-
-            return (nullptr);
-        }
-
-        template <typename REQUESTEDINTERFACE>
-        const REQUESTEDINTERFACE* QueryInterface() const
-        {
-            const void* baseInterface(const_cast<IUnknown*>(this)->QueryInterface(REQUESTEDINTERFACE::ID));
-
-            if (baseInterface != nullptr) {
-                return (reinterpret_cast<const REQUESTEDINTERFACE*>(baseInterface));
-            }
-
-            return (nullptr);
-        }
-    };
-
-    namespace memory_order {
-    #ifdef __WINDOWS__
-        static constexpr std::memory_order memory_order_relaxed = std::memory_order::memory_order_relaxed;
-        static constexpr std::memory_order memory_order_consume = std::memory_order::memory_order_seq_cst;
-        static constexpr std::memory_order memory_order_acquire = std::memory_order::memory_order_seq_cst;
-        static constexpr std::memory_order memory_order_release = std::memory_order::memory_order_release;
-        static constexpr std::memory_order memory_order_acq_rel = std::memory_order::memory_order_seq_cst;
-        static constexpr std::memory_order memory_order_seq_cst = std::memory_order::memory_order_seq_cst;
-    #else
+        namespace memory_order {
+#ifdef __WINDOWS__
+            static constexpr std::memory_order memory_order_relaxed = std::memory_order::memory_order_relaxed;
+            static constexpr std::memory_order memory_order_consume = std::memory_order::memory_order_seq_cst;
+            static constexpr std::memory_order memory_order_acquire = std::memory_order::memory_order_seq_cst;
+            static constexpr std::memory_order memory_order_release = std::memory_order::memory_order_release;
+            static constexpr std::memory_order memory_order_acq_rel = std::memory_order::memory_order_seq_cst;
+            static constexpr std::memory_order memory_order_seq_cst = std::memory_order::memory_order_seq_cst;
+#else
         static constexpr std::memory_order memory_order_relaxed = std::memory_order::memory_order_relaxed;
         static constexpr std::memory_order memory_order_consume = std::memory_order::memory_order_consume;
         static constexpr std::memory_order memory_order_acquire = std::memory_order::memory_order_acquire;
         static constexpr std::memory_order memory_order_release = std::memory_order::memory_order_release;
         static constexpr std::memory_order memory_order_acq_rel = std::memory_order::memory_order_acq_rel;
         static constexpr std::memory_order memory_order_seq_cst = std::memory_order::memory_order_seq_cst;
-    #endif
-    }
+#endif
+        }
 
-    #define COM_ERROR (0x80000000)
-    #define CUSTOM_ERROR (0x1000000)
+#define COM_ERROR (0x80000000)
+#define CUSTOM_ERROR (0x1000000)
+
+}  // Core
+}  // Thunder
+
+        // For now make these point to the base type instead of Thunder::Core::UInt24 and Thunder::Core::SInt24 until we make it possible to include these here.
+
+    using uint24_t = uint32_t;
+    using int24_t = int32_t;
+
+namespace Thunder {
+namespace Core {
 
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
 
     // transform a custum code into an hresult
-    EXTERNAL Core::hresult CustomCode(const int32_t customCode);
+    EXTERNAL Core::hresult CustomCode(const int24_t customCode);
     // query if the hresult is a custom code and if so extract the value, returns 0 if the hresult was not a custom code
-    EXTERNAL int32_t IsCustomCode(const Core::hresult code);
+    EXTERNAL int24_t IsCustomCode(const Core::hresult code);
 
 #endif
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -925,137 +925,6 @@ namespace Thunder {
 #endif
         }
 
-#define COM_ERROR (0x80000000)
-#define CUSTOM_ERROR (0x1000000)
-
-}  // Core
-}  // Thunder
-
-        // For now make these point to the base type instead of Thunder::Core::UInt24 and Thunder::Core::SInt24 until we make it possible to include these here.
-
-    using uint24_t = uint32_t;
-    using int24_t = int32_t;
-
-namespace Thunder {
-namespace Core {
-
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-
-    // transform a custum code into an hresult
-    EXTERNAL Core::hresult CustomCode(const int24_t customCode);
-    // query if the hresult is a custom code and if so extract the value, returns 0 if the hresult was not a custom code
-    EXTERNAL int24_t IsCustomCode(const Core::hresult code);
-
-#endif
-
-    #define ERROR_CODES \
-        ERROR_CODE(ERROR_NONE, 0) \
-        ERROR_CODE(ERROR_GENERAL, 1) \
-        ERROR_CODE(ERROR_UNAVAILABLE, 2) \
-        ERROR_CODE(ERROR_ASYNC_FAILED, 3) \
-        ERROR_CODE(ERROR_ASYNC_ABORTED, 4) \
-        ERROR_CODE(ERROR_ILLEGAL_STATE, 5) \
-        ERROR_CODE(ERROR_OPENING_FAILED, 6) \
-        ERROR_CODE(ERROR_ACCEPT_FAILED, 7) \
-        ERROR_CODE(ERROR_PENDING_SHUTDOWN, 8) \
-        ERROR_CODE(ERROR_ALREADY_CONNECTED, 9) \
-        ERROR_CODE(ERROR_CONNECTION_CLOSED, 10) \
-        ERROR_CODE(ERROR_TIMEDOUT, 11) \
-        ERROR_CODE(ERROR_INPROGRESS, 12) \
-        ERROR_CODE(ERROR_COULD_NOT_SET_ADDRESS, 13) \
-        ERROR_CODE(ERROR_INCORRECT_HASH, 14) \
-        ERROR_CODE(ERROR_INCORRECT_URL, 15) \
-        ERROR_CODE(ERROR_INVALID_INPUT_LENGTH, 16) \
-        ERROR_CODE(ERROR_DESTRUCTION_SUCCEEDED, 17) \
-        ERROR_CODE(ERROR_DESTRUCTION_FAILED, 18) \
-        ERROR_CODE(ERROR_CLOSING_FAILED, 19) \
-        ERROR_CODE(ERROR_PROCESS_TERMINATED, 20) \
-        ERROR_CODE(ERROR_PROCESS_KILLED, 21) \
-        ERROR_CODE(ERROR_UNKNOWN_KEY, 22) \
-        ERROR_CODE(ERROR_INCOMPLETE_CONFIG, 23) \
-        ERROR_CODE(ERROR_PRIVILIGED_REQUEST, 24) \
-        ERROR_CODE(ERROR_RPC_CALL_FAILED, 25) \
-        ERROR_CODE(ERROR_UNREACHABLE_NETWORK, 26) \
-        ERROR_CODE(ERROR_REQUEST_SUBMITTED, 27) \
-        ERROR_CODE(ERROR_UNKNOWN_TABLE, 28) \
-        ERROR_CODE(ERROR_DUPLICATE_KEY, 29) \
-        ERROR_CODE(ERROR_BAD_REQUEST, 30) \
-        ERROR_CODE(ERROR_PENDING_CONDITIONS, 31) \
-        ERROR_CODE(ERROR_SURFACE_UNAVAILABLE, 32) \
-        ERROR_CODE(ERROR_PLAYER_UNAVAILABLE, 33) \
-        ERROR_CODE(ERROR_FIRST_RESOURCE_NOT_FOUND, 34) \
-        ERROR_CODE(ERROR_SECOND_RESOURCE_NOT_FOUND, 35) \
-        ERROR_CODE(ERROR_ALREADY_RELEASED, 36) \
-        ERROR_CODE(ERROR_NEGATIVE_ACKNOWLEDGE, 37) \
-        ERROR_CODE(ERROR_INVALID_SIGNATURE, 38) \
-        ERROR_CODE(ERROR_READ_ERROR, 39) \
-        ERROR_CODE(ERROR_WRITE_ERROR, 40) \
-        ERROR_CODE(ERROR_INVALID_DESIGNATOR, 41) \
-        ERROR_CODE(ERROR_UNAUTHENTICATED, 42) \
-        ERROR_CODE(ERROR_NOT_EXIST, 43) \
-        ERROR_CODE(ERROR_NOT_SUPPORTED, 44) \
-        ERROR_CODE(ERROR_INVALID_RANGE, 45) \
-        ERROR_CODE(ERROR_HIBERNATED, 46) \
-        ERROR_CODE(ERROR_INPROC, 47) \
-        ERROR_CODE(ERROR_FAILED_REGISTERED, 48) \
-        ERROR_CODE(ERROR_FAILED_UNREGISTERED, 49) \
-        ERROR_CODE(ERROR_PARSE_FAILURE, 50) \
-        ERROR_CODE(ERROR_PRIVILIGED_DEFERRED, 51) \
-        ERROR_CODE(ERROR_INVALID_ENVELOPPE, 52) \
-        ERROR_CODE(ERROR_UNKNOWN_METHOD, 53) \
-        ERROR_CODE(ERROR_INVALID_PARAMETER, 54) \
-        ERROR_CODE(ERROR_INTERNAL_JSONRPC, 55) \
-        ERROR_CODE(ERROR_PARSING_ENVELOPPE, 56) \
-        ERROR_CODE(ERROR_COMPOSIT_OBJECT, 57) \
-        ERROR_CODE(ERROR_ABORTED, 58)
-
-    #define ERROR_CODE(CODE, VALUE) CODE = VALUE,
-
-    enum ErrorCodes {
-        ERROR_CODES
-        ERROR_COUNT
-    };
-
-    #undef ERROR_CODE
-
-    // Convert error enumerations to string
-
-    template<uint32_t N>
-    inline const TCHAR* _Err2Str()
-    {
-        return _T("");
-    };
-
-    #define ERROR_CODE(CODE, VALUE) \
-        template<> inline const TCHAR* _Err2Str<VALUE>() { return _T(#CODE); }
-
-    ERROR_CODES;
-
-    template<uint32_t N = (ERROR_COUNT - 1)>
-    inline const TCHAR* _bogus_ErrorToString(uint32_t code)
-    {
-        return (code == N? _Err2Str<N>() : _bogus_ErrorToString<N-1>(code));
-    };
-
-    template<>
-    inline const TCHAR* _bogus_ErrorToString<0u>(uint32_t code)
-    {
-        return (code == 0? _Err2Str<0u>() : _Err2Str<~0u>());
-    };
-
-    EXTERNAL const TCHAR* ErrorToString(const Core::hresult code);
-    EXTERNAL string ErrorToStringExtended(const Core::hresult code);
-
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-
-    using CustomCodeToStringHandler = const TCHAR* (*)(const int32_t code);
-
-    // can only set one, not multithreaded safe
-    EXTERNAL void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler);
-
-#endif
-
-    #undef ERROR_CODE
 
     EXTERNAL TextFragment Demangled(const char name[]); 
     EXTERNAL TextFragment ClassName(const char name[]); 
@@ -1063,6 +932,8 @@ namespace Core {
     
 }
 }
+
+// code to make (to some extend) old code whioch still uses the WPEFramework instead of Thunder still compile
 
 namespace WPEFramework {
     using namespace Thunder;

--- a/Source/core/ProcessInfo.cpp
+++ b/Source/core/ProcessInfo.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "Errors.h"
 #include "ProcessInfo.h"
 #include "FileSystem.h"
 #include "SystemInfo.h"

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -26,6 +26,7 @@
 
 // ---- Include local include files ----
 #include "Portability.h"
+#include "Errors.h"
 #include "StateTrigger.h"
 #include "Sync.h"
 #include "TypeTraits.h"

--- a/Source/core/Sync.cpp
+++ b/Source/core/Sync.cpp
@@ -37,6 +37,7 @@
 #include "Sync.h"
 #include "ProcessInfo.h"
 #include "Trace.h"
+#include "Errors.h"
 
 #ifdef __CORE_CRITICAL_SECTION_LOG__
 #include "Thread.h"

--- a/Source/core/core.h
+++ b/Source/core/core.h
@@ -109,6 +109,7 @@
 #include "WarningReportingCategories.h"
 #include "Number.h"
 #include "ExtraNumberDefinitions.h"
+#include "Errors.h"
 
 #ifdef __WINDOWS__
 #pragma comment(lib, "core.lib")

--- a/Source/core/core.h
+++ b/Source/core/core.h
@@ -107,6 +107,8 @@
 #include "WorkerPool.h"
 #include "WarningReportingControl.h"
 #include "WarningReportingCategories.h"
+#include "Number.h"
+#include "ExtraNumberDefinitions.h"
 
 #ifdef __WINDOWS__
 #pragma comment(lib, "core.lib")

--- a/Source/core/core.vcxproj
+++ b/Source/core/core.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="CallsignTLS.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="core.h" />
+    <ClInclude Include="Errors.h" />
     <ClInclude Include="ExtraNumberDefinitions.h" />
     <ClInclude Include="ICustomErrorCode.h" />
     <ClInclude Include="CyclicBuffer.h" />
@@ -114,6 +115,7 @@
     <ClCompile Include="DataElementFile.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="DoorBell.cpp" />
+    <ClCompile Include="Errors.cpp" />
     <ClCompile Include="FileSystem.cpp" />
     <ClCompile Include="ISO639.cpp" />
     <ClCompile Include="JSON.cpp" />

--- a/Source/core/core.vcxproj
+++ b/Source/core/core.vcxproj
@@ -24,6 +24,8 @@
     <ClInclude Include="CallsignTLS.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="core.h" />
+    <ClInclude Include="ExtraNumberDefinitions.h" />
+    <ClInclude Include="ICustomErrorCode.h" />
     <ClInclude Include="CyclicBuffer.h" />
     <ClInclude Include="DataBuffer.h" />
     <ClInclude Include="DataElement.h" />


### PR DESCRIPTION
Now full support for uint24_t and in24_t and Custom Code uses this now (of course still inside non complimentary code section :) )
To be able to do this I had to split off the error code from Portability as the U/SInt24 in its separate file still needed ASSERT.

So interface better indicates that only 24bits types are used where and overflow situation (Release, debug will still assert) no longer needs to be checked by a certain magic value externally which is much better but with a method now, added a templated version just like RealSize in case it might be needed more  types (e.g. in23_t :) ) in the future in some templated code (also abstracts away the need to call a specific method) (btw did not also make RealSize use the sfinae check to see if the method is there for a reason)

BTW Built for both Linux and Windows, for now only tested on Windows as the Linux lithospere update broke my build and I'll fix that tomorrow (Today that is ;) ). But there is nothing Linux specific on it so it should work anyway.

@mhughesacn I had to move the template code that gave the false warning a few days ago to a new file so you might see the same black duck error again, but it is the same code so again it is just a template specialization for our own types and needs to be done this way so it is a false warning.
