### PR TITLE
[Com] Close channel when no response after opening CommunicatorClient

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -520,6 +520,7 @@ namespace RPC {
 
         if ((result == Core::ERROR_NONE) && (_announceEvent.Lock(waitTime) != Core::ERROR_NONE)) {
             result = Core::ERROR_OPENING_FAILED;
+            BaseClass::Close(0);
         }
 
         return (result);
@@ -536,6 +537,7 @@ namespace RPC {
 
         if ((result == Core::ERROR_NONE) && (_announceEvent.Lock(waitTime) != Core::ERROR_NONE)) {
             result = Core::ERROR_OPENING_FAILED;
+            BaseClass::Close(0);
         }
 
         return (result);
@@ -554,6 +556,7 @@ namespace RPC {
 
         if ((result == Core::ERROR_NONE) && (_announceEvent.Lock(waitTime) != Core::ERROR_NONE)) {
             result = Core::ERROR_OPENING_FAILED;
+            BaseClass::Close(0);
         }
 
         return (result);

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -429,6 +429,7 @@ namespace ProxyStub {
         // Invalidate(), It is safe to use it on the _channel in an unlocked
         // fashion!!
         uint32_t Id() const;
+
         bool Invalidate() {
             bool succeeded = false;
             ASSERT(_refCount > 0);


### PR DESCRIPTION
When the CommunicatorClient succeeds in opening the channel but does not get a response on the announce message within the timeout specified it does return an error but subsequent IsOpen() calls return true. It is better to fully close the channel when a failure happens during opening.