### PR TITLE
Reverting to original Closed logic

### DIFF
--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1316,22 +1316,29 @@ namespace Thunder {
 
             StateChange();
 
-            DestroySocket(m_Socket);
-            ResourceMonitor::Instance().Unregister(*this);
+            m_State &= (~SHUTDOWN);
 
-            // Remove socket descriptor for UNIX domain datagram socket.
-            if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) &&
-                ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM)) &&
-                !m_SystemdSocket) {
-                TRACE_L1("CLOSED: Remove socket descriptor %s", m_LocalNode.HostName().c_str());
-#ifdef __WINDOWS__
-                _unlink(m_LocalNode.HostName().c_str());
-#else
-                unlink(m_LocalNode.HostName().c_str());
-#endif
+            // In StateChange, the socket may get destroyed and recreated and moved to 
+            // listening state. In such scenario, m_State will not be 0.
+            if (m_State != 0) {
+                result = false;
+            } else {
+                DestroySocket(m_Socket);
+                ResourceMonitor::Instance().Unregister(*this);
+
+                // Remove socket descriptor for UNIX domain datagram socket.
+                if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) &&
+                    ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM)) &&
+                    !m_SystemdSocket) {
+                    TRACE_L1("CLOSED: Remove socket descriptor %s", m_LocalNode.HostName().c_str());
+    #ifdef __WINDOWS__
+                    _unlink(m_LocalNode.HostName().c_str());
+    #else
+                    unlink(m_LocalNode.HostName().c_str());
+    #endif
+                }
             }
 
-            m_State &= (~SHUTDOWN);
 
             ASSERT (m_State == 0);
 


### PR DESCRIPTION
We are reverting to the original logic in Closed as we missed a scenario where the socket might be entering listening state during state change.