### PR TITLE
RDKDEV-1206 ERROR_ILLEGAL_STATE on quick rectivate

### DIFF
--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -332,6 +332,11 @@ namespace PluginHost {
 
         IShell::state currentState(State());
 
+        if (currentState == IShell::DEACTIVATION) {
+            // give the plugin some time to finish with the deactivation to avoid ERROR_ILLEGAL_STATE
+            currentState = waitForInitializationStateChange(500);
+        }
+
         if (currentState == IShell::state::ACTIVATION) {
             Unlock();
             result = Core::ERROR_INPROGRESS;
@@ -404,6 +409,8 @@ namespace PluginHost {
 
                 _administrator.Initialize(callSign, this);
 
+                _initDeinitDone.ResetEvent();
+
                 State(ACTIVATION);
 
                 Unlock();
@@ -472,6 +479,7 @@ namespace PluginHost {
                     #endif
                     Notify(_T("statechange"), string(_T("{\"state\":\"activated\",\"reason\":\"")) + textReason.Data() + _T("\"}"));
                 }
+                _initDeinitDone.SetEvent();
             }
         } else {
             Unlock();
@@ -521,6 +529,11 @@ namespace PluginHost {
 
         IShell::state currentState(State());
 
+        if (currentState == IShell::ACTIVATION && why != IShell::INITIALIZATION_FAILED) {
+            // give the plugin some time to finish current activation (to avoid ERROR_ILLEGAL_STATE)
+            currentState = waitForInitializationStateChange(500);
+        }
+
         if (currentState == IShell::state::DEACTIVATION) {
             result = Core::ERROR_INPROGRESS;
             Unlock();
@@ -552,6 +565,7 @@ namespace PluginHost {
                 ASSERT(_handler != nullptr);
 
                 State(DEACTIVATION);
+                _initDeinitDone.ResetEvent();
 
                 SystemInfo& systeminfo = _administrator.SubSystemInfo();
 
@@ -591,6 +605,8 @@ namespace PluginHost {
                 REPORT_DURATION_WARNING( { _handler->Deinitialize(this); }, WarningReporting::TooLongPluginState, WarningReporting::TooLongPluginState::StateChange::DEACTIVATION, callSign.c_str());
 
                 Lock();
+
+                _initDeinitDone.SetEvent();
 
                 if (currentState != IShell::state::ACTIVATION) {
                     SYSLOG(Logging::Shutdown, (_T("Deactivated plugin [%s]:[%s]"), className.c_str(), callSign.c_str()));
@@ -916,6 +932,15 @@ namespace PluginHost {
         }
 
         _administrator.Notification(PluginHost::Service::Callsign(), jsonrpcEvent, message);
+    }
+
+    // the caller needs to hold _adminLock!
+    IShell::state Server::Service::waitForInitializationStateChange(int timeMaxMs) {
+        // gives the plugin some time to finish with current ACTIVATION or DEACTIVATION to avoid ERROR_ILLEGAL_STATE
+        Unlock();
+        _initDeinitDone.Lock(timeMaxMs);
+        Lock();
+        return State();
     }
 
     //

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -853,6 +853,7 @@ namespace PluginHost {
                 , _composit(*this)
                 , _jobs(administrator)
                 , _type(type)
+                , _initDeinitDone(true, true)
             {
                 _jobs.Slots(_metadata.MaxRequests());
             }
@@ -1675,6 +1676,8 @@ namespace PluginHost {
                 }
             }
 
+            IShell::state waitForInitializationStateChange(int timeMaxMs);
+
         protected:
             ServiceMap& Administrator() {
                 return (_administrator);
@@ -1714,6 +1717,7 @@ namespace PluginHost {
             Core::SinkType<Composit> _composit;
             Jobs _jobs;
             mode _type;
+            mutable Core::Event _initDeinitDone;
 
             static Core::ProxyType<Web::Response> _unavailableHandler;
             static Core::ProxyType<Web::Response> _missingHandler;


### PR DESCRIPTION
In case of quick plugin deactivate/activate requests, it is currently possible for Thunder to respond with ERROR_ILLEGAL_STATE.
Seems that this is due to synchronisation implementation in Server::Service::Activate and Server::Service::Deactivate; while the execution is generally guarded with lock, these methods are partially allowed to run in parallel (there are parts of init/deinit code that run outside of critical section). And depending on the timing, the plugin state can still be DEACTIVATION when Activate starts to execute; in such case the request fails with ERROR_ILLEGAL_STATE. 
Exiting of critical section inside of Activate/Deactivate seems to be by design, to allow the plugins Initialize/Deinitialize methds run witout the Service admin lock, and would probably be dangerous to change (might result in deadlocks on initialization of some plugis, depending on plugins implementation, outside of Thunder core). Other solution would be to wait for some limited time to allow the ACTIVATION / DEACTIVATION action to finish.

This PR adds a mechanism to allow for up to 500ms for activation/deactivation to finish, before failing with ERROR_ILLEGAL_STATE.

Tested mostly on LG stb devices; also sanity-checked on linux/x86-64 with a script:

while true; do curl -X PUT http://127.0.0.1:9998/Service/Controller/Deactivate/OCDM; curl http://127.0.0.1:9998/Service/Controller | jq -r '.plugins[] | select(.callsign == "OCDM") | .state'; curl -X PUT http://127.0.0.1:9998/Service/Controller/Activate/OCDM; curl http://127.0.0.1:9998/Service/Controller | jq -r '.plugins[] | select(.callsign == "OCDM") | .state'; done 2>/dev/null