### PR TITLE
Fix failing dynamic cast for macos

### DIFF
--- a/Source/com/Communicator.cpp
+++ b/Source/com/Communicator.cpp
@@ -598,7 +598,7 @@ namespace RPC {
         // Message delivered and responded on....
         RPC::AnnounceMessage* announceMessage = static_cast<RPC::AnnounceMessage*>(&element);
 
-        ASSERT(dynamic_cast<RPC::AnnounceMessage*>(&element) != nullptr);
+        ASSERT(element.Label() == RPC::AnnounceMessage::Id());
 
         if (announceMessage->Response().IsSet() == true) {
             string jsonMessagingCategories(announceMessage->Response().MessagingCategories());


### PR DESCRIPTION
Here is a small example that will demonstrate the problem.

https://gist.github.com/sramani-metro/5ae93a88f86cba00e6e5813257c78156

Use the following command on Linux and macos to see the problem and workaround in action

# git clone https://gist.github.com/sramani-metro/5ae93a88f86cba00e6e5813257c78156 dylib_cast_demo && cd dylib_cast_demo && bash build.sh
# ./main