### PR TITLE
Porting of fixes from master to R4_4

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -45,6 +45,8 @@ option(EXCEPTION_CATCHING
         "Enable unhandled exception handling catching." OFF)
 option(DEADLOCK_DETECTION
         "Enable deadlock detection tooling." OFF)
+option(DISABLE_USE_COMPLEMENTARY_CODE_SET
+        "Disable the complementary code set" OFF)
 
 if(HIDE_NON_EXTERNAL_SYMBOLS)
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -107,4 +109,9 @@ endif()
 
 if(EXECUTABLE)
     add_subdirectory(WPEFramework)
+endif()
+
+if(DISABLE_USE_COMPLEMENTARY_CODE_SET)
+    add_definitions(-D__DISABLE_USE_COMPLEMENTARY_CODE_SET__)
+    message(STATUS "complementary code set disabled")
 endif()

--- a/Source/WPEFramework/Config.h
+++ b/Source/WPEFramework/Config.h
@@ -394,6 +394,9 @@ namespace PluginHost {
 #ifdef HIBERNATE_SUPPORT_ENABLED
                 , Hibernate()
 #endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                , CustomCodeLibrary()
+#endif
             {
                 // No IdleTime
                 Add(_T("model"), &Model);
@@ -433,6 +436,9 @@ namespace PluginHost {
                 Add(_T("observe"), &Observe);
 #ifdef HIBERNATE_SUPPORT_ENABLED
                 Add(_T("hibernate"), &Hibernate);
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                Add(_T("customcodelibrary"), &CustomCodeLibrary);
 #endif
             }
             ~JSONConfig() override = default;
@@ -477,6 +483,9 @@ namespace PluginHost {
             Observables Observe;
 #ifdef HIBERNATE_SUPPORT_ENABLED
             HibernateConfig Hibernate;
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+            Core::JSON::String CustomCodeLibrary;
 #endif
         };
 
@@ -638,6 +647,9 @@ namespace PluginHost {
             #ifdef HIBERNATE_SUPPORT_ENABLED
             , _hibernateLocator()
             #endif
+            #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+            , _customCodeLibrary()
+            #endif
         {
             JSONConfig config;
 
@@ -652,6 +664,9 @@ namespace PluginHost {
 #endif
 #ifdef HIBERNATE_SUPPORT_ENABLED
                 _hibernateLocator = config.Hibernate.Locator.Value();
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                _customCodeLibrary = config.CustomCodeLibrary.Value();
 #endif
                 _volatilePath = Core::Directory::Normalize(config.VolatilePath.Value());
                 _persistentPath = Core::Directory::Normalize(config.PersistentPath.Value());
@@ -783,6 +798,12 @@ POP_WARNING()
 #ifdef HIBERNATE_SUPPORT_ENABLED
         inline const string& HibernateLocator() const {
             return (_hibernateLocator);
+        }
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        inline const string& CustomCodeLibrary() const
+        {
+            return (_customCodeLibrary);
         }
 #endif
         inline const string& VolatilePath() const
@@ -1069,6 +1090,9 @@ POP_WARNING()
         std::vector<std::string> _linkerPluginPaths;
 #ifdef HIBERNATE_SUPPORT_ENABLED
         string _hibernateLocator;
+#endif
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        string _customCodeLibrary;
 #endif
     };
 }

--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -134,6 +134,66 @@ POP_WARNING()
         string _interface;
         Core::AdapterObserver _observer;
     };
+    
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+    class CustomCodeLibrary {
+    public:
+
+        CustomCodeLibrary(const CustomCodeLibrary&) = delete;
+        CustomCodeLibrary& operator=(const CustomCodeLibrary&) = delete;
+        CustomCodeLibrary(CustomCodeLibrary&&) = delete;
+        CustomCodeLibrary& operator=(CustomCodeLibrary&&) = delete;
+
+        CustomCodeLibrary()
+            : _customCodeLibrary()
+            , _customCodeToStringHandler(nullptr)
+        {
+        }
+        ~CustomCodeLibrary()
+        {
+            ASSERT(_customCodeToStringHandler == nullptr);
+            ASSERT(_customCodeLibrary.IsLoaded() == false);
+        }
+
+        void Load(const string& libraryPath)
+        {
+            ASSERT(_customCodeToStringHandler == nullptr);
+            ASSERT(_customCodeLibrary.IsLoaded() == false);
+
+            _customCodeLibrary = Core::Library(libraryPath.c_str());
+            if (_customCodeLibrary.IsLoaded() == true) {
+                _customCodeToStringHandler = reinterpret_cast<Core::CustomCodeToStringHandler>(_customCodeLibrary.LoadFunction(CustomCodeToStringName));
+                if (_customCodeToStringHandler != nullptr) {
+                    Core::SetCustomCodeToStringHandler(_customCodeToStringHandler);
+                } else {
+                    SYSLOG(Logging::Error, (_T("Could not find CustomCodeToString function in Custom Error Code library")));
+                    _customCodeLibrary = Core::Library();
+                }
+            } else {
+                SYSLOG(Logging::Error, (_T("Could not load Custom Error Code library")));
+            }
+        }
+
+        void Release()
+        {
+            if (_customCodeToStringHandler != nullptr) {
+                Core::SetCustomCodeToStringHandler(nullptr);
+                _customCodeToStringHandler = nullptr;
+            }
+            if (_customCodeLibrary.IsLoaded() == true) {
+                _customCodeLibrary = Core::Library();
+            }
+        }
+
+    private:
+        static constexpr const TCHAR* CustomCodeToStringName{ _T("CustomCodeToString") };
+
+        Core::Library _customCodeLibrary;
+        Core::CustomCodeToStringHandler _customCodeToStringHandler;
+    };
+
+#endif
 
     class ExitHandler : public Core::Thread {
     private:
@@ -514,6 +574,10 @@ POP_WARNING()
                 fprintf(stdout, "Config file [%s] could not be opened.\n", options.configFile);
             }
         }
+        
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        CustomCodeLibrary customcodelibraryhandler;
+#endif
 
         if (_config != nullptr) {
 
@@ -566,6 +630,14 @@ POP_WARNING()
             if (postMortemPath.Next() != true) {
                 postMortemPath.CreatePath();
             }
+
+            
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+            if (_config->CustomCodeLibrary().empty() == false) {
+                customcodelibraryhandler.Load(_config->CustomCodeLibrary());
+            }
+#endif
+
 
             if (_config->MessagingCategoriesFile()) {
 
@@ -1018,6 +1090,10 @@ POP_WARNING()
             fprintf(stderr, EXPAND_AND_QUOTE(APPLICATION_NAME) " shutting down due to a 'Q' press in the terminal. Regular shutdown\n");
             fflush(stderr);
         }
+        
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+         customcodelibraryhandler.Release();
+#endif
  
         ExitHandler::Destruct();
         std::set_terminate(nullptr);

--- a/Source/WPEFramework/PluginServer.cpp
+++ b/Source/WPEFramework/PluginServer.cpp
@@ -1080,6 +1080,7 @@ POP_WARNING()
         _config.Security(securityProvider);
 
         std::vector<PluginHost::ISubSystem::subsystem> externallyControlled;
+        _services.Open();
         ServiceMap::Iterator iterator(_services.Services());
 
         // Load the metadata for the subsystem information..

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -3969,7 +3969,9 @@ POP_WARNING()
 
                 request->Service(status, Core::ProxyType<PluginHost::Service>(service), serviceCall);
 
-                ASSERT(request->State() != Request::INCOMPLETE);
+                // for now disable the assert as it is trigger probably when it shouldn't. But we should investigate how to enable it again so it fires at the right time: jira issue METROL-1211 created
+
+                //ASSERT(request->State() != Request::INCOMPLETE);
 
                 if (request->State() == Request::COMPLETE) {
 

--- a/Source/WPEFramework/PluginServer.h
+++ b/Source/WPEFramework/PluginServer.h
@@ -2415,14 +2415,7 @@ namespace PluginHost {
                     // STRONG RECOMMENDATION TO HAVE THIS ACTIVE (TRUE)!!!
                     RPC::Administrator::Instance().DelegatedReleases(delegatedReleases);
 
-                    if (RPC::Communicator::Open(RPC::CommunicationTimeOut) != Core::ERROR_NONE) {
-                        TRACE_L1("We can not open the RPC server. No out-of-process communication available. %d", __LINE__);
-                    } else {
-                        // We need to pass the communication channel NodeId via an environment variable, for process,
-                        // not being started by the rpcprocess...
-                        Core::SystemInfo::SetEnvironment(string(CommunicatorConnector), RPC::Communicator::Connector());
-                        RPC::Communicator::ForcedDestructionTimes(softKillCheckWaitTime, hardKillCheckWaitTime);
-                    }
+                    RPC::Communicator::ForcedDestructionTimes(softKillCheckWaitTime, hardKillCheckWaitTime);
 
                     if (observableProxyStubPath.empty() == true) {
                         SYSLOG(Logging::Startup, (_T("Dynamic COMRPC disabled.")));
@@ -2571,6 +2564,16 @@ namespace PluginHost {
                         _deadProxiesProtection.Lock();
                     }
                     _deadProxiesProtection.Unlock();
+                }
+
+                void Open() {
+                    if (RPC::Communicator::Open(RPC::CommunicationTimeOut) != Core::ERROR_NONE) {
+                        TRACE_L1("We can not open the RPC server. No out-of-process communication available. %d", __LINE__);
+                    } else {
+                        // We need to pass the communication channel NodeId via an environment variable, for process,
+                        // not being started by the rpcprocess...
+                        Core::SystemInfo::SetEnvironment(string(CommunicatorConnector), RPC::Communicator::Connector());
+                    }
                 }
 
 
@@ -3085,6 +3088,9 @@ POP_WARNING()
                 return (result);
             }
 
+            void Open() {
+                _processAdministrator.Open();
+            }
             void* Instantiate(const RPC::Object& object, const uint32_t waitTime, uint32_t& sessionId, const string& dataPath, const string& persistentPath, const string& volatilePath)
             {
                 return (_processAdministrator.Create(sessionId, object, waitTime, dataPath, persistentPath, volatilePath));

--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1062,14 +1062,14 @@ namespace RPC {
                         observer++;
                     }
 
-                    // Don't forget to close on our side as well, if it is not already closed....
-                    index->second->Terminate();
 
                     // Release this entry, do not wait till it get's overwritten.
                     index->second->Release();
                     _connections.erase(index);
                     _adminLock.Unlock();
 
+                    // Don't forget to close on our side as well, if it is not already closed....
+                    connection->Terminate();
                     connection->Release();
                 }
             }

--- a/Source/com/ConnectorType.cpp
+++ b/Source/com/ConnectorType.cpp
@@ -37,8 +37,9 @@ Core::ProxyType<RPC::IIPCServer> DefaultInvokeServer()
             RPC::InvokeServerType<1, 0, 8>::Stop();
         }
     };
-    static Core::ProxyType<Engine> engine = Core::ProxyType<Engine>::Create();
-    return Core::ProxyType<RPC::IIPCServer>(engine);
+    static Core::ProxyType<Engine>& instance = Core::SingletonProxyType<Engine>::Instance();
+
+    return Core::ProxyType<RPC::IIPCServer>(instance);
 };
 
 Core::ProxyType<RPC::IIPCServer> WorkerPoolInvokeServer()

--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -95,6 +95,38 @@ namespace ProxyStub {
     // -------------------------------------------------------------------------------------------
     // PROXY
     // -------------------------------------------------------------------------------------------
+    uint32_t UnknownProxy::Invoke(Core::ProxyType<RPC::InvokeMessage>& message, const uint32_t waitTime) const
+    {
+        uint32_t result = Core::ERROR_UNAVAILABLE | COM_ERROR;
+
+        _adminLock.Lock();
+	Core::ProxyType<Core::IPCChannel> channel (_channel);
+        _adminLock.Unlock();
+
+        if (channel.IsValid() == true) {
+
+	    if (channel->InProgress() == true) {
+	        ASSERT(false && "IPC in progress detected on this channel. Possible deadlock!");
+	        SYSLOG(Logging::Error, (_T("IPC in progress detected on this channel for Interface [0x%X], Method ID [0x%X]. Possible deadlock!"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
+	    }
+
+	    result = channel->Invoke(message, waitTime);
+	    if (result != Core::ERROR_NONE) {
+
+	        if (result == Core::ERROR_TIMEDOUT) {
+		    Shutdown();
+	        }
+
+	        result |= COM_ERROR;
+
+	        // Oops something failed on the communication. Report it.
+	        TRACE_L1("IPC method invocation failed for 0x%X, Method ID 0x%X error: %d", message->Parameters().InterfaceId(), message->Parameters().MethodId(), result);
+	    }
+        }
+
+        return (result);
+    }
+
     const Core::SocketPort* UnknownProxy::Socket() const
     {
         const Core::SocketPort* result = nullptr;

--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -114,13 +114,13 @@ namespace ProxyStub {
 	    if (result != Core::ERROR_NONE) {
 
 	        if (result == Core::ERROR_TIMEDOUT) {
-		    Shutdown();
+		    SYSLOG(Logging::Error, (_T("IPC method Invoke failed due to timeout (Interface ID 0x%X, Method ID 0x%X). Execution of code may or may not have happened. Side effects are to be expected after this message"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
 	        }
 
 	        result |= COM_ERROR;
 
 	        // Oops something failed on the communication. Report it.
-	        TRACE_L1("IPC method invocation failed for 0x%X, Method ID 0x%X error: %d", message->Parameters().InterfaceId(), message->Parameters().MethodId(), result);
+            TRACE_L1("IPC method invocation failed for 0x%X, error: %d", message->Parameters().InterfaceId(), result);
 	    }
         }
 
@@ -141,19 +141,6 @@ namespace ProxyStub {
         _adminLock.Unlock();
 
         return (result);
-    }
-
-    void UnknownProxy::Shutdown() const
-    {
-        _adminLock.Lock();
-        if (_channel.IsValid() == true) {
-            RPC::Communicator::Client* comchannel = dynamic_cast<RPC::Communicator::Client*>(_channel.operator->());
-            if (comchannel != nullptr) {
-                SYSLOG(Logging::Error, (_T("Shutting down the socket to avoid side-effects likely because an IPC method Invoke failed due to timeout. Execution of code may or may not have happened.")));
-                comchannel->Source().Close(0);
-            }
-       }
-        _adminLock.Unlock();
     }
 
     static class UnknownInstantiation {

--- a/Source/com/IUnknown.cpp
+++ b/Source/com/IUnknown.cpp
@@ -111,6 +111,19 @@ namespace ProxyStub {
         return (result);
     }
 
+    void UnknownProxy::Shutdown() const
+    {
+        _adminLock.Lock();
+        if (_channel.IsValid() == true) {
+            RPC::Communicator::Client* comchannel = dynamic_cast<RPC::Communicator::Client*>(_channel.operator->());
+            if (comchannel != nullptr) {
+                SYSLOG(Logging::Error, (_T("Shutting down the socket to avoid side-effects likely because an IPC method Invoke failed due to timeout. Execution of code may or may not have happened.")));
+                comchannel->Source().Close(0);
+            }
+       }
+        _adminLock.Unlock();
+    }
+
     static class UnknownInstantiation {
     public:
         UnknownInstantiation()

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -230,9 +230,6 @@ namespace ProxyStub {
                     result = _channel->Invoke(message, RPC::CommunicationTimeOut);
 
                     if (result != Core::ERROR_NONE) {
-                        if (result == Core::ERROR_TIMEDOUT) {
-                            Shutdown();
-                        }
                         TRACE_L1("Could not remote release the Proxy for Interface [0x%X]", message->Parameters().InterfaceId());
                         result |= COM_ERROR;
                     }
@@ -426,8 +423,6 @@ namespace ProxyStub {
                 delete &_parent;
             }
         }
-
-        void Shutdown() const;
 
     private:
         mutable Core::CriticalSection _adminLock;

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -321,33 +321,9 @@ namespace ProxyStub {
 
             return (message);
         }
-        inline uint32_t Invoke(Core::ProxyType<RPC::InvokeMessage>& message, const uint32_t waitTime = RPC::CommunicationTimeOut) const
-        {
-	    uint32_t result = Core::ERROR_UNAVAILABLE | COM_ERROR;
-		
-            _adminLock.Lock();
-	    Core::ProxyType<Core::IPCChannel> channel (_channel);
-            _adminLock.Unlock();
-		
-            if (channel.IsValid() == true) {
 
-                result = channel->Invoke(message, waitTime);
+        uint32_t Invoke(Core::ProxyType<RPC::InvokeMessage>& message, const uint32_t waitTime = RPC::CommunicationTimeOut) const;
 
-                if (result != Core::ERROR_NONE) {
-
-                    if (result == Core::ERROR_TIMEDOUT) {
-                        Shutdown();
-                    }
-
-                    result |= COM_ERROR;
-
-                    // Oops something failed on the communication. Report it.
-                     TRACE_L1("IPC method invocation failed for 0x%X, Method ID 0x%X error: %d", message->Parameters().InterfaceId(), message->Parameters().MethodId(), result);
-                }
-            }
-
-            return (result);
-        }
         inline uint32_t Complete(const Core::instance_id& impl, const uint32_t id, const RPC::Data::Output::mode how)
         {
             // This method is called from the stubs.

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -230,7 +230,7 @@ namespace ProxyStub {
                     result = _channel->Invoke(message, RPC::CommunicationTimeOut);
 
                     if (result != Core::ERROR_NONE) {
-                        TRACE_L1("Could not remote release the Proxy for Interface [0x%X]", message->Parameters().InterfaceId());
+                        TRACE_L1("Could not remote release the Proxy.");
                         result |= COM_ERROR;
                     }
                     else {

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -230,7 +230,10 @@ namespace ProxyStub {
                     result = _channel->Invoke(message, RPC::CommunicationTimeOut);
 
                     if (result != Core::ERROR_NONE) {
-                        TRACE_L1("Could not remote release the Proxy.");
+                        if (result == Core::ERROR_TIMEDOUT) {
+                            Shutdown();
+                        }
+                        TRACE_L1("Could not remote release the Proxy for Interface [0x%X]", message->Parameters().InterfaceId());
                         result |= COM_ERROR;
                     }
                     else {
@@ -333,13 +336,13 @@ namespace ProxyStub {
                 if (result != Core::ERROR_NONE) {
 
                     if (result == Core::ERROR_TIMEDOUT) {
-                        SYSLOG(Logging::Error, (_T("IPC method Invoke failed due to timeout (Interface ID 0x%X, Method ID 0x%X). Execution of code may or may not have happened. Side effects are to be expected after this message"), message->Parameters().InterfaceId(), message->Parameters().MethodId()));
+                        Shutdown();
                     }
 
                     result |= COM_ERROR;
 
                     // Oops something failed on the communication. Report it.
-                    TRACE_L1("IPC method invocation failed for 0x%X, error: %d", message->Parameters().InterfaceId(), result);
+                     TRACE_L1("IPC method invocation failed for 0x%X, Method ID 0x%X error: %d", message->Parameters().InterfaceId(), message->Parameters().MethodId(), result);
                 }
             }
 
@@ -447,6 +450,8 @@ namespace ProxyStub {
                 delete &_parent;
             }
         }
+
+        void Shutdown() const;
 
     private:
         mutable Core::CriticalSection _adminLock;

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -144,6 +144,7 @@ set(PUBLIC_HEADERS
         CallsignTLS.h
         TokenizedStringList.h
         MessageStore.h
+        ICustomErrorCode.h
         )
 
 target_compile_options (${TARGET} PRIVATE -Wno-psabi)

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -98,6 +98,29 @@ namespace Core {
         static constexpr uint8_t RealSize() {
             return (T::SizeOf);
         }
+
+        template <typename NEW_TYPE, typename ORIGINAL_TYPE>
+        bool check_and_cast(const ORIGINAL_TYPE& input, NEW_TYPE& output) {
+
+            ASSERT(input <= std::numeric_limits<NEW_TYPE>::max());
+            ASSERT(input >= std::numeric_limits<NEW_TYPE>::min());
+
+            bool success = false;
+
+            if ((input <= std::numeric_limits<NEW_TYPE>::max()) && (input >= std::numeric_limits<NEW_TYPE>::min())) {
+
+                success = true;
+
+                PUSH_WARNING(DISABLE_WARNING_CONVERSION_POSSIBLE_LOSS_OF_DATA)
+
+                output = static_cast<NEW_TYPE>(input);
+
+                POP_WARNING()
+            }
+
+            return success;
+
+        }
     }
 
     template <const uint32_t BLOCKSIZE, const bool BIG_ENDIAN_ORDERING = true, typename SIZE_CONTEXT = uint16_t>

--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -98,29 +98,6 @@ namespace Core {
         static constexpr uint8_t RealSize() {
             return (T::SizeOf);
         }
-
-        template <typename NEW_TYPE, typename ORIGINAL_TYPE>
-        bool check_and_cast(const ORIGINAL_TYPE& input, NEW_TYPE& output) {
-
-            ASSERT(input <= std::numeric_limits<NEW_TYPE>::max());
-            ASSERT(input >= std::numeric_limits<NEW_TYPE>::min());
-
-            bool success = false;
-
-            if ((input <= std::numeric_limits<NEW_TYPE>::max()) && (input >= std::numeric_limits<NEW_TYPE>::min())) {
-
-                success = true;
-
-                PUSH_WARNING(DISABLE_WARNING_CONVERSION_POSSIBLE_LOSS_OF_DATA)
-
-                output = static_cast<NEW_TYPE>(input);
-
-                POP_WARNING()
-            }
-
-            return success;
-
-        }
     }
 
     template <const uint32_t BLOCKSIZE, const bool BIG_ENDIAN_ORDERING = true, typename SIZE_CONTEXT = uint16_t>

--- a/Source/core/ICustomErrorCode.h
+++ b/Source/core/ICustomErrorCode.h
@@ -1,0 +1,56 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+    This file contains the interface that a library can implement in case the "custom error codes" feature is used in Thunder and code to string conversion is desired
+*/
+
+#pragma once
+
+#undef EXTERNAL
+
+#if defined(WIN32) || defined(_WINDOWS) || defined(__CYGWIN__) || defined(_WIN64)
+#define EXTERNAL __declspec(dllexport)
+#else
+#define EXTERNAL __attribute__((visibility("default")))
+#endif
+
+#ifndef TCHAR
+#ifdef _UNICODE
+#define TCHAR wchar_t
+#else
+#define TCHAR char
+#endif
+#endif
+
+#ifdef __cplusplus
+#include <cstdint>
+extern "C" {
+#else
+#include <stdint.h>
+#endif
+
+// called from within Thunder to get the string representation for a custom code
+// note parameter code is the pure (signed) Custom Code passed to Thunder. no additional bits set (so for signed numbers 32nd bit used as sign bit). 
+// in case no special string representation is needed return nullptr (NULL), in that case Thunder will convert the Custom Code to a generic message itself
+EXTERNAL const TCHAR* CustomCodeToString(const int32_t code);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif 

--- a/Source/core/IPCConnector.h
+++ b/Source/core/IPCConnector.h
@@ -550,6 +550,7 @@ POP_WARNING()
 
             bool InProgress() const
             {
+                Core::SafeSyncType<Core::CriticalSection> lock(_lock);
                 return (_outbound.IsValid());
             }
 

--- a/Source/core/IPCConnector.h
+++ b/Source/core/IPCConnector.h
@@ -758,6 +758,10 @@ POP_WARNING()
         {
             _customData = data;
         }
+        bool InProgress() const
+        {
+            return (_administration.InProgress());
+        }
 
         virtual uint32_t ReportResponse(Core::ProxyType<IIPC>& inbound) = 0;
 

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -4238,8 +4238,6 @@ namespace Core {
             mutable String _fieldName;
         };
 
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-
         class VariantContainer;
 
         class EXTERNAL Variant : public JSON::String {
@@ -4533,8 +4531,11 @@ namespace Core {
                 return String::IsSet();
             }
 
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
             string GetDebugString(const TCHAR name[], int indent = 0, int arrayIndex = -1) const;
 
+#endif
         private:
             // IElement iface:
             uint16_t Deserialize(const char stream[], const uint16_t maxLength, uint32_t& offset, Core::OptionalType<Error>& error) override;
@@ -5137,7 +5138,7 @@ namespace Core {
             }
         };
 
-#endif // __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+//#endif // __DISABLE_USE_COMPLEMENTARY_CODE_SET__
 
     } // namespace JSON
 } // namespace Core

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3816,8 +3816,7 @@ namespace Core {
             {
                 JSONElementList::iterator index(_data.begin());
 
-                while ((index != _data.end())
-                       &&(strncmp(index->first, label, std::min(strlen(label), strlen(index->first))) != 0)) {
+                while (index != _data.end() && (strlen(index->first) != strlen(label) || strcmp(index->first, label) != 0)) {
                     index++;
                 }
 

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3816,7 +3816,8 @@ namespace Core {
             {
                 JSONElementList::iterator index(_data.begin());
 
-                while ((index != _data.end()) && (index->first != label)) {
+                while ((index != _data.end())
+                       &&(strncmp(index->first, label, std::min(strlen(label), strlen(index->first))) != 0)) {
                     index++;
                 }
 
@@ -4862,7 +4863,8 @@ namespace Core {
 
             bool HasLabel(const TCHAR labelName[]) const
             {
-                return (Find(labelName) != _elements.end());
+                return (Find(labelName) != _elements.end()
+                        && Container::HasLabel(labelName) != false);
             }
 
             Iterator Variants() const
@@ -4876,6 +4878,16 @@ namespace Core {
                 _elements.clear();
             }
             string GetDebugString(int indent = 0) const;
+
+            void Remove(const TCHAR label[])
+            {
+                Elements::iterator index = Find(label);
+                if (index != _elements.end()) {
+                    _elements.erase(index);
+                }
+
+                Container::Remove(label);
+            }
 
         private:
             Elements::iterator Find(const TCHAR fieldName[])

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -2021,7 +2021,7 @@ namespace Core {
                             // We are assumed to be opaque, but all quoted string stuff is enclosed between quotes
                             // and should be considered for scope counting.
                             // Check if we are entering or leaving a quoted area in the opaque object
-                            if ((current == '\"') && ((_value.empty() == true) || IsEscaped(_value))) {
+                            if ((current == '\"') && (IsEscaped(_value) == false)) {
                                 // This is not an "escaped" quote, so it should be considered a real quote. It means
                                 // we are now entering or leaving a quoted area within the opaque struct...
                                 _flagsAndCounters ^= QuotedAreaBit;
@@ -2220,17 +2220,28 @@ namespace Core {
 
         private:
             bool IsEscaped(const string& value) const {
-                // This code determines if a lot of back slashes to esscape the backslash
-                // Is odd or even, so does it escape the last character..
-                // e.g. 'Test \\\\\\\\\\"' is not the escaping of the quote (")
-                //      'Test \\\\\\\\\" continued"'  is the escaping of th quote..
-                //      'Test \" and \" and than \\\"' are all escaped quotes 
-                uint32_t index = static_cast<uint32_t>(value.length() - 1);
-                uint32_t start = index;
-                while ( (index != static_cast<uint32_t>(~0)) && (value[index] == '\\') ) {
-                    index--;
+                bool escaped(false);
+
+                if (_value.empty() == false) {
+                    // This code determines if a lot of back slashes to esscape the backslash
+                    // Is odd or even, so does it escape the last character..
+                    // e.g. 'Test \\\\\\\\\\"' is not the escaping of the quote (")
+                    //      'Test \\\\\\\\\" continued"'  is the escaping of th quote..
+                    //      'Test \" and \" and than \\\"' are all escaped quotes
+                    // Subtracting 2 here, because the length is always counted by
+                    // starting @1, so to a zero based buffer, i need to substract 1
+                    // however that will give us the last character. This is the character
+                    // for which we would like to know if is is escaped, so I need to go
+                    // even one position before that one, hence -2
+                    uint32_t index = static_cast<uint32_t>(value.length() - 2);
+                    uint32_t count = 0;
+                    while ((index != static_cast<uint32_t>(~0)) && (value[index] == '\\')) {
+                        index--;
+                        count++;
+                    }
+                    escaped =  ((count % 2) != 0);
                 }
-                return (((start - index) % 2) == 0);
+                return (escaped);
             }
             bool InScope(const ScopeBracket mode) {
                 bool added = false;

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -4238,6 +4238,8 @@ namespace Core {
             mutable String _fieldName;
         };
 
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
         class VariantContainer;
 
         class EXTERNAL Variant : public JSON::String {
@@ -4531,11 +4533,8 @@ namespace Core {
                 return String::IsSet();
             }
 
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-
             string GetDebugString(const TCHAR name[], int indent = 0, int arrayIndex = -1) const;
 
-#endif
         private:
             // IElement iface:
             uint16_t Deserialize(const char stream[], const uint16_t maxLength, uint32_t& offset, Core::OptionalType<Error>& error) override;
@@ -5138,7 +5137,7 @@ namespace Core {
             }
         };
 
-//#endif // __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+#endif // __DISABLE_USE_COMPLEMENTARY_CODE_SET__
 
     } // namespace JSON
 } // namespace Core

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -35,7 +35,6 @@ namespace Core {
 
         class EXTERNAL Message : public Core::JSON::Container {
         public:
-            static constexpr int32_t ApplicationErrorCodeBase = -31000;
             class Info : public Core::JSON::Container {
             public:
                 Info()
@@ -126,24 +125,33 @@ namespace Core {
                         Text = _T("The service is in an Hibernated state!!!.");
                         break;
                     default:
-                        if ((frameworkError & COM_ERROR) != 0) {
-                            Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError & 0x7FFFFFFF) - 500;
-                        } else {
+                        if ((frameworkError & 0x80000000) == 0) {
+
+                            // Heras solution to enable the possibility to override the json rpc errorcode and make it fall into
+                            // the -32000 to -32099 range (as desired by some externally defined interfaces). The 1000 offset and -31000 base are chosen to on
+                            // one hand keep the current Thunder error codes used in 4.4 backwards compatible (so the numbers as reported in
+                            // json rpc will not change) while at the same time making sure that code used in dynamic json rpc override will behave
+                            // as in Thunder 5 (so if the error code is changed to 1000 there it will result in a -32000 error code reported for json rpc)
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
                             int32_t customcode = IsCustomCode(frameworkError);
                             if (customcode != 0) {
-                                Code = (customcode == std::numeric_limits<int32_t>::min() ? 0 : customcode);
-                            } else {
-#endif
-                                Code = ApplicationErrorCodeBase - static_cast<int32_t>(frameworkError);
-#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                                Code = (customcode == std::numeric_limits<int32_t>::max() ? 0 : customcode);
                             }
 #endif
+                            else if( frameworkError <= 999 ) {
+                                Code = static_cast<int32_t>(frameworkError);
+                            } else {
+                                Code = -31000 - static_cast<int32_t>(frameworkError);
+                            }
+                        } else {
+                            Code = static_cast<int32_t>(frameworkError & 0x7FFFFFFF) + 500;
                         }
-
-                        if (Text.IsSet() == false) {
-                            Text = Core::ErrorToStringExtended(frameworkError);
-                        }
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+                    if (Text.IsSet() == false) {
+                        Text = Core::ErrorToStringExtended(frameworkError);
+                    }
+#endif
+                        Text = Core::ErrorToString(frameworkError);
                         break;
                     }
                 }

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -141,7 +141,7 @@ namespace Core {
                         } else {
                             Code = static_cast<int32_t>(frameworkError & 0x7FFFFFFF) + 500;
                         }                       
-                        Text = Core::ErrorToString(frameworkError);
+                        Text = Core::ErrorToStringExtended(frameworkError);
                         break;
                     }
                 }

--- a/Source/core/JSONRPC.h
+++ b/Source/core/JSONRPC.h
@@ -25,6 +25,7 @@
 
 #include <cctype>
 #include <functional>
+#include <limits>
 #include <vector>
 
 namespace WPEFramework {
@@ -136,9 +137,9 @@ namespace Core {
                             int32_t customcode = IsCustomCode(frameworkError);
                             if (customcode != 0) {
                                 Code = (customcode == std::numeric_limits<int32_t>::max() ? 0 : customcode);
-                            }
+                            } else
 #endif
-                            else if( frameworkError <= 999 ) {
+                            if (frameworkError <= 999) {
                                 Code = static_cast<int32_t>(frameworkError);
                             } else {
                                 Code = -31000 - static_cast<int32_t>(frameworkError);
@@ -147,11 +148,12 @@ namespace Core {
                             Code = static_cast<int32_t>(frameworkError & 0x7FFFFFFF) + 500;
                         }
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-                    if (Text.IsSet() == false) {
-                        Text = Core::ErrorToStringExtended(frameworkError);
-                    }
-#endif
+                        if (Text.IsSet() == false) {
+                            Text = Core::ErrorToStringExtended(frameworkError);
+                        }
+#else
                         Text = Core::ErrorToString(frameworkError);
+#endif
                         break;
                     }
                 }

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -26,6 +26,7 @@
 #include "SystemInfo.h"
 #include "Serialization.h"
 #include "Number.h"
+#include "Frame.h"
 
 #ifdef __LINUX__
 #include <atomic>
@@ -456,7 +457,12 @@ namespace {
         hresult result = Core::ERROR_NONE;
 
         if (customCode != 0) {
-            result = static_cast<hresult>(customCode);
+            int24_t code;
+            if (Core::Frame::check_and_cast<int24_t, int32_t>(customCode, code) == true) {
+                result = static_cast<hresult>(code & 0xFFFFFF);
+            } else {
+                result = 0; // set invalid customCode result;
+            }
             result |= CUSTOM_ERROR; // set custom code bit
         }
 

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -421,7 +421,7 @@ namespace {
     {
         const TCHAR* text = nullptr;
 
-        if (customcode == std::numeric_limits<int32_t>::min()) {
+        if (customcode == std::numeric_limits<int32_t>::max()) {
             text = _T("Invalid Custom ErrorCode set");
         } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
             text = _T("Undefined Custom Error");
@@ -432,10 +432,11 @@ namespace {
 
     string HandleCustomErrorCodeToStringExtended(const int32_t customcode)
     {
+
         string result;
 
         const TCHAR* text = nullptr;
-        if (customcode == std::numeric_limits<int32_t>::min()) {
+        if (customcode == std::numeric_limits<int32_t>::max()) {
             result = _T("Invalid Custom ErrorCode set");
         } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
             result = _T("Undefined Custom Error: ") + Core::NumberType<int32_t>(customcode).Text();
@@ -488,7 +489,7 @@ namespace {
         int24_t result = 0;
 
         if ((code & CUSTOM_ERROR) != 0) {
-            result = static_cast<int32_t>(ToInt24_Truncate(code)); // remove custom error bit before assigning
+            result = static_cast<uint32_t>(ToInt24_Truncate(code)); // remove custom error bit before assigning
             if (result == 0) {
                 result = std::numeric_limits<int32_t>::max(); // this will assert in debug, but if that happens one managed to fill an hresult with an overflowed core result, that should have asserted already when using CustomCode to fill it, os this is probably caused by either manually incorrectly filling the hresult or memory corruption
             }
@@ -502,7 +503,7 @@ namespace {
     const TCHAR* ErrorToString(const Core::hresult code)
     {
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
-        int32_t customcode = IsCustomCode(code);
+        int24_t customcode = IsCustomCode(code);
 
         if (customcode != 0) {
             return HandleCustomErrorCodeToString(customcode);

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -25,6 +25,7 @@
 #include "Sync.h"
 #include "SystemInfo.h"
 #include "Serialization.h"
+#include "Number.h"
 
 #ifdef __LINUX__
 #include <atomic>
@@ -407,5 +408,111 @@ namespace Core {
     {
         toString(dst, format, ap);
     }
+    
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
+namespace {
+
+    static CustomCodeToStringHandler customerrorcodehandler = nullptr;
+
+    const TCHAR* HandleCustomErrorCodeToString(const int32_t customcode)
+    {
+        const TCHAR* text = nullptr;
+
+        if (customcode == std::numeric_limits<int32_t>::min()) {
+            text = _T("Invalid Custom ErrorCode set");
+        } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
+            text = _T("Undefined Custom Error");
+        } 
+
+        return text;
+    }
+
+    string HandleCustomErrorCodeToStringExtended(const int32_t customcode)
+    {
+        string result;
+
+        const TCHAR* text = nullptr;
+        if (customcode == std::numeric_limits<int32_t>::min()) {
+            result = _T("Invalid Custom ErrorCode set");
+        } else if ((customerrorcodehandler == nullptr) || ((text = customerrorcodehandler(customcode)) == nullptr)) {
+            result = _T("Undefined Custom Error: ") + Core::NumberType<int32_t>(customcode).Text();
+        } else {
+            result = text;
+        }
+
+        return result;
+    }
+
+}
+    void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler) {
+        customerrorcodehandler = handler;
+    }
+
+    hresult CustomCode(const int32_t customCode) {
+
+        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
+
+        hresult result = Core::ERROR_NONE;
+
+        if (customCode != 0) {
+            int24_t code; 
+            // if (Core::check_and_cast<int24_t, int32_t>(customCode, code) == true) {
+            //     result = static_cast<hresult>(customCode);
+            // } else {
+            //     result = 0; // set invalid customCode result;
+            // }
+            result |= CUSTOM_ERROR; // set custom code bit
+        }
+
+        return result;
+    }
+
+    int32_t IsCustomCode(const Core::hresult code) {
+        static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
+
+        int32_t result = 0;
+
+        if ((code & CUSTOM_ERROR) != 0) {
+            int24_t custumcode(code & 0xFFFFFF); // remove custom error bit before assigning
+            result = custumcode;
+            if (result == 0) {
+                result = std::numeric_limits<int32_t>::min();
+            }
+        }
+        return result;
+    }
+
+#endif
+
+    const TCHAR* ErrorToString(const Core::hresult code)
+    {
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        int32_t customcode = IsCustomCode(code);
+
+        if (customcode != 0) {
+            return HandleCustomErrorCodeToString(customcode);
+        }
+#endif
+        return _bogus_ErrorToString<>(code & (~COM_ERROR));
+    }
+
+    string ErrorToStringExtended(const Core::hresult code)
+    {
+#ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+        int32_t customcode = IsCustomCode(code);
+
+        if (customcode != 0) {
+            return HandleCustomErrorCodeToStringExtended(customcode);
+        }
+#endif
+        string result = _bogus_ErrorToString<>(code & (~COM_ERROR));
+
+        if (result.empty() == true) {
+            result = _T("Undefined Thunder error code: ") + Core::NumberType<Core::hresult>(code).Text();
+        }
+        return result;
+    }
+
 }
 }

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -456,12 +456,7 @@ namespace {
         hresult result = Core::ERROR_NONE;
 
         if (customCode != 0) {
-            int24_t code; 
-            // if (Core::check_and_cast<int24_t, int32_t>(customCode, code) == true) {
-            //     result = static_cast<hresult>(customCode);
-            // } else {
-            //     result = 0; // set invalid customCode result;
-            // }
+            result = static_cast<hresult>(customCode);
             result |= CUSTOM_ERROR; // set custom code bit
         }
 

--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -413,6 +413,7 @@ namespace Core {
     }
     
 #ifndef __DISABLE_USE_COMPLEMENTARY_CODE_SET__
+
 namespace {
 
     static CustomCodeToStringHandler customerrorcodehandler = nullptr;
@@ -447,7 +448,9 @@ namespace {
         return result;
     }
 }
-    void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler) {
+
+    void SetCustomCodeToStringHandler(CustomCodeToStringHandler handler)
+    {
         customerrorcodehandler = handler;
     }
 
@@ -463,8 +466,7 @@ namespace {
         return value;
     }
 
-
-    hresult CustomCode(const int32_t customCode) {
+    hresult CustomCode(const int24_t customCode) {
 
         static_assert(CUSTOM_ERROR == 0x1000000, "Code below assumes 25th bit used for CUSTOM_ERROR");
 
@@ -472,10 +474,11 @@ namespace {
 
         if (customCode != 0) {
 
-            ASSERT(customCode >= INT24_MIN && customCode <= INT24_MAX);
-
-            result = static_cast<hresult>(ToInt24_Truncate(customCode)) & 0x00FFFFFF;
-
+            if (customCode != std::numeric_limits<int32_t>::max()) {
+                result = static_cast<hresult>(customCode & 0xFFFFFF);
+            } else {
+                result = 0; // set invalid customCode result;
+            }
             result |= CUSTOM_ERROR; // set custom code bit
         }
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -837,7 +837,7 @@ namespace Core {
     // transform a custum code into an hresult
     EXTERNAL Core::hresult CustomCode(const int32_t customCode);
     // query if the hresult is a custom code and if so extract the value, returns 0 if the hresult was not a custom code
-    EXTERNAL int32_t IsCustomCode(const Core::hresult code);
+    EXTERNAL int24_t IsCustomCode(const Core::hresult code);
 
 #endif
 

--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -173,7 +173,7 @@
 #define DISABLE_WARNING_UNUSED_PARAMETERS PUSH_WARNING_ARG_(4100)
 // W4 - 'function': unreferenced function with internal linkage has been removed
 #define DISABLE_WARNING_UNUSED_FUNCTIONS PUSH_WARNING_ARG_(5242)
-/ W3 - 'argument': conversion from 'type' to 'type', possible loss of data
+// W3 - 'argument': conversion from 'type' to 'type', possible loss of data
 #define DISABLE_WARNING_CONVERSION_POSSIBLE_LOSS_OF_DATA PUSH_WARNING_ARG_(4267)
 #define DISABLE_WARNING_DEPRECATED_COPY
 #define DISABLE_WARNING_NON_VIRTUAL_DESTRUCTOR

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -1468,7 +1468,7 @@ POP_WARNING()
                 for (uint32_t index = 0; index < initialQueueSize; index++) {
                     Core::ProxyType<ContainerElement> newElement;
 
-                    Core::ProxyType<ContainerElement>::CreateMove(newElement, 0, *this, std::forward<Args>(args)...);
+                    Core::ProxyType<ContainerElement>::template CreateMove(newElement, 0, *this, std::forward<Args>(args)...);
                     _queue.emplace_back(std::move(newElement));
                     ASSERT(_queue.back().IsValid() == true);
                 }
@@ -1520,7 +1520,7 @@ POP_WARNING()
 
                     _lock.Unlock();
 
-                    Core::ProxyType<ContainerElement>::CreateMove(element, 0, *this, std::forward<Args>(args)...);
+                    Core::ProxyType<ContainerElement>::template CreateMove(element, 0, *this, std::forward<Args>(args)...);
 
                     result = Core::ProxyType<PROXYELEMENT>(element);
                 }
@@ -1638,7 +1638,7 @@ POP_WARNING()
                 if (index == _map.end()) {
                     // Oops we do not have such an element, create it...
                     Core::ProxyType<ActualElement> newItem;
-                    Core::ProxyType<ActualElement>CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
+                    Core::ProxyType<ActualElement>::template CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
 
                     if (newItem.IsValid() == true) {
 
@@ -1799,7 +1799,7 @@ POP_WARNING()
                 Core::ProxyType<ACTUALOBJECT> result;
 
                 Core::ProxyType<ActualElement> newItem;
-                Core::ProxyType<ActualElement>::CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
+                Core::ProxyType<ActualElement>::template CreateMove(newItem, 0, *this, std::forward<Args>(args)...);
 
                 if (newItem.IsValid() == true) {
 

--- a/Source/core/Singleton.h
+++ b/Source/core/Singleton.h
@@ -226,14 +226,19 @@ namespace Core {
         SingletonProxyType(const SingletonProxyType<PROXYTYPE>&) = delete;
         SingletonProxyType& operator=(const SingletonProxyType<PROXYTYPE>&) = delete;
 
-        static ProxyType<PROXYTYPE> Instance()
+        static ProxyType<PROXYTYPE>& Instance()
         {
             return (SingletonType<SingletonProxyType<PROXYTYPE>>::Instance()._wrapped);
         }
         template <typename... Args>
-        DEPRECATED static ProxyType<PROXYTYPE> Instance(Args&&... args)
+        DEPRECATED static ProxyType<PROXYTYPE>& Instance(Args&&... args)
         {
             return (SingletonType<SingletonProxyType<PROXYTYPE>>::Instance(std::forward<Args>(args)...)._wrapped);
+        }
+
+        ~SingletonProxyType()
+        {
+            ASSERT(ProxyType<PROXYTYPE>::LastRefAccessor::LastRef(_wrapped) == true);
         }
 
     private:

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1018,6 +1018,10 @@ namespace WPEFramework {
                 }
 
                 if ((IsForcedClosing() == true) && (Closed() == true)) {
+                    // In the Closed() method, which is only run on the Resouce Monitor Thread, the unregister
+                    // happens. After the Unregister the last bit in the _state is cleared which means that
+                    // there is nolonger a guarantee that the socket is alive anymore. Do not execute *any*
+                    // operation on the socket members anymore!!!
                     result = 0;
                     m_State &= ~SocketPort::MONITOR;
                 }
@@ -1043,6 +1047,10 @@ namespace WPEFramework {
 
 #ifdef __WINDOWS__
                 if ((flagsSet & FD_CLOSE) != 0) {
+                    // In the Closed() method, which is only run on the Resouce Monitor Thread, the unregister
+                    // happens. After the Unregister the last bit in the _state is cleared which means that
+                    // there is nolonger a guarantee that the socket is alive anymore. Do not execute *any*
+                    // operation on the socket members anymore!!!
                     Closed();
                 }
                 else if (IsListening()) {
@@ -1065,6 +1073,10 @@ namespace WPEFramework {
                 }
 #else
                 if ((flagsSet & POLLHUP) != 0) {
+                    // In the Closed() method, which is only run on the Resouce Monitor Thread, the unregister
+                    // happens. After the Unregister the last bit in the _state is cleared which means that
+                    // there is nolonger a guarantee that the socket is alive anymore. Do not execute *any*
+                    // operation on the socket members anymore!!!
                     TRACE_L3("HUP event received on socket %u", static_cast<uint32_t>(m_Socket));
                     Closed();
                 }
@@ -1247,26 +1259,22 @@ namespace WPEFramework {
 
             StateChange();
 
-            m_State &= (~SHUTDOWN);
+            DestroySocket(m_Socket);
+            ResourceMonitor::Instance().Unregister(*this);
 
-            if (m_State != 0) {
-                result = false;
-            }
-            else {
-                DestroySocket(m_Socket);
-                ResourceMonitor::Instance().Unregister(*this);
-                // Remove socket descriptor for UNIX domain datagram socket.
-                if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) &&
-                    ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM)) &&
-                    !m_SystemdSocket) {
-                    TRACE_L1("CLOSED: Remove socket descriptor %s", m_LocalNode.HostName().c_str());
+            // Remove socket descriptor for UNIX domain datagram socket.
+            if ((m_LocalNode.Type() == NodeId::TYPE_DOMAIN) &&
+                ((m_SocketType == SocketPort::LISTEN) || (SocketMode() != SOCK_STREAM)) &&
+                !m_SystemdSocket) {
+                TRACE_L1("CLOSED: Remove socket descriptor %s", m_LocalNode.HostName().c_str());
 #ifdef __WINDOWS__
-                    _unlink(m_LocalNode.HostName().c_str());
+                _unlink(m_LocalNode.HostName().c_str());
 #else
-                    unlink(m_LocalNode.HostName().c_str());
+                unlink(m_LocalNode.HostName().c_str());
 #endif
-                }
             }
+
+            m_State &= (~SHUTDOWN);
 
             m_syncAdmin.Unlock();
 

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1192,7 +1192,8 @@ namespace WPEFramework {
 
                 if (l_Size == 0) {
                     if ((m_State & SocketPort::LINK) != 0) {
-                        m_State = ((m_State & (~SocketPort::OPEN)) | SocketPort::EXCEPTION);
+                        m_State = ((m_State & (~SocketPort::OPEN)) | SocketPort::REMOTE_CLOSED );
+                        StateChange();
                     }
                 }
                 else if (l_Size != static_cast<uint32_t>(SOCKET_ERROR)) {
@@ -1205,7 +1206,8 @@ namespace WPEFramework {
                         m_State |= SocketPort::READ;
                     }
                     else if (l_Result == __ERROR_CONNRESET__) {
-                        m_State = ((m_State & (~SocketPort::OPEN)) | SocketPort::EXCEPTION);
+                        m_State = ((m_State & (~SocketPort::OPEN)) | SocketPort::REMOTE_CLOSED );
+                        StateChange();
                     }
                     else if (l_Result != 0) {
                         printf("Read exception %d: %s\n", l_Result, strerror(__ERRORRESULT__));

--- a/Source/core/SocketPort.h
+++ b/Source/core/SocketPort.h
@@ -68,6 +68,7 @@ namespace WPEFramework {
                 LINK = 0x040,
                 MONITOR = 0x080,
                 WRITESLOT = 0x100,
+                REMOTE_CLOSED = 0x200,
                 UPDATE = 0x8000
 
             } enumState;
@@ -139,7 +140,8 @@ namespace WPEFramework {
             }
             inline bool IsSuspended() const
             {
-                return ((State() & (SocketPort::SHUTDOWN | SocketPort::EXCEPTION)) == SocketPort::SHUTDOWN);
+                return (((State() & (SocketPort::SHUTDOWN | SocketPort::EXCEPTION| SocketPort::REMOTE_CLOSED)) == (SocketPort::SHUTDOWN)) ||
+                ((State() & (SocketPort::SHUTDOWN | SocketPort::EXCEPTION| SocketPort::REMOTE_CLOSED)) == (SocketPort::REMOTE_CLOSED)));
             }
             inline bool IsForcedClosing() const
             {

--- a/Source/core/SystemInfo.cpp
+++ b/Source/core/SystemInfo.cpp
@@ -167,12 +167,13 @@ namespace Core {
         struct sysinfo info;
         sysinfo(&info);
 
+        const uint64_t unit = (info.mem_unit != 0) ? info.mem_unit : 1;
         m_uptime = info.uptime;
-        m_totalram = info.totalram;
+        m_totalram = info.totalram * unit;
         m_pageSize = static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
-        m_freeram = info.freeram;
-        m_totalswap = info.totalswap;
-        m_freeswap = info.freeswap;
+        m_freeram = info.freeram * unit;
+        m_totalswap = info.totalswap * unit;
+        m_freeswap = info.freeswap * unit;
         m_cpuloadavg[0]=info.loads[0];
         m_cpuloadavg[1]=info.loads[1];
         m_cpuloadavg[2]=info.loads[2];
@@ -317,11 +318,12 @@ namespace Core {
         struct sysinfo info;
         sysinfo(&info);
 
+        const uint64_t unit = (info.mem_unit != 0) ? info.mem_unit : 1;
         m_uptime = info.uptime;
-        m_freeram = info.freeram;
-        m_totalram = info.totalram;
-        m_totalswap = info.totalswap;
-        m_freeswap = info.freeswap;
+        m_freeram = info.freeram * unit;
+        m_totalram = info.totalram * unit;
+        m_totalswap = info.totalswap * unit;
+        m_freeswap = info.freeswap * unit;
         m_cpuloadavg[0] = info.loads[0];
         m_cpuloadavg[1] = info.loads[1];
         m_cpuloadavg[2] = info.loads[2];

--- a/Source/core/WorkerPool.h
+++ b/Source/core/WorkerPool.h
@@ -365,10 +365,13 @@ POP_WARNING()
             uint32_t report = _threadPool.Revoke(job, waitTime);
 
             if (report == Core::ERROR_UNKNOWN_KEY) {
-                report = _external.Completed(job, waitTime);
-                
-                if ( (report != Core::ERROR_UNKNOWN_KEY) && (result == Core::ERROR_UNKNOWN_KEY) ) {
-                    result = report;
+               if (_joined == Thread::ThreadId()) {
+                    result = Core::ERROR_NONE;
+                } else {
+                    report = _external.Completed(job, waitTime);
+                    if ((report != Core::ERROR_UNKNOWN_KEY) && (result == Core::ERROR_UNKNOWN_KEY)) {
+                        result = report;
+                    }
                 }
             }
 

--- a/Source/plugins/IController.h
+++ b/Source/plugins/IController.h
@@ -47,8 +47,7 @@ namespace Controller {
         // @property
         // @brief Provides the value of request environment variable.
         // @return Environment value
-        virtual Core::hresult Environment(const string& index /* @index */, string& environment /* @out @opaque */ ) const = 0;
-
+        virtual Core::hresult Environment(const string& index /* @index */, string& environment /* @out */ ) const = 0;       
     };
 
     /* @json */

--- a/Tests/unit/Module.h
+++ b/Tests/unit/Module.h
@@ -1,0 +1,24 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME ThunderUnitTests
+#endif

--- a/Tests/unit/core/CMakeLists.txt
+++ b/Tests/unit/core/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(${TEST_RUNNER_NAME}
    #test_ipcclient.cpp
    test_iso639.cpp
    test_iterator.cpp
+   test_jsonobject.cpp
    test_jsonparser.cpp
    test_keyvalue.cpp
    test_library.cpp

--- a/Tests/unit/core/test_jsonobject.cpp
+++ b/Tests/unit/core/test_jsonobject.cpp
@@ -1,0 +1,190 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __APPLE__
+#include <time.h>
+#endif
+
+#include <gtest/gtest.h>
+
+#ifndef MODULE_NAME
+#include "../Module.h"
+#endif
+
+#include <core/core.h>
+
+namespace Thunder {
+namespace Tests {
+namespace Core {
+
+    TEST(JSONOBJECT, FirstKeyRemove)
+    {
+        const std::string keyValues = R"({"Name": "Your full name", "Age": 0, "Gender": "Undisclosed"})";
+
+        JsonObject container;
+
+        EXPECT_TRUE(container.FromString(keyValues));
+
+        EXPECT_FALSE(container.HasLabel("name"));
+
+        EXPECT_TRUE(container.HasLabel("Name"));
+
+        /* void */ container.Remove("Name");
+
+        EXPECT_FALSE(container.HasLabel("Name"));
+    }
+
+    TEST(JSONOBJECT, SecondKeyRemove)
+    {
+        const std::string keyValues = R"({"Name": "Your full name", "Age": 0, "Gender": "Undisclosed"})";
+
+        JsonObject container;
+
+        EXPECT_TRUE(container.FromString(keyValues));
+
+        EXPECT_FALSE(container.HasLabel("age"));
+
+        EXPECT_TRUE(container.HasLabel("Age"));
+
+        /* void */ container.Remove("Age");
+
+        EXPECT_FALSE(container.HasLabel("Age"));
+    }
+
+    TEST(JSONOBJECT, ThirdKeyRemove)
+    {
+        const std::string keyValues = R"({"Name": "Your full name", "Age": 0, "Gender": "Undisclosed"})";
+
+        JsonObject container;
+
+        EXPECT_TRUE(container.FromString(keyValues));
+
+        EXPECT_FALSE(container.HasLabel("gender"));
+
+        EXPECT_TRUE(container.HasLabel("Gender"));
+
+        /* void */ container.Remove("Gender");
+
+        EXPECT_FALSE(container.HasLabel("Gender"));
+    }
+
+    TEST(JSONOBJECT, IdenticalKeyValueRemove)
+    {
+        const std::string keyValues = R"({"Name": "Your full name", "Age": "Age", "Gender": "Undisclosed"})";
+
+        JsonObject container;
+
+        EXPECT_TRUE(container.FromString(keyValues));
+
+        EXPECT_FALSE(container.HasLabel("age"));
+
+        EXPECT_TRUE(container.HasLabel("Age"));
+
+        /* void */ container.Remove("Age");
+
+        EXPECT_FALSE(container.HasLabel("Age"));
+    }
+
+    TEST(JSONOBJECT, KeyValueAccess)
+    {
+        JsonObject container;
+
+        ::Thunder::Core::JSON::Variant intType{ 123 };
+        ::Thunder::Core::JSON::Variant floatType{ 123.456f };
+        ::Thunder::Core::JSON::Variant doubleType{ 123.456 }; // defaults to double with omitted suffix
+        ::Thunder::Core::JSON::Variant boolType{ true };
+        ::Thunder::Core::JSON::Variant stringType{ "scribble" };
+
+        // An empty JsonObject is valid
+        EXPECT_TRUE(container.IsValid());
+
+        /* void */ container.Set("integer", intType);
+        /* void */ container.Set("float", floatType);
+        /* void */ container.Set("double", doubleType);
+        /* void */ container.Set("boolean", boolType);
+        /* void */ container.Set("string", stringType);
+
+        // All contained elements are valid
+        EXPECT_TRUE(container.IsValid());
+
+        ::Thunder::Core::JSON::Variant intFound     = container.Get("integer");
+        // Create and add if it does not exist otherwise return the existing element
+        ::Thunder::Core::JSON::Variant& intRefFound = container["integer"];
+
+        EXPECT_TRUE(intFound.Content() == ::Thunder::Core::JSON::Variant::type::NUMBER);
+        EXPECT_EQ(intFound.Number(), 123);
+        EXPECT_TRUE(intFound == intRefFound);
+
+        ::Thunder::Core::JSON::Variant floatFound = container.Get("float");
+        ::Thunder::Core::JSON::Variant& floatRefFound = container["float"];
+        EXPECT_TRUE(floatFound.Content() == ::Thunder::Core::JSON::Variant::type::FLOAT);
+        EXPECT_FLOAT_EQ(floatFound.Float(), 123.456);
+        EXPECT_TRUE(floatFound == floatRefFound);
+
+        ::Thunder::Core::JSON::Variant doubleFound = container.Get("double");
+        ::Thunder::Core::JSON::Variant& doubleRefFound = container["double"];
+        EXPECT_TRUE(doubleFound.Content() == ::Thunder::Core::JSON::Variant::type::DOUBLE);
+        EXPECT_FLOAT_EQ(doubleFound.Float(), 123.456);
+        EXPECT_TRUE(doubleFound == doubleRefFound);
+
+        ::Thunder::Core::JSON::Variant boolFound = container.Get("boolean");
+        ::Thunder::Core::JSON::Variant& boolRefFound = container["boolean"];
+        EXPECT_TRUE(boolFound.Content() == ::Thunder::Core::JSON::Variant::type::BOOLEAN);
+        EXPECT_EQ(boolFound.Boolean(), true);
+        EXPECT_TRUE(boolFound == boolRefFound);
+
+        ::Thunder::Core::JSON::Variant stringFound = container.Get("string");
+        ::Thunder::Core::JSON::Variant& stringRefFound = container["string"];
+        EXPECT_TRUE(stringFound.Content() == ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_STREQ(stringFound.String().c_str(), "scribble");
+        EXPECT_TRUE(stringFound == stringRefFound);
+
+        container.Clear();
+
+        // The container should have nothing to index
+        ::Thunder::Core::JSON::VariantContainer::Iterator it = container.Variants();
+        EXPECT_FALSE(it.IsValid());
+
+        // It does not exist so a default constructed variant is returned
+        // Create and add a default variant with the label 'integer'
+        ::Thunder::Core::JSON::Variant& intRefCreated = container["integer"];
+        EXPECT_TRUE(container.HasLabel("integer"));
+        EXPECT_TRUE(intRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+
+        ::Thunder::Core::JSON::Variant& floatRefCreated = container["float"];
+        EXPECT_TRUE(container.HasLabel("float"));
+        EXPECT_TRUE(floatRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+
+        ::Thunder::Core::JSON::Variant& doubleRefCreated = container["double"];
+        EXPECT_TRUE(container.HasLabel("double"));
+        EXPECT_TRUE(doubleRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+
+        ::Thunder::Core::JSON::Variant& boolRefCreated = container["boolean"];
+        EXPECT_TRUE(container.HasLabel("boolean"));
+        EXPECT_TRUE(boolRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+
+        ::Thunder::Core::JSON::Variant& stringRefCreated = container["string"];
+        EXPECT_TRUE(container.HasLabel("string"));
+        EXPECT_TRUE(stringRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+    }
+
+
+} // Core
+} // Tests
+} // Thunder

--- a/Tests/unit/core/test_jsonobject.cpp
+++ b/Tests/unit/core/test_jsonobject.cpp
@@ -29,7 +29,7 @@
 
 #include <core/core.h>
 
-namespace Thunder {
+namespace WPEFramework {
 namespace Tests {
 namespace Core {
 
@@ -105,11 +105,11 @@ namespace Core {
     {
         JsonObject container;
 
-        ::Thunder::Core::JSON::Variant intType{ 123 };
-        ::Thunder::Core::JSON::Variant floatType{ 123.456f };
-        ::Thunder::Core::JSON::Variant doubleType{ 123.456 }; // defaults to double with omitted suffix
-        ::Thunder::Core::JSON::Variant boolType{ true };
-        ::Thunder::Core::JSON::Variant stringType{ "scribble" };
+        ::WPEFramework::Core::JSON::Variant intType{ 123 };
+        ::WPEFramework::Core::JSON::Variant floatType{ 123.456f };
+        ::WPEFramework::Core::JSON::Variant doubleType{ 123.456 }; // defaults to double with omitted suffix
+        ::WPEFramework::Core::JSON::Variant boolType{ true };
+        ::WPEFramework::Core::JSON::Variant stringType{ "scribble" };
 
         // An empty JsonObject is valid
         EXPECT_TRUE(container.IsValid());
@@ -123,68 +123,68 @@ namespace Core {
         // All contained elements are valid
         EXPECT_TRUE(container.IsValid());
 
-        ::Thunder::Core::JSON::Variant intFound     = container.Get("integer");
+        ::WPEFramework::Core::JSON::Variant intFound     = container.Get("integer");
         // Create and add if it does not exist otherwise return the existing element
-        ::Thunder::Core::JSON::Variant& intRefFound = container["integer"];
+        ::WPEFramework::Core::JSON::Variant& intRefFound = container["integer"];
 
-        EXPECT_TRUE(intFound.Content() == ::Thunder::Core::JSON::Variant::type::NUMBER);
+        EXPECT_TRUE(intFound.Content() == ::WPEFramework::Core::JSON::Variant::type::NUMBER);
         EXPECT_EQ(intFound.Number(), 123);
         EXPECT_TRUE(intFound == intRefFound);
 
-        ::Thunder::Core::JSON::Variant floatFound = container.Get("float");
-        ::Thunder::Core::JSON::Variant& floatRefFound = container["float"];
-        EXPECT_TRUE(floatFound.Content() == ::Thunder::Core::JSON::Variant::type::FLOAT);
+        ::WPEFramework::Core::JSON::Variant floatFound = container.Get("float");
+        ::WPEFramework::Core::JSON::Variant& floatRefFound = container["float"];
+        EXPECT_TRUE(floatFound.Content() == ::WPEFramework::Core::JSON::Variant::type::FLOAT);
         EXPECT_FLOAT_EQ(floatFound.Float(), 123.456);
         EXPECT_TRUE(floatFound == floatRefFound);
 
-        ::Thunder::Core::JSON::Variant doubleFound = container.Get("double");
-        ::Thunder::Core::JSON::Variant& doubleRefFound = container["double"];
-        EXPECT_TRUE(doubleFound.Content() == ::Thunder::Core::JSON::Variant::type::DOUBLE);
+        ::WPEFramework::Core::JSON::Variant doubleFound = container.Get("double");
+        ::WPEFramework::Core::JSON::Variant& doubleRefFound = container["double"];
+        EXPECT_TRUE(doubleFound.Content() == ::WPEFramework::Core::JSON::Variant::type::DOUBLE);
         EXPECT_FLOAT_EQ(doubleFound.Float(), 123.456);
         EXPECT_TRUE(doubleFound == doubleRefFound);
 
-        ::Thunder::Core::JSON::Variant boolFound = container.Get("boolean");
-        ::Thunder::Core::JSON::Variant& boolRefFound = container["boolean"];
-        EXPECT_TRUE(boolFound.Content() == ::Thunder::Core::JSON::Variant::type::BOOLEAN);
+        ::WPEFramework::Core::JSON::Variant boolFound = container.Get("boolean");
+        ::WPEFramework::Core::JSON::Variant& boolRefFound = container["boolean"];
+        EXPECT_TRUE(boolFound.Content() == ::WPEFramework::Core::JSON::Variant::type::BOOLEAN);
         EXPECT_EQ(boolFound.Boolean(), true);
         EXPECT_TRUE(boolFound == boolRefFound);
 
-        ::Thunder::Core::JSON::Variant stringFound = container.Get("string");
-        ::Thunder::Core::JSON::Variant& stringRefFound = container["string"];
-        EXPECT_TRUE(stringFound.Content() == ::Thunder::Core::JSON::Variant::type::STRING);
+        ::WPEFramework::Core::JSON::Variant stringFound = container.Get("string");
+        ::WPEFramework::Core::JSON::Variant& stringRefFound = container["string"];
+        EXPECT_TRUE(stringFound.Content() == ::WPEFramework::Core::JSON::Variant::type::STRING);
         EXPECT_STREQ(stringFound.String().c_str(), "scribble");
         EXPECT_TRUE(stringFound == stringRefFound);
 
         container.Clear();
 
         // The container should have nothing to index
-        ::Thunder::Core::JSON::VariantContainer::Iterator it = container.Variants();
+        ::WPEFramework::Core::JSON::VariantContainer::Iterator it = container.Variants();
         EXPECT_FALSE(it.IsValid());
 
         // It does not exist so a default constructed variant is returned
         // Create and add a default variant with the label 'integer'
-        ::Thunder::Core::JSON::Variant& intRefCreated = container["integer"];
+        ::WPEFramework::Core::JSON::Variant& intRefCreated = container["integer"];
         EXPECT_TRUE(container.HasLabel("integer"));
-        EXPECT_TRUE(intRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+        EXPECT_TRUE(intRefCreated.Content() == ::WPEFramework::Core::JSON::Variant::type::EMPTY);
 
-        ::Thunder::Core::JSON::Variant& floatRefCreated = container["float"];
+        ::WPEFramework::Core::JSON::Variant& floatRefCreated = container["float"];
         EXPECT_TRUE(container.HasLabel("float"));
-        EXPECT_TRUE(floatRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+        EXPECT_TRUE(floatRefCreated.Content() == ::WPEFramework::Core::JSON::Variant::type::EMPTY);
 
-        ::Thunder::Core::JSON::Variant& doubleRefCreated = container["double"];
+        ::WPEFramework::Core::JSON::Variant& doubleRefCreated = container["double"];
         EXPECT_TRUE(container.HasLabel("double"));
-        EXPECT_TRUE(doubleRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+        EXPECT_TRUE(doubleRefCreated.Content() == ::WPEFramework::Core::JSON::Variant::type::EMPTY);
 
-        ::Thunder::Core::JSON::Variant& boolRefCreated = container["boolean"];
+        ::WPEFramework::Core::JSON::Variant& boolRefCreated = container["boolean"];
         EXPECT_TRUE(container.HasLabel("boolean"));
-        EXPECT_TRUE(boolRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+        EXPECT_TRUE(boolRefCreated.Content() == ::WPEFramework::Core::JSON::Variant::type::EMPTY);
 
-        ::Thunder::Core::JSON::Variant& stringRefCreated = container["string"];
+        ::WPEFramework::Core::JSON::Variant& stringRefCreated = container["string"];
         EXPECT_TRUE(container.HasLabel("string"));
-        EXPECT_TRUE(stringRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
+        EXPECT_TRUE(stringRefCreated.Content() == ::WPEFramework::Core::JSON::Variant::type::EMPTY);
     }
 
 
 } // Core
 } // Tests
-} // Thunder
+} // WPEFramework

--- a/Tests/unit/core/test_jsonobject.cpp
+++ b/Tests/unit/core/test_jsonobject.cpp
@@ -50,6 +50,25 @@ namespace Core {
         EXPECT_FALSE(container.HasLabel("Name"));
     }
 
+    TEST(JSONOBJECT, KeyRemoveWithPartialMatch)
+    {
+        const std::string keyValues = R"({"Service": "Wifi", "Wifi_ssid": "ssid-name", "Wifi_key": 0, "status": "Connected"})";
+
+        JsonObject container;
+
+        EXPECT_TRUE(container.FromString(keyValues));
+
+        EXPECT_FALSE(container.HasLabel("Wifi"));
+
+        EXPECT_TRUE(container.HasLabel("Wifi_ssid"));
+
+        /* void */ container.Remove("Wifi");
+
+        EXPECT_TRUE(container.HasLabel("Wifi_ssid"));
+
+    }
+
+
     TEST(JSONOBJECT, SecondKeyRemove)
     {
         const std::string keyValues = R"({"Name": "Your full name", "Age": 0, "Gender": "Undisclosed"})";


### PR DESCRIPTION
    Below list of fixes were ported from master to R4_4
 • [Core] another typo in the header file... ([#2024](https://github.com/rdkcentral/Thunder/pull/2024))
	• [Core] Type in comment ([#2021](https://github.com/rdkcentral/Thunder/pull/2021))
	• Starting COM after Controller is initialized ([#2001](https://github.com/rdkcentral/Thunder/pull/2001))
	• Break dependency of UnknownProxy::Invoke ([#1999](https://github.com/rdkcentral/Thunder/pull/1999))
	• [Core] disable webrequest incomplete assert for now ([#1992](https://github.com/rdkcentral/Thunder/pull/1992))
	• [LIMIT] Limit handing out interfaces of Plugins *only* if the plugin is active! ([#1977](https://github.com/rdkcentral/Thunder/pull/1977))
	• [FIX] for issue [#1948](https://github.com/rdkcentral/Thunder/issues/1948) ([#1976](https://github.com/rdkcentral/Thunder/pull/1976))

	• [METADATADISCOVERY] Make the Metadata discover configurable. ([#1972](https://github.com/rdkcentral/Thunder/pull/1972))
	* [METADATADISCOVERY] Make the Metadata discover configurable. For automatic configuration of the subsystems and plugin version retrieval, thunder loads all plugins into memory at startup without starting them. This allows for a proper build up of the subsystem dependencies (read from the build in code of the plugin) and allows for retrieval of plugin versions, without the plugins being activated. This feature however, moves the additional loading time of each plugin, into the Thunder startup timer. If squashfilesystem (assumption this is the rootcasue) is used and you have a great deal of plugins that are not activated at startup, increase the Thunder Plugin time by 6 Seconds. Measurements using an ext4 filesystem show (using 150 reference stack plugins) that the additional loading time is increased by 600mS. To reduce the startup time of the software it was requested by Comcast to make this feature configurable. With this PR, there is a flag in the config called "discovery". By default it is true Comcast can, in their build, configure this to false. If configured to false, the plugins are nolonger preloaded to extracte the metadata from the plugins, effectively reducing the initial startup time of Thunder. Note: If disabled, the subsystems functionality, is nolonger taken from the plugin and if needed must be placed in the plugin config, manual labour, error prone but still available. Versions of plugins will not give any output as long as the plugin is not loaded, at least once. So the plugin must be at least started once to get this version info. The startup time is still required at first startup, so the feature only "moves" the startup time from Thunder to whenever the plugin is activated for the first time! Bottonlime: From Thunder perspective, it is *not* recommended to turn of the "discovery"!

	• [core] make it more clear ErrorToString now handles hresult correctly ([#1896](https://github.com/rdkcentral/Thunder/pull/1896))
	• [core] Fix CoreErrorToString For ComError ([#1894](https://github.com/rdkcentral/Thunder/pull/1894))
	• [com] Fix DefaultInvokeServer for Windows (and SingletonProxyType improvements) ([#1892](https://github.com/rdkcentral/Thunder/pull/1892))
	• [com] log comrpc timeout reached on invoke to syslog ([#1882](https://github.com/rdkcentral/Thunder/pull/1882))
	• Development/metrol 1231 ([#2038](https://github.com/rdkcentral/Thunder/pull/2038))
	• Metrol-1231: Corrected Remove() to act on exact key match ([#2051](https://github.com/rdkcentral/Thunder/pull/2051))
 

	• SocketPort Imrovments(2004 branch)
		
		○ Removing unwanted assert ([#2025](https://github.com/rdkcentral/Thunder/pull/2025))

		If the Closed() method, was run, it would set the m_State = 0, which meant that the SocketPort class was ([#2004](https://github.com/rdkcentral/Thunder/pull/2004))
		closed and eligable for destruction. iThe CLosed() is always running on the ResourceMonitor thread. In a race condition, this setting of the m_State = 0 allowed a server to "cleanup" the children (Clients). In the unlucky case that after the setting of the m_State =0, the kernel would preempt the ResourceMonitor thread for later continuation, the Server cleanup thread migh have killed the whole SocketPort object. Effectively any operation following the closed() on the ResourceMonitor threas that was preempted and continues would happen on a dead object! [ReourceMonitorThread] SocketPort::Closed() { ... m_State -> 0 [preempted] [Server Cleanup Thread] Delete all Clients that are Closed() [preemted] [ResourceMonitorThread] m_State &= ~SocketPort::MONITOR; CRASH! ... } This PR prevents this race condition from happening. As this is in the core of Thunder, the biggest risk is the Lock in the destructor. It might casue (if the socket is used incorrectly) to ABBA locks. Request thorough testing ! Also the ASSERT to validate if the CLosed() is indeed only run on the resource monitor thread is a risk!
		
		○ Remove some more risky changes

		○ Propagating Socket StateChange to layers above ([#1941](https://github.com/rdkcentral/Thunder/pull/1941))

		○ Reverting to original Closed logic ([#2013](https://github.com/rdkcentral/Thunder/pull/2013))
			We are reverting to the original logic in Closed as we missed a scenario where the socket might be entering listening state during state change.