### PR TITLE
[Core] Add LockFixedBuffer to Frame

### DIFF
--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -207,6 +207,15 @@ namespace Core {
             {
                 return (_container == nullptr ? 0 : _container->Size() - _offset);
             }
+            SIZE_CONTEXT LockFixedBuffer(const uint8_t*& buffer, const uint32_t length) const
+            {
+                ASSERT(_container != nullptr);
+                ASSERT(length <= Length());
+
+                buffer = &(_container->operator[](_offset));
+
+                return (length < Length() ? Length() : length);
+            }
             template <typename TYPENAME>
             TYPENAME LockBuffer(const uint8_t*& buffer) const
             {
@@ -215,6 +224,8 @@ namespace Core {
                 ASSERT(_container != nullptr);
 
                 _offset += _container->GetNumber<TYPENAME>(_offset, result);
+                ASSERT(result <= Length());
+
                 buffer = &(_container->operator[](_offset));
 
                 return (result);
@@ -223,6 +234,7 @@ namespace Core {
             void UnlockBuffer(TYPENAME length) const
             {
                 ASSERT(_container != nullptr);
+                ASSERT(length <= Length());
 
                 _offset += length;
             }
@@ -295,14 +307,16 @@ namespace Core {
 
                 return (result);
             }
-            const uint8_t* Data() const {
-
+            const uint8_t* Data() const
+            {
                 ASSERT(_container != nullptr);
 
                 return (&(_container->Data()[_offset]));
             }
-            void Forward (const SIZE_CONTEXT skip) {
+            void Forward(const SIZE_CONTEXT skip)
+            {
                 ASSERT(skip <= Length());
+
                 _offset += skip;
             }
             template <typename TYPENAME>


### PR DESCRIPTION
To pass a c-style byte array or macadress you does not need to store the length.