### PR TITLE
[Com] competing invoke jobs and channel close issue

### DIFF
--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -200,10 +200,9 @@ namespace RPC {
 
         ProxyStub::UnknownStub* stub = ExtractStub(interfaceId);
 
-        uint16_t methodId = message->Parameters().MethodId();
-
         if (stub != nullptr) {
-            REPORT_DURATION_WARNING({ stub->Handle(methodId, channel, message); },  WarningReporting::TooLongInvokeRPC, interfaceId, methodId);
+            uint16_t methodId = message->Parameters().MethodId();
+            REPORT_DURATION_WARNING({ stub->Handle(methodId, channel, message); }, WarningReporting::TooLongInvokeRPC, interfaceId, methodId);
         } 
     }
 
@@ -436,7 +435,7 @@ namespace RPC {
 
     // make sure the security setting is only set once, in a thread safe way without locking...
     struct Administrator::ProxyStubSecuritySettingSetter {
-        ProxyStubSecuritySettingSetter(Administrator& administrator, SecureProxyStubType secure)
+        ProxyStubSecuritySettingSetter(Administrator& administrator, const SecureProxyStubType secure)
         {
             administrator._securitySettingProxyStubs = secure;
         }
@@ -467,7 +466,7 @@ namespace RPC {
             _adminLock.Unlock();
         } else {
 
-            SYSLOG(Logging::Error, (_T("Proxy and Stubs for interface %U was generated with a different proxystub security setting then the other Proxy and Stubs, it will be ignored (so expect errors due to this)")));
+            SYSLOG(Logging::Error, (_T("Proxy and Stubs for interface %U were generated with a different proxystub security setting than the other Proxy and Stubs, it will be ignored (so expect errors due to this)")));
         }
     }
 

--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -168,11 +168,8 @@ namespace RPC {
         if (index != _stubs.end()) {
             result = index->second;
         } else {
-            // Oops this is an unknown interface, Do not think this could happen.
-            TRACE_L1("Unknown interface. %d", interfaceId);
-            if (CoherentProxyStubs() == true) {
-                SYSLOG(Logging::Error, (_T("COMRPC received Invoke message with invalid interface ID , interface ID [%u]"), interfaceId));
-            }
+            // Oops this is an unknown interface, 
+            SYSLOG(Logging::Error, (_T("Unknown interface received, either the received COMRPC Invoke message had an invalid interface ID or the interface was not registered, interface ID [%u]"), interfaceId));
         }
         return (result);
     }

--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -180,6 +180,10 @@ namespace RPC {
 
     Core::IUnknown* Administrator::ExtractIUnknown(Core::ProxyType<Core::IPCChannel>& channel, Core::ProxyType<InvokeMessage>& message) const
     {
+        ASSERT(channel.IsValid() == true);
+        ASSERT(message.IsValid() == true);
+        ASSERT(message->Parameters().IsValid() == true);
+
         Core::IUnknown* result = nullptr;
 
         uint32_t interfaceId(message->Parameters().InterfaceId());
@@ -196,6 +200,10 @@ namespace RPC {
 
     void Administrator::Invoke(Core::ProxyType<Core::IPCChannel>& channel, Core::ProxyType<InvokeMessage>& message)
     {
+        ASSERT(channel.IsValid() == true);
+        ASSERT(message.IsValid() == true);
+        ASSERT(message->Parameters().IsValid() == true);
+
         uint32_t interfaceId(message->Parameters().InterfaceId());
 
         ProxyStub::UnknownStub* stub = ExtractStub(interfaceId);

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -438,6 +438,7 @@ namespace RPC {
             if (invokemessage.IsValid() == true) {
                 Core::IUnknown* instance = _administrator.ExtractIUnknown(_channel, invokemessage);
                 if (instance != nullptr) {
+                    // note Set is called from the Monitor thread so we know the channel is still valid and there is no possible race confition with the channel closing and Release due to that as that is also handled in the ResourceMonitor
                     _instance = Core::ProxyType<Core::IUnknown>(*instance);
                 }
             }

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -406,7 +406,7 @@ namespace RPC {
             Core::ProxyType<InvokeMessage> message(data);
             ASSERT(message.IsValid() == true);
             if (message->Parameters().IsValid() == false) {
-                message = std::move(Core::ProxyType<InvokeMessage>());
+                message = Core::ProxyType<InvokeMessage>();
             }
             return message;
         }

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -243,16 +243,15 @@ namespace ProxyStub {
                             if (result == Core::ERROR_TIMEDOUT) {
                                 Shutdown();
                             }
-                            TRACE_L1("Could not remote release the Proxy for Interface [0x%X]", message->Parameters().InterfaceId());
-                            result |= COM_ERROR;
+                            SYSLOG(Logging::Error, (_T("Could not remote release the Proxy for Interface [0x%X]"), message->Parameters().InterfaceId()));
                         }
                         else {
                             // Pass the remote release return value through
                             RPC::Data::Frame::Reader reader(message->Response().Reader());
                             if ((RPC::Administrator::Instance().CoherentProxyStubs() == true) && (reader.Length() < (Core::RealSize<uint32_t>()))) {
-                                result = (COM_ERROR | Core::ERROR_READ_ERROR);
+                                SYSLOG(Logging::Error, (_T("Incoherent Release invoke message received for interface [0x%X]"), message->Parameters().InterfaceId()));
                             } else {
-                                result = reader.Number<uint32_t>();
+                                reader.Number<uint32_t>();
                             }
                         }
                     }

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -49,8 +49,15 @@ namespace ProxyStub {
         virtual ~UnknownStub() = default;
 
     public:
+        enum class StubMethodsIndexType : uint8_t {
+            ADRREF          = 0,
+            RELEASE         = 1,
+            QUERYINTERFACE  = 2 // when this list is extended and this is no longer the last entry, update the Length() method as well
+        };
+
+    public:
         inline uint16_t Length() const {
-            return (3);
+            return (static_cast<uint16_t>(StubMethodsIndexType::QUERYINTERFACE) + 1);
         }
         virtual Core::IUnknown* Convert(void* incomingData) const {
             return (reinterpret_cast<Core::IUnknown*>(incomingData));
@@ -59,6 +66,11 @@ namespace ProxyStub {
             return (Core::IUnknown::ID);
         }
         virtual void Handle(const uint16_t index, Core::ProxyType<Core::IPCChannel>& channel, Core::ProxyType<RPC::InvokeMessage>& message);
+
+    private:
+        friend class Thunder::RPC::Administrator;
+
+        Core::IUnknown* ExtractInstance(Core::ProxyType<Core::IPCChannel>& channel, const Core::ProxyType<RPC::InvokeMessage>& message, const bool log) const;
     };
 
     template <typename INTERFACE, MethodHandler METHODS[]>
@@ -107,6 +119,10 @@ namespace ProxyStub {
                 ASSERT(handler != nullptr);
 
                 handler(channel, message);
+            } else {
+                // if we get here, the message was already checked for validness, so just log the error with the interface id
+                SYSLOG(Logging::Error, (_T("COMRPC received Invoke message with invalid method index , interface ID [%u]"), message->Parameters().InterfaceId()));
+                TRACE_L1("Warning: This COM-RPC failure will not propagate!");
             }
         }
 
@@ -215,7 +231,7 @@ namespace ProxyStub {
                         // We have reached "0", signal the other side..
                         Core::ProxyType<RPC::InvokeMessage> message(RPC::Administrator::Instance().Message());
 
-                        message->Parameters().Set(_implementation, _interfaceId, 1);
+                        message->Parameters().Set(_implementation, _interfaceId, static_cast<uint8_t>(UnknownStub::StubMethodsIndexType::RELEASE));
 
                         // Pass on the number of reference we need to drop, this is indicated by the amount of times this proxy had to be created
                         message->Parameters().Writer().Number<uint32_t>(_remoteReferences);
@@ -232,7 +248,12 @@ namespace ProxyStub {
                         }
                         else {
                             // Pass the remote release return value through
-                            result = message->Response().Reader().Number<uint32_t>();
+                            RPC::Data::Frame::Reader reader(message->Response().Reader());
+                            if ((RPC::Administrator::Instance().CoherentProxyStubs() == true) && (reader.Length() < (Core::RealSize<uint32_t>()))) {
+                                result = (COM_ERROR | Core::ERROR_READ_ERROR);
+                            } else {
+                                result = reader.Number<uint32_t>();
+                            }
                         }
                     }
 
@@ -258,7 +279,7 @@ namespace ProxyStub {
             Core::ProxyType<RPC::InvokeMessage> message(RPC::Administrator::Instance().Message());
             RPC::Data::Frame::Writer parameters(message->Parameters().Writer());
 
-            message->Parameters().Set(_implementation, _interfaceId, 2);
+            message->Parameters().Set(_implementation, _interfaceId, static_cast<uint8_t>(UnknownStub::StubMethodsIndexType::QUERYINTERFACE));
             parameters.Number<uint32_t>(id);
 
             _adminLock.Lock();
@@ -268,12 +289,17 @@ namespace ProxyStub {
             }
             else {
                 RPC::Data::Frame::Reader response(message->Response().Reader());
-                Core::instance_id impl = response.Number<Core::instance_id>();
-                _adminLock.Unlock();
 
-                // From what is returned, we need to create a proxy
-                RPC::Administrator::Instance().ProxyInstance(_channel, impl, true, id, result);
-
+                if ((RPC::Administrator::Instance().CoherentProxyStubs() == false) || (response.Length() >= (Core::RealSize<Core::instance_id>()))) {
+                    Core::instance_id impl = response.Number<Core::instance_id>();
+                    _adminLock.Unlock();
+                    // From what is returned, we need to create a proxy
+                    RPC::Administrator::Instance().ProxyInstance(_channel, impl, true, id, result);
+                } else {
+                    _adminLock.Unlock();
+                    SYSLOG(Logging::Error, (_T("COMRPC Coherency check failed, QueryInterface message incomplete, interface ID [%u]"), message->Parameters().InterfaceId()));
+                    TRACE_L1("Warning: This COM-RPC failure will not propagate!");
+                }
             }
             return (result);
         }

--- a/Source/core/IPCChannel.h
+++ b/Source/core/IPCChannel.h
@@ -100,19 +100,11 @@ namespace Core {
         {
             return (BaseClass::Source().Close(waitTime));
         }
-        bool IsOpen() const
-        {
-            return (BaseClass::Source().IsOpen());
-        }
-        bool IsClosed() const
-        {
-            return (BaseClass::Source().IsClosed());
-        }
         template <typename ACTUALELEMENT>
         void CreateFactory(const uint32_t initialSize)
         {
             ASSERT(_factory.IsValid());
-            ASSERT(BaseClass::Source().IsOpen() == false);
+            ASSERT(BaseClass::IsOpen() == false);
 
             static_assert(INTERNALFACTORY == true, "This method can only be called if you specify an INTERNAL factory");
 
@@ -123,7 +115,7 @@ namespace Core {
         {
 
             ASSERT(_factory.IsValid());
-            ASSERT(BaseClass::Source().IsOpen() == false);
+            ASSERT(BaseClass::IsOpen() == false);
 
             static_assert(INTERNALFACTORY == true, "This method can only be called if you specify an INTERNAL factory");
 

--- a/Source/core/IPCConnector.h
+++ b/Source/core/IPCConnector.h
@@ -759,6 +759,7 @@ POP_WARNING()
         virtual uint32_t Id() const = 0;
         virtual string Origin() const = 0;
         virtual uint32_t ReportResponse(Core::ProxyType<IIPC>& inbound) = 0;
+        virtual bool IsOpen() const = 0;
 
     private:
         virtual uint32_t Execute(const ProxyType<IIPC>& command, IDispatchType<IIPC>* completed) = 0;
@@ -929,6 +930,10 @@ POP_WARNING()
             _link.SendResponse(inbound);
 
             return (Core::ERROR_NONE);
+        }
+        bool IsOpen() const override
+        {
+            return _link.IsOpen();
         }
         virtual void StateChange()
         {

--- a/Source/core/IPCConnector.h
+++ b/Source/core/IPCConnector.h
@@ -760,6 +760,7 @@ POP_WARNING()
         virtual string Origin() const = 0;
         virtual uint32_t ReportResponse(Core::ProxyType<IIPC>& inbound) = 0;
         virtual bool IsOpen() const = 0;
+        virtual bool IsClosed() const = 0;
 
     private:
         virtual uint32_t Execute(const ProxyType<IIPC>& command, IDispatchType<IIPC>* completed) = 0;
@@ -934,6 +935,10 @@ POP_WARNING()
         bool IsOpen() const override
         {
             return _link.IsOpen();
+        }
+        bool IsClosed() const override
+        {
+            return _link.IsClosed();
         }
         virtual void StateChange()
         {


### PR DESCRIPTION
There was a chance a channel close job could release instances (on behalf of the client which did not do that yet) while an invoke job from that client was still in the workerpool queue (leading to crashes as the instance the invoke worked on was already dead then)

This PR does
- take addref on instance when posting invoke job (fixes the above)
- take secure and coherent proxy stubs into account for this (and add that to the Unknown proxy and stubs in general)
- check when running the Invoke job if the channel is still open (otherwise do not run the job anymore). Note this is an optimization and no fix for the above as there can be raceconditions here