### PR TITLE
[Core] Fix ToHexString

### DIFF
--- a/Source/core/Serialization.cpp
+++ b/Source/core/Serialization.cpp
@@ -155,8 +155,6 @@ POP_WARNING()
         uint32_t index = static_cast<uint32_t>(result.length());
         result.resize(index + (length * 2) + (delimiter == '\0' ? 0 : (length - 1)));
 
-        result[1] = hex_chars[object[0] & 0xF];
-
         for (uint32_t i = 0, j = index; i < length; i++) {
             if ((delimiter != '\0') && (i > 0)) {
                 result[j++] = delimiter;


### PR DESCRIPTION
This line was just doing nothing useful if the output string was empty to begin with but caused issues when calling with a prefilled string like:

   uint8_t input[4] = { 0xAB, 0xCD, 0xEF, 0x12 };
    string out = "0x";
    
    ToHexString(input, sizeof(input), out);
    
    std:: cout << out << endl;

would print:

0babcdef12

probably not what was intended
