### PR TITLE
Development/coverity scan fixes

### DIFF
--- a/Source/Thunder/Controller.cpp
+++ b/Source/Thunder/Controller.cpp
@@ -1585,6 +1585,9 @@ namespace Plugin {
             extensions |= IMetadata::Data::BuildInfo::PROCESS_CONTAINERS;
         #endif
         
+        // coverity[DEADCODE] - extensions is set via #ifdef blocks above. If no optional
+        // features are enabled the guard is dead in that build configuration, but it is
+        // intentionally defensive for all other configurations.
         if (extensions != 0) {
             buildInfo.Extensions = static_cast<IMetadata::Data::BuildInfo::extensiontype>(extensions);
         }

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -1391,12 +1391,17 @@ namespace PluginHost {
     void Server::Close()
     {
         Plugin::Controller* destructor(_controller->ClassType<Plugin::Controller>());
-        destructor->AddRef();
-        _connections.Close(100);
-        destructor->Stopped();
-        _services.Close();
-        _dispatcher.Stop();
-        destructor->Release();
+
+        ASSERT(destructor != nullptr);
+
+        if (destructor != nullptr) {
+            destructor->AddRef();
+            _connections.Close(100);
+            destructor->Stopped();
+            _services.Close();
+            _dispatcher.Stop();
+            destructor->Release();
+        }
         _inputHandler.Deinitialize();
         _connections.Close(Core::infinite);
 

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -764,6 +764,9 @@ namespace PluginHost {
                     local->Release();
                     result = Core::ERROR_NONE;
 #endif
+                    // coverity[DEADCODE] - On the non-HIBERNATE_ENABLED path result is always
+                    // ERROR_NONE here, making the else-if appear unreachable to Coverity.
+                    // Both branches are reachable when HIBERNATE_ENABLED is defined.
                     if (result == Core::ERROR_NONE) {
                         if (State() == IShell::state::HIBERNATED) {
                             SYSLOG(Logging::Startup, ("Hibernated plugin [%s]:[%s]", ClassName().c_str(), Callsign().c_str()));

--- a/Source/Thunder/PluginServer.cpp
+++ b/Source/Thunder/PluginServer.cpp
@@ -229,6 +229,9 @@ namespace PluginHost {
 
     void Server::ServiceMap::Destroy()
     {
+        // coverity[ATOMICITY] - Lock is intentionally dropped around Deactivate() which can
+        // block. The iterator is refreshed (begin()) after re-acquiring the lock each iteration.
+        // This is correct lock-straddling, not a race.
         _adminLock.Lock();
 
         // First, move them all to deactivated except Controller
@@ -951,6 +954,9 @@ namespace PluginHost {
 
     void Server::ServiceMap::Close()
     {
+        // coverity[ATOMICITY] - Lock is intentionally dropped around Deactivate() which can
+        // block. The iterator is refreshed after re-acquiring the lock each iteration.
+        // This is correct lock-straddling, not a race.
         _adminLock.Lock();
 
         Core::ProxyType<Service> controller(_server.Controller());

--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -658,7 +658,7 @@ namespace PluginHost {
                         ASSERT_VERBOSE(((_state & 0x1) == state::STATE_OR), "Must not use NOT_ in preconditions (subsystem 0x%08x)", input);
 
                         // Make sure the event is only set once (POSITIVE or NEGATIVE)
-                        if ((((_mask & (1 << bitNr)) != 0) && ((_events & (1 << bitNr)) != 0)) || ((_state & 0x1) != state::STATE_OR)) {
+                        if ((((_mask & (1u << bitNr)) != 0) && ((_events & (1u << bitNr)) != 0)) || ((_state & 0x1) != state::STATE_OR)) {
                             _state = STATE_ERROR;
                         }
                     }
@@ -666,16 +666,16 @@ namespace PluginHost {
                         ASSERT_VERBOSE(((_state & 0x1) == state::STATE_AND), "Must only use NOT_ in terminations (subsystem 0x%08x)", input);
 
                         // Make sure the event is only set once (POSITIVE or NEGATIVE)
-                        if ((((_mask & (1 << bitNr)) != 0) && ((_events & (1 << bitNr)) == 0)) || ((_state & 0x1) != state::STATE_AND)) {
+                        if ((((_mask & (1u << bitNr)) != 0) && ((_events & (1u << bitNr)) == 0)) || ((_state & 0x1) != state::STATE_AND)) {
                             _state = STATE_ERROR;
                         }
                         else {
-                            _events |= (1 << bitNr);
+                            _events |= (1u << bitNr);
                         }
                     }
 
                     // This bit should be taken into account if we check the condition
-                    _mask |= 1 << bitNr;
+                    _mask |= 1u << bitNr;
                 }
 
             private:

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -127,6 +127,8 @@ namespace RPC {
 
             ProxyStub::UnknownProxy* CreateProxy(const Core::ProxyType<Core::IPCChannel>& channel, const Core::instance_id& implementation, const bool remoteRefCounted) override
             {
+                // coverity[RESOURCE_LEAK] - Ownership transfers to caller; lifetime managed by
+                // Thunder ref-counting (AddRef/Release), not RAII.
                 return (*(new PROXY(channel, implementation, remoteRefCounted)));
             }
         };
@@ -203,6 +205,8 @@ namespace RPC {
         template <typename ACTUALINTERFACE, typename PROXY, typename STUB>
         void Announce(const SecureProxyStubType secure = SecureProxyStubType::PROXYSTUBS_SECURITY_NONE)
         {
+            // coverity[RESOURCE_LEAK] - Both allocations are handed to Announce() which takes
+            // ownership; lifetime managed by the stub/proxy registry.
             Announce(ACTUALINTERFACE::ID, new STUB(), new ProxyType<PROXY>(), secure);
         }
 

--- a/Source/core/DoorBell.cpp
+++ b/Source/core/DoorBell.cpp
@@ -86,11 +86,19 @@ namespace Core {
 #endif
 
 #ifndef __WINDOWS__
-            // Check if domain path already exists, if so remove.
+            // Remove any stale domain socket path before binding. Using unlink()
+            // directly avoids the TOCTOU race between access() and remove().
             if (_doorbell.Type() == NodeId::TYPE_DOMAIN) {
-                if (access(_doorbell.HostName().c_str(), F_OK) != -1) {
-                    TRACE_L1("Found out domain path already exists, deleting: %s", _doorbell.HostName().c_str());
-                    remove(_doorbell.HostName().c_str());
+                const string path = _doorbell.HostName();
+
+                if (::unlink(path.c_str()) != 0) {
+                    const int err = errno;
+
+                    if (err != ENOENT) {
+                        TRACE_L1("Failed to remove domain socket %s: %s", path.c_str(), strerror(err));
+                    }
+                } else {
+                    TRACE_L1("Removed stale domain socket: %s", path.c_str());
                 }
             }
 #endif

--- a/Source/core/NodeId.cpp
+++ b/Source/core/NodeId.cpp
@@ -895,6 +895,7 @@ POP_WARNING()
 #ifndef __APPLE__
         else {
             struct sockaddr_nl info;
+            memset(&info, 0, sizeof(info));
             info.nl_family = AF_NETLINK;
             info.nl_pid = 0;
             info.nl_groups = 0;

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -1561,10 +1561,13 @@ POP_WARNING()
 
                 return (result);
             }
+            // coverity[MISSING_LOCK] - Intentional: diagnostic accessors returning a momentary
+            // snapshot. Callers are expected to tolerate a slightly stale value.
             inline uint32_t CreatedElements() const
             {
                 return (_createdElements);
             }
+            // coverity[MISSING_LOCK]
             inline uint32_t QueuedElements() const
             {
                 return (static_cast<uint32_t>(_queue.size()));

--- a/Source/core/Proxy.h
+++ b/Source/core/Proxy.h
@@ -155,10 +155,14 @@ POP_WARNING()
             inline operator const IReferenceCounted* () const {
                 return (this);
             }
+            // coverity[PW.CONVERSION_FUNCTION_NOT_USABLE] - Intentional: ProxyObject exposes both the
+            // ref-counted wrapper and the underlying CONTEXT via implicit conversion. This is the
+            // proxy pattern by design; ambiguity in overload resolution is accepted.
             inline operator CONTEXT& ()
             {
                 return (*this);
             }
+            // coverity[PW.CONVERSION_FUNCTION_NOT_USABLE]
             inline operator const CONTEXT& () const
             {
                 return (*this);

--- a/Source/core/ResourceMonitor.h
+++ b/Source/core/ResourceMonitor.h
@@ -181,6 +181,8 @@ namespace Core {
         {
             return (_monitor != nullptr ? _monitor->Id() : 0);
         }
+        // coverity[MISSING_LOCK] - Intentional: diagnostic accessor returning a momentary
+        // snapshot of the resource count. Callers tolerate a slightly stale value.
         uint32_t Count() const 
         {
             return (static_cast<uint32_t>(_resources.size()));

--- a/Source/core/Singleton.h
+++ b/Source/core/Singleton.h
@@ -172,6 +172,7 @@ namespace Core {
 
         inline static bool Dispose()
         {
+            bool disposed = false;
             // Unprotected. Make sure the dispose is *ONLY* called
             // after all usage of the singleton is completed!!!
             SINGLETON* ptr = g_TypedSingleton.exchange(nullptr, std::memory_order_acq_rel);
@@ -179,9 +180,9 @@ namespace Core {
             if (ptr != nullptr) {
                 // Bypass the destructor's store — we already zeroed via exchange.
                 delete ptr;
-                return true;
+                disposed = true;
             }
-            return false;
+            return disposed;
         }
 
     private:

--- a/Source/core/Singleton.h
+++ b/Source/core/Singleton.h
@@ -21,6 +21,7 @@
 #define __SINGLETON_H
 
 // ---- Include system wide include files ----
+#include <atomic>
 #include <list>
 
 // ---- Include local include files ----
@@ -68,7 +69,9 @@ namespace Core {
 
         virtual ~Singleton()
         {
-            (*_realDeal) = nullptr;
+            if (_realDeal != nullptr) {
+                (*_realDeal) = nullptr;
+            }
         }
 
         inline static void Dispose()
@@ -92,7 +95,7 @@ namespace Core {
     protected:
         template <typename... Args>
         inline SingletonType(Args&&... args)
-            : Singleton(reinterpret_cast<void**>(&g_TypedSingleton))
+            : Singleton(nullptr)  // g_TypedSingleton is now std::atomic; zeroed in ~SingletonType
             , SINGLETON(std::forward<Args>(args)...)
         {
             ListInstance().Register(this);
@@ -106,10 +109,9 @@ namespace Core {
         virtual ~SingletonType()
         {
            ListInstance().Unregister(this);
-           ASSERT(g_TypedSingleton != nullptr);
-           g_TypedSingleton = nullptr;
+           // ASSERT(g_TypedSingleton.load(std::memory_order_relaxed) != nullptr);
+           g_TypedSingleton.store(nullptr, std::memory_order_relaxed);
         }
-
     public:
         virtual string ImplementationName() const
         {
@@ -121,21 +123,20 @@ namespace Core {
         {
             static CriticalSection g_AdminLock;
 
-            // Hmm Double Lock syndrom :-)
-            if (g_TypedSingleton == nullptr) {
+            SINGLETON* ptr = g_TypedSingleton.load(std::memory_order_acquire);
+            if (ptr == nullptr) {
                 g_AdminLock.Lock();
-
-                if (g_TypedSingleton == nullptr) {
-                    // Create a singleton
-                    g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(std::forward<Args>(args)...));
+                ptr = g_TypedSingleton.load(std::memory_order_relaxed);
+                if (ptr == nullptr) {
+                    ptr = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(std::forward<Args>(args)...));
+                    g_TypedSingleton.store(ptr, std::memory_order_release);
                 }
-
                 g_AdminLock.Unlock();
             }
 
-            ASSERT(g_TypedSingleton != nullptr);
+            ASSERT(ptr != nullptr);
 
-            return *(g_TypedSingleton);
+            return *ptr;
         }
 
         inline static SINGLETON& Instance() {
@@ -155,28 +156,32 @@ namespace Core {
         template <typename... Args>
         inline static void Create(Args&&... args)
         {
-            ASSERT(g_TypedSingleton == nullptr);
+            ASSERT(g_TypedSingleton.load(std::memory_order_relaxed) == nullptr);
 
-            if (g_TypedSingleton == nullptr) {
+            if (g_TypedSingleton.load(std::memory_order_relaxed) == nullptr) {
 
-                // Create a singleton
-                g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(std::forward<Args>(args)...));
+                // Create a singleton — caller guarantees single-threaded context
+                SINGLETON* ptr = static_cast<SINGLETON*>(new SingletonType<SINGLETON>(std::forward<Args>(args)...));
+                g_TypedSingleton.store(ptr, std::memory_order_release);
             }
 
-            ASSERT(g_TypedSingleton != nullptr);
+            ASSERT(g_TypedSingleton.load(std::memory_order_relaxed) != nullptr);
+
+
         }
+
         inline static bool Dispose()
         {
             // Unprotected. Make sure the dispose is *ONLY* called
-            // after all usage of the singlton is completed!!!
-            bool disposed = false;
-            if (g_TypedSingleton != nullptr) {
-
-                delete g_TypedSingleton;
-                // note destructor will set g_TypedSingleton to nullptr;
-                disposed = true;
+            // after all usage of the singleton is completed!!!
+            SINGLETON* ptr = g_TypedSingleton.exchange(nullptr, std::memory_order_acq_rel);
+            
+            if (ptr != nullptr) {
+                // Bypass the destructor's store — we already zeroed via exchange.
+                delete ptr;
+                return true;
             }
-            return disposed;
+            return false;
         }
 
     private:
@@ -184,37 +189,37 @@ namespace Core {
         {
             static CriticalSection g_AdminLock;
 
-            // Hmm Double Lock syndrom :-)
-            if (g_TypedSingleton == nullptr) {
+            SINGLETON* ptr = g_TypedSingleton.load(std::memory_order_acquire);
+            if (ptr == nullptr) {
                 g_AdminLock.Lock();
-
-                if (g_TypedSingleton == nullptr) {
-                    // Create a singleton
-                    g_TypedSingleton = static_cast<SINGLETON*>(new SingletonType<SINGLETON>());
+                ptr = g_TypedSingleton.load(std::memory_order_relaxed);
+                if (ptr == nullptr) {
+                    ptr = static_cast<SINGLETON*>(new SingletonType<SINGLETON>());
+                    g_TypedSingleton.store(ptr, std::memory_order_release);
                 }
-
                 g_AdminLock.Unlock();
             }
 
-            ASSERT(g_TypedSingleton != nullptr);
+            ASSERT(ptr != nullptr);
 
-            return *(g_TypedSingleton);
+            return *ptr;
         }
         static SINGLETON& GetObject(const TemplateIntToType<false>& /* For compile time diffrentiation */)
         {
             // If the Singleton needs to be constructed with a parameter, the Create() method
             // should have been called prior to the instance..
-            ASSERT(g_TypedSingleton != nullptr);
+            SINGLETON* ptr = g_TypedSingleton.load(std::memory_order_acquire);
+            ASSERT(ptr != nullptr);
 
-            return *(g_TypedSingleton);
+            return *ptr;
         }
 
       private:
-        static SINGLETON* g_TypedSingleton;
+        static std::atomic<SINGLETON*> g_TypedSingleton;
     };
 
     template <typename SINGLETONTYPE>
-    EXTERNAL_HIDDEN SINGLETONTYPE*  SingletonType<SINGLETONTYPE>::g_TypedSingleton = nullptr;
+    EXTERNAL_HIDDEN std::atomic<SINGLETONTYPE*> SingletonType<SINGLETONTYPE>::g_TypedSingleton{ nullptr };
 
     template <typename PROXYTYPE>
     class SingletonProxyType {

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -498,7 +498,7 @@ namespace Thunder {
 
         uint32_t SocketPort::Open(const uint32_t waitTime, const string& specificInterface)
         {
-            uint32_t nStatus = Core::ERROR_ILLEGAL_STATE;
+            uint32_t nStatus = Core::ERROR_GENERAL;
 
             m_ReadBytes = 0;
             m_SendBytes = 0;
@@ -514,6 +514,11 @@ namespace Thunder {
                     m_State.fetch_or(SocketPort::UPDATE, Core::memory_order::memory_order_relaxed);
                     nStatus = Core::ERROR_INPROGRESS;
                 }
+            }
+            else if (m_State.load(Core::memory_order::memory_order_relaxed) != 0) {
+                // Socket is already open — caller violated the Open() precondition.
+                TRACE_L1("Socket is already open, Open() called twice on the same instance.");
+                nStatus = Core::ERROR_ILLEGAL_STATE;
             }
             else {
                 ASSERT((m_Socket == INVALID_SOCKET) && (m_State.load(Core::memory_order::memory_order_relaxed) == 0));
@@ -540,6 +545,10 @@ namespace Thunder {
                     else if (m_SocketType == LISTEN) {
                         if (::listen(m_Socket, MAX_LISTEN_QUEUE) == SOCKET_ERROR) {
                             TRACE_L1("Error on port socket LISTEN. Error %d", __ERRORRESULT__);
+                            // ERROR_GENERAL signals an OS-level failure during socket setup.
+                            // The socket was constructed but listen() rejected it — the fd
+                            // must be cleaned up via DestroySocket() at the bottom of Open().
+                            nStatus = Core::ERROR_GENERAL;
                         }
                         else {
                             // Trigger state to Open
@@ -596,10 +605,13 @@ namespace Thunder {
                 }
 
             }
-            else {
+            else if (nStatus != Core::ERROR_ILLEGAL_STATE) {
+                // ERROR_ILLEGAL_STATE is returned when the socket is already open and
+                // registered in the ResourceMonitor — destroying it here would corrupt
+                // the monitor's poll array. All other error paths constructed a new
+                // socket that failed before registration and must be cleaned up.
                 DestroySocket(m_Socket);
             }
-
             return (nStatus);
         }
 
@@ -767,10 +779,18 @@ namespace Thunder {
 
 #ifndef __WINDOWS__
             int foundUnixSocketFd = -1;
-            // Check if domain path already exists, if so remove.
-            if ((localNode.Type() == NodeId::TYPE_DOMAIN) && (m_SocketType == SocketPort::LISTEN)) {
-                if (access(localNode.HostName().c_str(), R_OK | W_OK) != -1) {
+            // Remove any stale socket file before binding. All domain socket types
+            // except STREAM call bind() on their local path and will fail with
+            // EADDRINUSE if a leftover file exists (e.g. after a crash).
+            // STREAM sockets are excluded because they call connect() to a remote
+            // path — they never bind to a path of their own.
+            if ((localNode.Type() == NodeId::TYPE_DOMAIN) && (m_SocketType != SocketPort::STREAM)) {
 #ifdef SYSTEMD_FOUND
+                // Systemd socket activation only applies to LISTEN sockets — systemd
+                // creates and passes pre-bound listening sockets to the process via
+                // SD_LISTEN_FDS_START file descriptors. DATAGRAM and SEQUENCED sockets
+                // are never handed over by systemd, so there is no fd to inherit here.
+                if (m_SocketType == SocketPort::LISTEN) {
                     int fd, n;
                     n = sd_listen_fds(0);
                     TRACE_L1("Found %d systemd created listening sockets", n);
@@ -784,13 +804,29 @@ namespace Thunder {
                             }
                         }
                     }
+                }
 #endif
-                    if (foundUnixSocketFd == -1) {
-                        TRACE_L1("Found out domain path already exists, deleting: %s", localNode.HostName().c_str());
-                        remove(localNode.HostName().c_str());
+                // Only attempt unlink if systemd did not hand us a pre-bound fd.
+                // If it did, the socket file is managed by systemd and must not be removed.
+                if (foundUnixSocketFd == -1) {
+                    const string path = localNode.HostName();
+
+                    // Unconditional unlink avoids the TOCTOU race that exists when using
+                    // access() followed by remove() — another process could create or delete
+                    // the file between those two calls. A single unlink() is atomic.
+                    if (::unlink(path.c_str()) == 0) {
+                        TRACE_L1("Removed stale domain socket: %s", path.c_str());
+                    } else {
+                        const int err = errno;
+
+                        if (err != ENOENT) {
+                            TRACE_L1("Failed to remove domain socket %s: %s", path.c_str(), strerror(err));
+                            return INVALID_SOCKET;
+                        }
                     }
                 }
             }
+
             if (foundUnixSocketFd != -1) {
                 if (SetNonBlocking(foundUnixSocketFd) == false) {
                     TRACE_L1("Error on setting non blocking");
@@ -828,22 +864,6 @@ namespace Thunder {
                     TRACE_L1("Error on setting SO_REUSEADDR option. Error %d: %s", __ERRORRESULT__, strerror(__ERRORRESULT__));
                 }
             }
-
-#ifndef __WINDOWS__
-            else if ((localNode.Type() == NodeId::TYPE_DOMAIN) && (m_SocketType == SocketPort::LISTEN)) {
-                // The effect of SO_REUSEADDR  but then on Domain Sockets :-)
-                if (unlink(localNode.HostName().c_str()) == -1) {
-                    int report = __ERRORRESULT__;
-
-                    if (report != 2) {
-                        ::close(l_Result);
-                        l_Result = INVALID_SOCKET;
-
-                        TRACE_L1("Error on unlinking domain socket. Error %d: %s", report, strerror(report));
-                    }
-                }
-            }
-#endif
 
 #ifdef __APPLE__
     {
@@ -1334,7 +1354,16 @@ namespace Thunder {
     #ifdef __WINDOWS__
                     _unlink(m_LocalNode.HostName().c_str());
     #else
-                    unlink(m_LocalNode.HostName().c_str());
+                    const string path = m_LocalNode.HostName();
+
+                    if (::unlink(path.c_str()) != 0) {
+                        const int err = __ERRORRESULT__;
+                        if (err != ENOENT) {
+                            TRACE_L1("Failed to remove domain socket on close %s: %s", path.c_str(), strerror(err));
+                        }
+                    } else {
+                        TRACE_L1("Removed domain socket on close: %s", path.c_str());
+                    }
     #endif
                 }
             }

--- a/Source/core/SocketPort.cpp
+++ b/Source/core/SocketPort.cpp
@@ -1485,9 +1485,8 @@ namespace Thunder {
             ip_mreq_source multicastRequest;
 #else
             ip_mreq_source multicastRequest;
-
-            // TODO, Fix multicast join with interface
-            // multicastRequest.imr_interface = in_addr{ 0, 0;
+            memset(&multicastRequest, 0, sizeof(multicastRequest));
+            multicastRequest.imr_interface.s_addr = INADDR_ANY;
 #endif
 
 #ifdef __WINDOWS__
@@ -1515,9 +1514,8 @@ namespace Thunder {
             ip_mreq_source multicastRequest;
 #else
             ip_mreq_source multicastRequest;
-
-            // TODO, Fix multicast join with source
-            // multicastRequest.imr_interface = 0;
+            memset(&multicastRequest, 0, sizeof(multicastRequest));
+            multicastRequest.imr_interface.s_addr = INADDR_ANY;
 #endif
 
 #ifdef __WINDOWS__

--- a/Source/cryptalgo/Random.cpp
+++ b/Source/cryptalgo/Random.cpp
@@ -147,7 +147,7 @@ namespace Crypto {
         uint8_t hsb2 = static_cast<uint8_t>(random() & 0xFF);
         uint8_t lsb2 = static_cast<uint8_t>(random() & 0xFF);
 #endif // __LINUX__
-        value = (hsb1 << 24) | (lsb1 < 16) | (hsb2 << 8) | lsb2;
+        value = (hsb1 << 24) | (lsb1 << 16) | (hsb2 << 8) | lsb2;
 #else
 #error "Can not create random functionality"
 #endif
@@ -185,8 +185,8 @@ namespace Crypto {
         uint16_t hsw2 = static_cast<uint16_t>(random() & 0xFFFF);
         uint16_t lsw2 = static_cast<uint16_t>(random() & 0xFFFF);
 #endif // __LINUX__
-        value = (hsw1 << 16) | lsw1;
-        value = (value << 32) | (hsw2 << 16) | lsw2;
+        value = (static_cast<uint64_t>(hsw1) << 16) | lsw1;
+        value = (value << 32) | (static_cast<uint64_t>(hsw2) << 16) | lsw2;
 #elif RAND_MAX >= 0xFF
 #ifdef __WINDOWS__
         uint8_t hsb1 = static_cast<uint8_t>(rand() & 0xFF);
@@ -208,8 +208,8 @@ namespace Crypto {
         uint8_t hsb4 = static_cast<uint8_t>(random() & 0xFF);
         uint8_t lsb4 = static_cast<uint8_t>(random() & 0xFF);
 #endif // __LINUX__
-        value = (hsb1 << 24) | (lsb1 < 16) | (hsb2 << 8) | lsb2;
-        value = (value << 32) | (hsb3 << 24) | (lsb3 < 16) | (hsb4 << 8) | lsb4;
+        value = (hsb1 << 24) | (lsb1 << 16) | (hsb2 << 8) | lsb2;
+        value = (value << 32) | (hsb3 << 24) | (lsb3 << 16) | (hsb4 << 8) | lsb4;
 #else
 #error "Can not create random functionality"
 #endif

--- a/Source/plugins/IPlugin.h
+++ b/Source/plugins/IPlugin.h
@@ -260,6 +260,8 @@ namespace PluginHost {
 } // namespace Thunder
 
 
+// coverity[PW.INCLUDE_RECURSION] - Mutual include with IShell.h is intentional and safe;
+// both files are guarded by include guards (__IPLUGIN_H__ / __ISHELL_H__).
 #include "IShell.h" // needed for the proxy/stub generation
 
 #endif

--- a/Source/plugins/IShell.h
+++ b/Source/plugins/IShell.h
@@ -20,6 +20,8 @@
 #ifndef __ISHELL_H__
 #define __ISHELL_H__
 
+// coverity[PW.INCLUDE_RECURSION] - Mutual include with IPlugin.h is intentional and safe;
+// both files are guarded by include guards (__IPLUGIN_H__ / __ISHELL_H__).
 #include "IPlugin.h"
 #include "ISubSystem.h"
 

--- a/Source/websocket/WebSerializer.cpp
+++ b/Source/websocket/WebSerializer.cpp
@@ -427,6 +427,7 @@ namespace Web
 
         if (hashType.IsSet() && hashValue.IsSet()) {
             uint8_t data[64];
+            // coverity[INTEGER_OVERFLOW] - sizeof(data) is 64, well within uint16_t range.
             uint16_t length = sizeof(data);
 
             // It should be base64 encoded, convert it here

--- a/Tests/unit/core/CMakeLists.txt
+++ b/Tests/unit/core/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_semaphore.cpp
    test_sharedbuffer.cpp
    test_singleton.cpp
+   test_socketport.cpp
    test_socketstreamjson.cpp
    test_socketstreamtext.cpp
    test_statetrigger.cpp

--- a/Tests/unit/core/test_singleton.cpp
+++ b/Tests/unit/core/test_singleton.cpp
@@ -29,49 +29,56 @@ namespace Thunder {
 namespace Tests {
 namespace Core {
 
+    // -------------------------------------------------------------------------
+    // Test types
+    // -------------------------------------------------------------------------
+
     class SingletonTypeOne {
-        public:
-            SingletonTypeOne()
-            {
-            }
-            virtual ~SingletonTypeOne()
-            {
-            }
-            bool operator==(const SingletonTypeOne&) const
-            {
-                return true;
-            }
+    public:
+        SingletonTypeOne() = default;
+        virtual ~SingletonTypeOne() = default;
+        bool operator==(const SingletonTypeOne&) const { return true; }
     };
 
     class SingletonTypeTwo {
-        public:
-            SingletonTypeTwo() = default; // Required by Instance()
-            explicit SingletonTypeTwo(string)
-            {
-            }
-            virtual ~SingletonTypeTwo()
-            {
-            }
+    public:
+        SingletonTypeTwo() = default;
+        explicit SingletonTypeTwo(string) {}
+        virtual ~SingletonTypeTwo() = default;
     };
+
     class SingletonTypeThree {
-        public:
-            SingletonTypeThree() = default; // Required by Instance()
-            explicit SingletonTypeThree (string, string)
-            {
-            }
-            virtual ~SingletonTypeThree()
-            {
-            }
+    public:
+        SingletonTypeThree() = default;
+        explicit SingletonTypeThree(string, string) {}
+        virtual ~SingletonTypeThree() = default;
     };
+
+    // Tracks construction and destruction counts to verify lifetime behaviour.
+    class TrackedSingleton {
+    public:
+        static int constructCount;
+        static int destructCount;
+
+        TrackedSingleton()  { ++constructCount; }
+        ~TrackedSingleton() { ++destructCount;  }
+
+        static void Reset() { constructCount = 0; destructCount = 0; }
+    };
+    int TrackedSingleton::constructCount = 0;
+    int TrackedSingleton::destructCount  = 0;
+
+    // -------------------------------------------------------------------------
+    // Original test — preserved exactly
+    // -------------------------------------------------------------------------
 
     TEST(test_singleton, simple_singleton)
     {
         // 'old' use
         ::Thunder::Tests::Core::SingletonTypeOne& objectTypeOne = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
 
-        // Multiple inheritance, SingletonType has base SINGLETON, eg, ::Thunder::Tests::Core::SingletonTypeOne, and base Singleton
-        // Internally a ::Thunder::Core::SingletonType<SINGLETON> pointer is contructed and via upcasted version of a base avaiable via Instance
-        // It is safe to downcast it
+        // Multiple inheritance: SingletonType<T> derives from both Singleton and T.
+        // Instance() returns T& but it is safe to downcast to SingletonType<T>*.
         ASSERT_NE(dynamic_cast<::Thunder::Core::SingletonType<SingletonTypeOne>*>(&objectTypeOne), nullptr);
         EXPECT_FALSE(dynamic_cast<::Thunder::Core::SingletonType<SingletonTypeOne>*>(&objectTypeOne)->ImplementationName().empty());
         EXPECT_STREQ(dynamic_cast<::Thunder::Core::SingletonType<SingletonTypeOne>*>(&objectTypeOne)->ImplementationName().c_str(), "SingletonTypeOne");
@@ -91,10 +98,256 @@ namespace Core {
         EXPECT_TRUE(::Thunder::Core::SingletonType<SingletonTypeThree>::Dispose());
 
         // SingletonTypeOne has not yet been destroyed
-        // Assume equality operator has been defined
         EXPECT_EQ(::Thunder::Core::SingletonType<SingletonTypeOne>::Instance(), ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance());
 
-        // Keep going with good practise
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // -------------------------------------------------------------------------
+    // Instance identity — same reference across multiple calls
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, instance_returns_same_object)
+    {
+        SingletonTypeOne& a = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
+        SingletonTypeOne& b = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
+        SingletonTypeOne& c = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
+
+        EXPECT_EQ(&a, &b);
+        EXPECT_EQ(&b, &c);
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // -------------------------------------------------------------------------
+    // Dispose() return value — true first time, false if already disposed
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, dispose_returns_false_when_already_disposed)
+    {
+        ::Thunder::Core::SingletonType<SingletonTypeTwo>::Create("test");
+
+        EXPECT_TRUE(::Thunder::Core::SingletonType<SingletonTypeTwo>::Dispose());
+        EXPECT_FALSE(::Thunder::Core::SingletonType<SingletonTypeTwo>::Dispose());
+    }
+
+    // -------------------------------------------------------------------------
+    // Re-init cycle — Create -> Dispose -> Create -> Instance works correctly
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, reinit_after_dispose)
+    {
+        TrackedSingleton::Reset();
+
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Create();
+        EXPECT_EQ(TrackedSingleton::constructCount, 1);
+        EXPECT_EQ(TrackedSingleton::destructCount,  0);
+
+        EXPECT_TRUE(::Thunder::Core::SingletonType<TrackedSingleton>::Dispose());
+        EXPECT_EQ(TrackedSingleton::constructCount, 1);
+        EXPECT_EQ(TrackedSingleton::destructCount,  1);
+
+        // Re-create after dispose — must work cleanly
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Create();
+        EXPECT_EQ(TrackedSingleton::constructCount, 2);
+        EXPECT_EQ(TrackedSingleton::destructCount,  1);
+
+        TrackedSingleton& instance = ::Thunder::Core::SingletonType<TrackedSingleton>::Instance();
+        EXPECT_NE(&instance, nullptr);
+
+        EXPECT_TRUE(::Thunder::Core::SingletonType<TrackedSingleton>::Dispose());
+        EXPECT_EQ(TrackedSingleton::constructCount, 2);
+        EXPECT_EQ(TrackedSingleton::destructCount,  2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Destructor is called exactly once on Dispose()
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, destructor_called_exactly_once_on_dispose)
+    {
+        TrackedSingleton::Reset();
+
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Create();
+        EXPECT_EQ(TrackedSingleton::destructCount, 0);
+
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Dispose();
+        EXPECT_EQ(TrackedSingleton::destructCount, 1);
+
+        // Second Dispose() must not call destructor again
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Dispose();
+        EXPECT_EQ(TrackedSingleton::destructCount, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Singleton::Dispose() cleans up all registered singletons
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, global_dispose_cleans_all)
+    {
+        TrackedSingleton::Reset();
+
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Create();
+        ::Thunder::Core::SingletonType<SingletonTypeTwo>::Create("global-dispose-test");
+
+        EXPECT_EQ(TrackedSingleton::constructCount, 1);
+        EXPECT_EQ(TrackedSingleton::destructCount,  0);
+
+        ::Thunder::Core::Singleton::Dispose();
+
+        EXPECT_EQ(TrackedSingleton::destructCount, 1);
+
+        // After global dispose both singletons should be gone — Dispose() returns false
+        EXPECT_FALSE(::Thunder::Core::SingletonType<TrackedSingleton>::Dispose());
+        EXPECT_FALSE(::Thunder::Core::SingletonType<SingletonTypeTwo>::Dispose());
+    }
+
+    // -------------------------------------------------------------------------
+    // Instance() via GetObject path — lazy construction on first call
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, lazy_construction_via_instance)
+    {
+        TrackedSingleton::Reset();
+
+        // No Create() called — Instance() should construct lazily
+        EXPECT_EQ(TrackedSingleton::constructCount, 0);
+
+        TrackedSingleton& instance = ::Thunder::Core::SingletonType<TrackedSingleton>::Instance();
+        EXPECT_NE(&instance, nullptr);
+        EXPECT_EQ(TrackedSingleton::constructCount, 1);
+
+        // Second call must not construct again
+        ::Thunder::Core::SingletonType<TrackedSingleton>::Instance();
+        EXPECT_EQ(TrackedSingleton::constructCount, 1);
+
+        ::Thunder::Core::Singleton::Dispose();
+        EXPECT_EQ(TrackedSingleton::destructCount, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // ImplementationName — correct on both Instance() and Create() paths
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, implementation_name_via_instance_path)
+    {
+        SingletonTypeOne& obj = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
+        auto* typed = dynamic_cast<::Thunder::Core::SingletonType<SingletonTypeOne>*>(&obj);
+
+        ASSERT_NE(typed, nullptr);
+        EXPECT_STREQ(typed->ImplementationName().c_str(), "SingletonTypeOne");
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    TEST(test_singleton, implementation_name_via_create_path)
+    {
+        ::Thunder::Core::SingletonType<SingletonTypeTwo>::Create("name-test");
+        SingletonTypeTwo& obj = ::Thunder::Core::SingletonType<SingletonTypeTwo>::Instance();
+        auto* typed = dynamic_cast<::Thunder::Core::SingletonType<SingletonTypeTwo>*>(&obj);
+
+        ASSERT_NE(typed, nullptr);
+        EXPECT_STREQ(typed->ImplementationName().c_str(), "SingletonTypeTwo");
+
+        ::Thunder::Core::SingletonType<SingletonTypeTwo>::Dispose();
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiple independent singleton types do not interfere with each other
+    // -------------------------------------------------------------------------
+
+    TEST(test_singleton, independent_singleton_types_do_not_interfere)
+    {
+        SingletonTypeOne& one = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
+        ::Thunder::Core::SingletonType<SingletonTypeTwo>::Create("interference-test");
+        SingletonTypeTwo& two = ::Thunder::Core::SingletonType<SingletonTypeTwo>::Instance();
+
+        // Suppress unused warning — the point is both are alive simultaneously
+        (void)two;
+
+        // Disposing two must not affect one
+        ::Thunder::Core::SingletonType<SingletonTypeTwo>::Dispose();
+
+        SingletonTypeOne& oneAgain = ::Thunder::Core::SingletonType<SingletonTypeOne>::Instance();
+        EXPECT_EQ(&one, &oneAgain);
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+        // A singleton with detectable partial construction.
+    // The constructor sets two sentinel values with a yield() between them
+    // to widen the window in which another thread can observe an
+    // incompletely constructed object.
+    class DCLPSingleton {
+    public:
+        static constexpr uint32_t SENTINEL_A = 0xDEADBEEF;
+        static constexpr uint32_t SENTINEL_B = 0xCAFEBABE;
+
+        DCLPSingleton()
+        {
+            _a = SENTINEL_A;
+            // Yield to maximise the chance that another thread observes
+            // the pointer as non-null before _b is written.
+            std::this_thread::yield();
+            _b = SENTINEL_B;
+        }
+        ~DCLPSingleton() = default;
+
+        bool IsFullyConstructed() const
+        {
+            return (_a == SENTINEL_A) && (_b == SENTINEL_B);
+        }
+
+    private:
+        // Padding between the two sentinels increases the probability that
+        // the CPU will commit _a and the pointer write before _b on weakly-
+        // ordered architectures (ARM).
+        uint32_t _a;
+        uint8_t  _pad[64];
+        uint32_t _b;
+    };
+
+    // Stress test: N threads all call Instance() simultaneously through a
+    // barrier, then verify the returned object is fully constructed.
+    //
+    // On x86 this test may pass even with the bug present due to the strong
+    // memory model. On ARM it is more likely to expose the race. In both
+    // cases ThreadSanitizer will flag the underlying data race deterministically.
+    TEST(test_singleton, concurrent_instance_returns_fully_constructed_object)
+    {
+        constexpr int NUM_THREADS = 32;
+
+        // Release all threads simultaneously against a cold singleton.
+        // The yield() inside DCLPSingleton's constructor widens the window
+        // enough that a broken DCLP implementation will hand out a partially
+        // constructed object to one or more threads on this single attempt.
+        std::atomic<bool> go{ false };
+        std::atomic<int>  failures{ 0 };
+        std::vector<std::thread> threads;
+        threads.reserve(NUM_THREADS);
+
+        for (int i = 0; i < NUM_THREADS; ++i) {
+            threads.emplace_back([&]() {
+                while (!go.load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                }
+
+                DCLPSingleton& instance = ::Thunder::Core::SingletonType<DCLPSingleton>::Instance();
+
+                if (!instance.IsFullyConstructed()) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+        }
+
+        go.store(true, std::memory_order_release);
+
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        EXPECT_EQ(failures.load(), 0) << "Partially constructed singleton observed — DCLP race triggered.";
+
         ::Thunder::Core::Singleton::Dispose();
     }
 

--- a/Tests/unit/core/test_socketport.cpp
+++ b/Tests/unit/core/test_socketport.cpp
@@ -1,0 +1,1218 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <condition_variable>
+#include <mutex>
+
+#include <gtest/gtest.h>
+
+#ifndef MODULE_NAME
+#include "../Module.h"
+#endif
+
+#include <core/core.h>
+#include "../IPTestAdministrator.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace Thunder {
+namespace Tests {
+namespace Core {
+
+    // -------------------------------------------------------------------------
+    // EchoConnector — TCP stream connector that echoes back received text.
+    // Server side echoes; client side signals when echo is received.
+    // -------------------------------------------------------------------------
+
+    class EchoConnector
+        : public ::Thunder::Core::StreamTextType<
+              ::Thunder::Core::SocketStream,
+              ::Thunder::Core::TerminatorCarriageReturn> {
+
+        using Base = ::Thunder::Core::StreamTextType<
+            ::Thunder::Core::SocketStream,
+            ::Thunder::Core::TerminatorCarriageReturn>;
+
+    public:
+        EchoConnector() = delete;
+        EchoConnector(const EchoConnector&) = delete;
+        EchoConnector& operator=(const EchoConnector&) = delete;
+
+        // Client constructor
+        explicit EchoConnector(const ::Thunder::Core::NodeId& remote)
+            : Base(false, remote.AnyInterface(), remote, 1024, 1024)
+            , _isServer(false)
+            , _dataPending(false, false)
+        {
+        }
+
+        // Server-side accepted connection constructor
+        EchoConnector(const SOCKET& connector,
+                      const ::Thunder::Core::NodeId& remote,
+                      ::Thunder::Core::SocketServerType<EchoConnector>*)
+            : Base(false, connector, remote, 1024, 1024)
+            , _isServer(true)
+            , _dataPending(false, false)
+        {
+        }
+
+        ~EchoConnector() override = default;
+
+        void Received(string& text) override
+        {
+            if (_isServer) {
+                Submit(text);
+            } else {
+                _received = text;
+                _dataPending.Unlock();
+            }
+        }
+
+        void Send(VARIABLE_IS_NOT_USED const string&) override {}
+
+        void StateChange() override
+        {
+            if (IsOpen() && _isServer) {
+                std::unique_lock<std::mutex> lk(s_mutex);
+                s_connected = true;
+                s_cv.notify_one();
+            }
+        }
+
+        uint32_t WaitForEcho() { return _dataPending.Lock(); }
+
+        string ReceivedText() const { return _received; }
+
+        static void ResetState()
+        {
+            std::unique_lock<std::mutex> lk(s_mutex);
+            s_connected = false;
+        }
+
+        static bool WaitForServerConnection(uint32_t ms)
+        {
+            std::unique_lock<std::mutex> lk(s_mutex);
+            return s_cv.wait_for(lk, std::chrono::milliseconds(ms),
+                                 [] { return s_connected; });
+        }
+
+    private:
+        bool _isServer;
+        string _received;
+        ::Thunder::Core::Event _dataPending;
+
+    public:
+        static std::mutex s_mutex;
+        static std::condition_variable s_cv;
+        static bool s_connected;
+    };
+
+    std::mutex EchoConnector::s_mutex;
+    std::condition_variable EchoConnector::s_cv;
+    bool EchoConnector::s_connected = false;
+
+    // -------------------------------------------------------------------------
+    // Minimal datagram socket — no data flow needed.
+    // -------------------------------------------------------------------------
+
+    class TestDatagram : public ::Thunder::Core::SocketDatagram {
+    public:
+        TestDatagram() = delete;
+        TestDatagram(const TestDatagram&) = delete;
+        TestDatagram& operator=(const TestDatagram&) = delete;
+
+        explicit TestDatagram(const ::Thunder::Core::NodeId& local,
+                              const ::Thunder::Core::NodeId& remote = ::Thunder::Core::NodeId())
+            : ::Thunder::Core::SocketDatagram(false, local, remote, 512, 512)
+        {
+        }
+        ~TestDatagram() override = default;
+
+        uint16_t SendData(uint8_t*, const uint16_t) override { return 0; }
+        uint16_t ReceiveData(uint8_t*, const uint16_t size) override { return size; }
+        void StateChange() override {}
+    };
+
+    // Datagram that captures the last received payload.
+    class CaptureDatagram : public ::Thunder::Core::SocketDatagram {
+    public:
+        CaptureDatagram() = delete;
+        CaptureDatagram(const CaptureDatagram&) = delete;
+        CaptureDatagram& operator=(const CaptureDatagram&) = delete;
+
+        explicit CaptureDatagram(const ::Thunder::Core::NodeId& local)
+            : ::Thunder::Core::SocketDatagram(false, local, ::Thunder::Core::NodeId(), 512, 512)
+            , _payloadSize(0)
+            , _received(false)
+        {
+            memset(_payload, 0, sizeof(_payload));
+        }
+        ~CaptureDatagram() override = default;
+
+        uint16_t SendData(uint8_t*, const uint16_t) override { return 0; }
+
+        uint16_t ReceiveData(uint8_t* frame, const uint16_t size) override
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            _payloadSize = std::min(size, static_cast<uint16_t>(sizeof(_payload)));
+            memcpy(_payload, frame, _payloadSize);
+            _received = true;
+            _cv.notify_all();
+            return size;
+        }
+
+        void StateChange() override {}
+
+        bool WaitForData(uint32_t ms)
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            return _cv.wait_for(lk, std::chrono::milliseconds(ms),
+                                [this] { return _received; });
+        }
+
+        string ReceivedPayload() const
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            return string(reinterpret_cast<const char*>(_payload), _payloadSize);
+        }
+
+    private:
+        mutable std::mutex _mutex;
+        std::condition_variable _cv;
+        uint16_t _payloadSize;
+        bool _received;
+        uint8_t _payload[512];
+    };
+
+    // Datagram that sends a fixed message on the first SendData() call.
+    class SenderDatagram : public ::Thunder::Core::SocketDatagram {
+    public:
+        SenderDatagram() = delete;
+        SenderDatagram(const SenderDatagram&) = delete;
+        SenderDatagram& operator=(const SenderDatagram&) = delete;
+
+        SenderDatagram(const ::Thunder::Core::NodeId& local,
+                       const ::Thunder::Core::NodeId& remote,
+                       const string& msg)
+            : ::Thunder::Core::SocketDatagram(false, local, remote, 512, 512)
+            , _message(msg)
+            , _sent(false)
+        {
+        }
+        ~SenderDatagram() override = default;
+
+        uint16_t SendData(uint8_t* frame, const uint16_t maxSize) override
+        {
+            if (_sent) return 0;
+            uint16_t len = static_cast<uint16_t>(
+                std::min(_message.size(), static_cast<size_t>(maxSize)));
+            memcpy(frame, _message.data(), len);
+            _sent = true;
+            return len;
+        }
+        uint16_t ReceiveData(uint8_t*, const uint16_t) override { return 0; }
+        void StateChange() override {}
+
+    private:
+        string _message;
+        bool _sent;
+    };
+
+    // =========================================================================
+    // State queries — no network activity
+    // =========================================================================
+
+    TEST(test_socketport, initial_state_is_closed)
+    {
+        TestDatagram sock(::Thunder::Core::NodeId("/tmp/test_sp_init.sock"));
+
+        EXPECT_TRUE(sock.IsClosed());
+        EXPECT_FALSE(sock.IsOpen());
+        EXPECT_FALSE(sock.IsListening());
+        EXPECT_FALSE(sock.HasError());
+        EXPECT_EQ(sock.State(), 0u);
+        EXPECT_EQ(sock.Type(), ::Thunder::Core::SocketPort::DATAGRAM);
+    }
+
+    TEST(test_socketport, local_node_accessor_reflects_construction_path)
+    {
+        const string path = "/tmp/test_sp_node.sock";
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        EXPECT_STREQ(sock.LocalNode().HostName().c_str(), path.c_str());
+    }
+
+    TEST(test_socketport, buffer_size_accessors)
+    {
+        // TestDatagram uses 512/512 — check the values we actually pass.
+        ::Thunder::Core::NodeId node("/tmp/test_sp_buf.sock");
+        TestDatagram sock(node);
+
+        EXPECT_EQ(sock.SendBufferSize(), 512u);
+        EXPECT_EQ(sock.ReceiveBufferSize(), 512u);
+    }
+
+    TEST(test_socketport, local_id_contains_path)
+    {
+        const string path = "/tmp/test_sp_lid.sock";
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        EXPECT_NE(sock.LocalId().find(path), string::npos);
+    }
+
+    TEST(test_socketport, remote_node_can_be_updated_on_closed_datagram)
+    {
+        ::Thunder::Core::NodeId r1("/tmp/test_sp_rn1.sock");
+        ::Thunder::Core::NodeId r2("/tmp/test_sp_rn2.sock");
+        TestDatagram sock(::Thunder::Core::NodeId("/tmp/test_sp_rn.sock"), r1);
+
+        EXPECT_STREQ(sock.RemoteNode().HostName().c_str(), r1.HostName().c_str());
+        sock.RemoteNode(r2);
+        EXPECT_STREQ(sock.RemoteNode().HostName().c_str(), r2.HostName().c_str());
+    }
+
+    // =========================================================================
+    // TOCTOU fix: stale file handling on Open()
+    // =========================================================================
+
+    TEST(test_socketport, open_removes_stale_domain_socket_file)
+    {
+        const string path = "/tmp/test_sp_stale.sock";
+        ::unlink(path.c_str());
+
+        int fd = ::open(path.c_str(), O_CREAT | O_WRONLY, 0600);
+        ASSERT_GE(fd, 0);
+        ::close(fd);
+        ASSERT_EQ(::access(path.c_str(), F_OK), 0);
+
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+        EXPECT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsOpen());
+
+        sock.Close(1000);
+
+        uint32_t waited = 0;
+        while (!sock.IsClosed() && waited < 1000) {
+            SleepMs(10);
+            waited += 10;
+        }
+        EXPECT_TRUE(sock.IsClosed());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    TEST(test_socketport, open_succeeds_when_no_stale_file_exists)
+    {
+        const string path = "/tmp/test_sp_clean.sock";
+        ::unlink(path.c_str());
+
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+        EXPECT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsOpen());
+
+        sock.Close(1000);
+
+        uint32_t waited = 0;
+        while (!sock.IsClosed() && waited < 1000) {
+            SleepMs(10);
+            waited += 10;
+        }
+        EXPECT_TRUE(sock.IsClosed());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    TEST(test_socketport, reopen_after_close_removes_previous_socket_file)
+    {
+        const string path = "/tmp/test_sp_reopen.sock";
+        ::unlink(path.c_str());
+        ::Thunder::Core::NodeId node(path.c_str());
+
+        {
+            TestDatagram first(node);
+            ASSERT_EQ(first.Open(1000), ::Thunder::Core::ERROR_NONE);
+            first.Close(1000);
+        }
+        {
+            TestDatagram second(node);
+            EXPECT_EQ(second.Open(1000), ::Thunder::Core::ERROR_NONE);
+            EXPECT_TRUE(second.IsOpen());
+            second.Close(1000);
+        }
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Open / Close lifecycle
+    // =========================================================================
+
+    TEST(test_socketport, open_then_close_transitions_state)
+    {
+        const string path = "/tmp/test_sp_lc.sock";
+        ::unlink(path.c_str());
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        EXPECT_TRUE(sock.IsClosed());
+        EXPECT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsOpen());
+        EXPECT_FALSE(sock.IsClosed());
+
+        EXPECT_EQ(sock.Close(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsClosed());
+        EXPECT_FALSE(sock.IsOpen());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    TEST(test_socketport, close_on_already_closed_socket_does_not_crash)
+    {
+        const string path = "/tmp/test_sp_dblclose.sock";
+        ::unlink(path.c_str());
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_EQ(sock.Close(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_NO_FATAL_FAILURE(sock.Close(1000));
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    TEST(test_socketport, flush_on_open_socket_does_not_crash)
+    {
+        const string path = "/tmp/test_sp_flush.sock";
+        ::unlink(path.c_str());
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_NO_FATAL_FAILURE(sock.Flush());
+        EXPECT_TRUE(sock.IsOpen());
+
+        sock.Close(1000);
+
+        uint32_t waited = 0;
+        while (!sock.IsClosed() && waited < 1000) {
+            SleepMs(10);
+            waited += 10;
+        }
+        EXPECT_TRUE(sock.IsClosed());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Socket options: TTL and Broadcast
+    // =========================================================================
+
+    TEST(test_socketport, ttl_get_set_on_udp_socket)
+    {
+        ::Thunder::Core::NodeId node("0.0.0.0", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+        TestDatagram sock(node);
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+
+        EXPECT_EQ(sock.TTL(64), static_cast<uint32_t>(::Thunder::Core::ERROR_NONE));
+        EXPECT_EQ(sock.TTL(), 64u);
+
+        sock.Close(1000);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    TEST(test_socketport, broadcast_enable_disable_on_udp_socket)
+    {
+        ::Thunder::Core::NodeId node("0.0.0.0", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+        TestDatagram sock(node);
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.Broadcast(true));
+        EXPECT_TRUE(sock.Broadcast(false));
+
+        sock.Close(1000);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Data exchange: domain UDP loopback
+    // =========================================================================
+
+    TEST(test_socketport, datagram_send_receive_domain_socket)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 4,
+                           maxWaitTimeMs = 4000, maxInitTime = 500;
+        constexpr uint8_t maxRetries = 1;
+
+        const string serverPath = "/tmp/test_sp_dgram_srv.sock";
+        const string clientPath = "/tmp/test_sp_dgram_cli.sock";
+        const string message    = "hello_socketport";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(serverPath.c_str());
+            ::Thunder::Core::NodeId serverNode(serverPath.c_str());
+            CaptureDatagram server(serverNode);
+
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            EXPECT_TRUE(server.WaitForData(maxWaitTimeMs));
+            EXPECT_EQ(server.ReceivedPayload(), message);
+
+            server.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+            ::unlink(clientPath.c_str());
+
+            ::Thunder::Core::NodeId clientNode(clientPath.c_str());
+            ::Thunder::Core::NodeId serverNode(serverPath.c_str());
+            SenderDatagram sender(clientNode, serverNode, message);
+
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(sender.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            sender.Trigger();
+
+            SleepMs(500);
+            sender.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // TCP stream: connect, echo, close
+    // =========================================================================
+
+    TEST(test_socketport, stream_connect_echo_close)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 4,
+                           maxWaitTimeMs = 4000, maxInitTime = 500;
+        constexpr uint8_t maxRetries = 1;
+
+        const string connector = "/tmp/test_sp_stream.sock";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(connector.c_str());
+            EchoConnector::ResetState();
+
+            ::Thunder::Core::SocketServerType<EchoConnector> server(
+                ::Thunder::Core::NodeId(connector.c_str()));
+
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            EXPECT_TRUE(EchoConnector::WaitForServerConnection(maxWaitTimeMs));
+
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(server.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+
+            EchoConnector client(::Thunder::Core::NodeId(connector.c_str()));
+
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(client.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            EXPECT_TRUE(client.IsOpen());
+            EXPECT_FALSE(client.IsClosed());
+
+            const string msg = "echo_test";
+            client.Submit(msg);
+            EXPECT_EQ(client.WaitForEcho(), ::Thunder::Core::ERROR_NONE);
+            EXPECT_EQ(client.ReceivedText(), msg);
+
+            ASSERT_EQ(client.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Multicast UNINIT fix: source-specific Join/Leave with INADDR_ANY
+    // =========================================================================
+
+    TEST(test_socketport, source_specific_multicast_join_does_not_crash)
+    {
+        ::Thunder::Core::NodeId local("0.0.0.0", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+        ::Thunder::Core::NodeId group("224.0.0.1", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+        ::Thunder::Core::NodeId src("127.0.0.1", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+
+        TestDatagram sock(local);
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+
+        // Return value may be false on hosts without multicast on loopback.
+        // What matters is no crash or UB from the previously uninitialized
+        // imr_interface field.
+        EXPECT_NO_FATAL_FAILURE(sock.Join(group, src));
+        EXPECT_NO_FATAL_FAILURE(sock.Leave(group, src));
+
+        sock.Close(1000);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Close(waitTime=0) — non-blocking close, no waiting for far-end
+    // =========================================================================
+
+    TEST(test_socketport, close_with_zero_wait_does_not_block)
+    {
+        const string path = "/tmp/test_sp_closenowait.sock";
+        ::unlink(path.c_str());
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsOpen());
+
+        // Close(0) returns immediately without waiting for the far end.
+        EXPECT_NO_FATAL_FAILURE(sock.Close(0));
+
+        // The socket is not yet fully deregistered from the ResourceMonitor.
+        // Wait for IsClosed() before Singleton::Dispose() to avoid the debug
+        // assert that fires if resources are still registered at teardown.
+        uint32_t waited = 0;
+        while (!sock.IsClosed() && waited < 1000) {
+            SleepMs(10);
+            waited += 10;
+        }
+        EXPECT_TRUE(sock.IsClosed());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // unlink() non-ENOENT failure — directory at the socket path
+    // =========================================================================
+
+    TEST(test_socketport, open_fails_when_path_is_a_directory)
+    {
+        const string path = "/tmp/test_sp_dir.sock";
+        ::unlink(path.c_str());
+        ::rmdir(path.c_str());
+
+        ASSERT_EQ(::mkdir(path.c_str(), 0700), 0);
+
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+        EXPECT_NE(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsClosed());
+
+        ::rmdir(path.c_str());
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Domain socket file is removed after Close()
+    // =========================================================================
+
+    TEST(test_socketport, close_removes_domain_socket_file)
+    {
+        const string path = "/tmp/test_sp_closeclean.sock";
+        ::unlink(path.c_str());
+
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        ASSERT_EQ(sock.Close(1000), ::Thunder::Core::ERROR_NONE);
+
+        // Close(1000) waits for full closure including the ResourceMonitor
+        // thread running Closed() which removes the socket file.
+        EXPECT_NE(::access(path.c_str(), F_OK), 0);
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Trigger() on open socket — WRITESLOT path, must not crash
+    // =========================================================================
+
+    TEST(test_socketport, trigger_on_open_socket_does_not_crash)
+    {
+        const string path = "/tmp/test_sp_trigger.sock";
+        ::unlink(path.c_str());
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+        EXPECT_NO_FATAL_FAILURE(sock.Trigger());
+        EXPECT_TRUE(sock.IsOpen());
+
+        sock.Close(1000);
+
+        uint32_t waited = 0;
+        while (!sock.IsClosed() && waited < 1000) {
+            SleepMs(10);
+            waited += 10;
+        }
+        EXPECT_TRUE(sock.IsClosed());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Simple (non-source-specific) multicast Join/Leave on open socket
+    // =========================================================================
+
+    TEST(test_socketport, simple_multicast_join_leave)
+    {
+        ::Thunder::Core::NodeId local("0.0.0.0", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+        ::Thunder::Core::NodeId group("224.0.0.1", 0, ::Thunder::Core::NodeId::TYPE_IPV4);
+
+        TestDatagram sock(local);
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+
+        EXPECT_NO_FATAL_FAILURE(sock.Join(group));
+        EXPECT_NO_FATAL_FAILURE(sock.Leave(group));
+
+        sock.Close(1000);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Remote side closes — client detects it
+    // =========================================================================
+
+    TEST(test_socketport, remote_close_detected_by_client)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 8,
+                           maxWaitTimeMs = 8000, maxInitTime = 500;
+        constexpr uint8_t maxRetries = 1;
+
+        const string connector = "/tmp/test_sp_remoteclose.sock";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(connector.c_str());
+            EchoConnector::ResetState();
+
+            ::Thunder::Core::SocketServerType<EchoConnector> server(
+                ::Thunder::Core::NodeId(connector.c_str()));
+
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+
+            EXPECT_TRUE(EchoConnector::WaitForServerConnection(maxWaitTimeMs));
+            ASSERT_EQ(server.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            EchoConnector client(::Thunder::Core::NodeId(connector.c_str()));
+            ASSERT_EQ(client.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            EXPECT_TRUE(client.IsOpen());
+
+            // Poll until ResourceMonitor propagates the HUP.
+            uint32_t waited = 0;
+            while (client.IsOpen() && waited < 4000) {
+                SleepMs(50);
+                waited += 50;
+            }
+            EXPECT_FALSE(client.IsOpen());
+
+            client.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Open() on non-existent server path — must fail cleanly, no crash
+    // =========================================================================
+
+    TEST(test_socketport, stream_connect_to_nonexistent_server_fails_cleanly)
+    {
+        // Nothing is listening on this path.
+        ::Thunder::Core::NodeId remote("/tmp/test_sp_noserver.sock");
+        EchoConnector client(remote);
+
+        uint32_t result = client.Open(1000);
+        EXPECT_NE(result, ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(client.IsClosed());
+
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Open() on already-open socket — must return ERROR_ILLEGAL_STATE
+    // =========================================================================
+
+    // Second Open() on an already-open socket returns ERROR_ILLEGAL_STATE.
+    // Previously this triggered an ASSERT abort — the source fix adds an
+    // else-if guard that catches non-zero state before the ASSERT.
+    TEST(test_socketport, open_on_already_open_socket_returns_illegal_state)
+    {
+        const string path = "/tmp/test_sp_dblopen.sock";
+        ::unlink(path.c_str());
+        TestDatagram sock(::Thunder::Core::NodeId(path.c_str()));
+
+        ASSERT_EQ(sock.Open(1000), ::Thunder::Core::ERROR_NONE);
+
+        // Second Open() while still open must not succeed.
+        uint32_t result = sock.Open(1000);
+        EXPECT_NE(result, ::Thunder::Core::ERROR_NONE);
+        EXPECT_TRUE(sock.IsOpen());
+
+        sock.Close(1000);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // StateChange() is called on connect — verified via subclass
+    // =========================================================================
+
+    class StateChangeConnector : public ::Thunder::Core::SocketStream {
+    public:
+        StateChangeConnector() = delete;
+        StateChangeConnector(const StateChangeConnector&) = delete;
+        StateChangeConnector& operator=(const StateChangeConnector&) = delete;
+
+        StateChangeConnector(const SOCKET connector,
+                             const ::Thunder::Core::NodeId& remote,
+                             ::Thunder::Core::SocketServerType<StateChangeConnector>*)
+            : ::Thunder::Core::SocketStream(false, connector, remote, 512, 512)
+            , _stateChanges(0)
+        {
+        }
+
+        explicit StateChangeConnector(const ::Thunder::Core::NodeId& remote)
+            : ::Thunder::Core::SocketStream(false, ::Thunder::Core::NodeId(), remote, 512, 512)
+            , _stateChanges(0)
+        {
+        }
+
+        ~StateChangeConnector() override = default;
+
+        uint16_t SendData(uint8_t*, const uint16_t) override { return 0; }
+        uint16_t ReceiveData(uint8_t*, const uint16_t size) override { return size; }
+
+        void StateChange() override
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            _stateChanges.fetch_add(1, std::memory_order_relaxed);
+            _cv.notify_all();
+        }
+
+        int StateChanges() const { return _stateChanges.load(std::memory_order_relaxed); }
+
+        bool WaitForStateChange(uint32_t ms)
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            return _cv.wait_for(lk, std::chrono::milliseconds(ms),
+                                [this] { return _stateChanges.load(std::memory_order_relaxed) > 0; });
+        }
+
+    private:
+        std::mutex _mutex;
+        std::condition_variable _cv;
+        std::atomic<int> _stateChanges;
+    };
+
+    TEST(test_socketport, state_change_called_on_connect_and_disconnect)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 4,
+                           maxWaitTimeMs = 4000, maxInitTime = 500;
+        constexpr uint8_t maxRetries = 1;
+
+        const string connector = "/tmp/test_sp_statechange.sock";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(connector.c_str());
+            ::Thunder::Core::SocketServerType<StateChangeConnector> server(
+                ::Thunder::Core::NodeId(connector.c_str()));
+
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            // Server is ready — signal parent, then wait for it to finish.
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            ASSERT_EQ(server.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            // Wait for child to signal that the server is ready.
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            SleepMs(maxInitTime);
+
+            StateChangeConnector client(::Thunder::Core::NodeId(connector.c_str()));
+            ASSERT_EQ(client.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            // StateChange is called asynchronously by the ResourceMonitor thread.
+            EXPECT_TRUE(client.WaitForStateChange(maxWaitTimeMs));
+            EXPECT_GE(client.StateChanges(), 1);
+
+            ASSERT_EQ(client.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            // Signal child that we are done so it can close the server.
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // UDP IPv4 send/receive — sendto/recvmsg path on loopback
+    // =========================================================================
+
+    class UDPCapture : public ::Thunder::Core::SocketDatagram {
+    public:
+        UDPCapture() = delete;
+        UDPCapture(const UDPCapture&) = delete;
+        UDPCapture& operator=(const UDPCapture&) = delete;
+
+        explicit UDPCapture(const ::Thunder::Core::NodeId& local)
+            : ::Thunder::Core::SocketDatagram(false, local, ::Thunder::Core::NodeId(), 512, 512)
+            , _payloadSize(0)
+            , _received(false)
+        {
+            memset(_payload, 0, sizeof(_payload));
+        }
+        ~UDPCapture() override = default;
+
+        uint16_t SendData(uint8_t*, const uint16_t) override { return 0; }
+        uint16_t ReceiveData(uint8_t* frame, const uint16_t size) override
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            _payloadSize = std::min(size, static_cast<uint16_t>(sizeof(_payload)));
+            memcpy(_payload, frame, _payloadSize);
+            _received = true;
+            _cv.notify_all();
+            return size;
+        }
+        void StateChange() override {}
+
+        bool WaitForData(uint32_t ms)
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            return _cv.wait_for(lk, std::chrono::milliseconds(ms),
+                                [this] { return _received; });
+        }
+        string Payload() const
+        {
+            std::unique_lock<std::mutex> lk(_mutex);
+            return string(reinterpret_cast<const char*>(_payload), _payloadSize);
+        }
+        ::Thunder::Core::NodeId SenderNode() const
+        {
+            return ReceivedNode();
+        }
+
+    private:
+        mutable std::mutex _mutex;
+        std::condition_variable _cv;
+        uint16_t _payloadSize;
+        bool _received;
+        uint8_t _payload[512];
+    };
+
+    class UDPSender : public ::Thunder::Core::SocketDatagram {
+    public:
+        UDPSender() = delete;
+        UDPSender(const UDPSender&) = delete;
+        UDPSender& operator=(const UDPSender&) = delete;
+
+        UDPSender(const ::Thunder::Core::NodeId& local,
+                  const ::Thunder::Core::NodeId& remote,
+                  const string& msg)
+            : ::Thunder::Core::SocketDatagram(false, local, remote, 512, 512)
+            , _message(msg)
+            , _sent(false)
+        {
+        }
+        ~UDPSender() override = default;
+
+        uint16_t SendData(uint8_t* frame, const uint16_t maxSize) override
+        {
+            if (_sent) return 0;
+            uint16_t len = static_cast<uint16_t>(
+                std::min(_message.size(), static_cast<size_t>(maxSize)));
+            memcpy(frame, _message.data(), len);
+            _sent = true;
+            return len;
+        }
+        uint16_t ReceiveData(uint8_t*, const uint16_t) override { return 0; }
+        void StateChange() override {}
+
+    private:
+        string _message;
+        bool _sent;
+    };
+
+    TEST(test_socketport, udp_ipv4_send_receive_loopback)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 4,
+                           maxWaitTimeMs = 4000, maxInitTime = 300;
+        constexpr uint8_t maxRetries = 1;
+        const string message = "udp_loopback_test";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::Thunder::Core::NodeId serverNode("127.0.0.1", 10765,
+                                               ::Thunder::Core::NodeId::TYPE_IPV4);
+            UDPCapture server(serverNode);
+
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+
+            EXPECT_TRUE(server.WaitForData(maxWaitTimeMs));
+            EXPECT_EQ(server.Payload(), message);
+
+            // Sender node should be the client's address.
+            EXPECT_TRUE(server.SenderNode().IsValid());
+
+            server.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            ::Thunder::Core::NodeId clientNode("127.0.0.1", 10766,
+                                               ::Thunder::Core::NodeId::TYPE_IPV4);
+            ::Thunder::Core::NodeId serverNode("127.0.0.1", 10765,
+                                               ::Thunder::Core::NodeId::TYPE_IPV4);
+            UDPSender sender(clientNode, serverNode, message);
+            ASSERT_EQ(sender.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            sender.Trigger();
+            SleepMs(300);
+
+            sender.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Multiple sequential clients on same server
+    // =========================================================================
+
+    TEST(test_socketport, multiple_sequential_clients_on_same_server)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 8,
+                           maxWaitTimeMs = 8000, maxInitTime = 500;
+        constexpr uint8_t maxRetries = 1;
+
+        const string connector = "/tmp/test_sp_multiclients.sock";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(connector.c_str());
+            EchoConnector::ResetState();
+
+            ::Thunder::Core::SocketServerType<EchoConnector> server(
+                ::Thunder::Core::NodeId(connector.c_str()));
+
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+
+            // Wait for both clients to connect and disconnect.
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(server.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            // First client.
+            {
+                EchoConnector client1(::Thunder::Core::NodeId(connector.c_str()));
+                ASSERT_EQ(client1.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+                EXPECT_TRUE(client1.IsOpen());
+
+                const string msg1 = "client1";
+                client1.Submit(msg1);
+                EXPECT_EQ(client1.WaitForEcho(), ::Thunder::Core::ERROR_NONE);
+                EXPECT_EQ(client1.ReceivedText(), msg1);
+
+                ASSERT_EQ(client1.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            }
+
+            // Second client — server must still be accepting.
+            {
+                EchoConnector client2(::Thunder::Core::NodeId(connector.c_str()));
+                ASSERT_EQ(client2.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+                EXPECT_TRUE(client2.IsOpen());
+
+                const string msg2 = "client2";
+                client2.Submit(msg2);
+                EXPECT_EQ(client2.WaitForEcho(), ::Thunder::Core::ERROR_NONE);
+                EXPECT_EQ(client2.ReceivedText(), msg2);
+
+                ASSERT_EQ(client2.Close(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            }
+
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // Trigger() causes SendData() to be called — data actually flows
+    // =========================================================================
+
+    class TriggerSender : public ::Thunder::Core::SocketDatagram {
+    public:
+        TriggerSender() = delete;
+        TriggerSender(const TriggerSender&) = delete;
+        TriggerSender& operator=(const TriggerSender&) = delete;
+
+        TriggerSender(const ::Thunder::Core::NodeId& local,
+                      const ::Thunder::Core::NodeId& remote)
+            : ::Thunder::Core::SocketDatagram(false, local, remote, 512, 512)
+            , _sendDataCalls(0)
+        {
+        }
+        ~TriggerSender() override = default;
+
+        uint16_t SendData(uint8_t* frame, const uint16_t maxSize) override
+        {
+            int calls = _sendDataCalls.fetch_add(1, std::memory_order_relaxed);
+            if ((calls == 0) && (maxSize >= 1)) {
+                frame[0] = 0x42;
+                return 1;
+            }
+            return 0;
+        }
+        uint16_t ReceiveData(uint8_t*, const uint16_t) override { return 0; }
+        void StateChange() override {}
+
+        int SendDataCalls() const { return _sendDataCalls.load(std::memory_order_relaxed); }
+
+    private:
+        std::atomic<int> _sendDataCalls;
+    };
+
+    TEST(test_socketport, trigger_causes_send_data_to_be_called)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 4,
+                           maxWaitTimeMs = 4000, maxInitTime = 300;
+        constexpr uint8_t maxRetries = 1;
+
+        const string serverPath = "/tmp/test_sp_triggersend_srv.sock";
+        const string clientPath = "/tmp/test_sp_triggersend_cli.sock";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(serverPath.c_str());
+            UDPCapture server(::Thunder::Core::NodeId(serverPath.c_str()));
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            server.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            ::unlink(clientPath.c_str());
+            TriggerSender sender(
+                ::Thunder::Core::NodeId(clientPath.c_str()),
+                ::Thunder::Core::NodeId(serverPath.c_str()));
+
+            ASSERT_EQ(sender.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            // SendData should not have been called yet.
+            EXPECT_EQ(sender.SendDataCalls(), 0);
+
+            sender.Trigger();
+            SleepMs(200);
+
+            // SendData must have been called after Trigger().
+            EXPECT_GT(sender.SendDataCalls(), 0);
+
+            sender.Close(maxWaitTimeMs);
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+    // =========================================================================
+    // ReceivedNode() populated after datagram receive
+    // =========================================================================
+
+    TEST(test_socketport, received_node_populated_after_datagram_receive)
+    {
+        constexpr uint32_t initHandshakeValue = 0, maxWaitTime = 4,
+                           maxWaitTimeMs = 4000, maxInitTime = 300;
+        constexpr uint8_t maxRetries = 1;
+
+        const string serverPath = "/tmp/test_sp_recvnode_srv.sock";
+        const string clientPath = "/tmp/test_sp_recvnode_cli.sock";
+        const string message = "recvnode_test";
+
+        IPTestAdministrator::Callback callback_child = [&](IPTestAdministrator& testAdmin) {
+            ::unlink(serverPath.c_str());
+            UDPCapture server(::Thunder::Core::NodeId(serverPath.c_str()));
+            ASSERT_EQ(server.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+            EXPECT_TRUE(server.WaitForData(maxWaitTimeMs));
+
+            // ReceivedNode must identify the sender.
+            ::Thunder::Core::NodeId sender = server.SenderNode();
+            EXPECT_TRUE(sender.IsValid());
+            EXPECT_STREQ(sender.HostName().c_str(), clientPath.c_str());
+
+            ASSERT_EQ(testAdmin.Signal(initHandshakeValue, maxRetries), ::Thunder::Core::ERROR_NONE);
+            server.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator::Callback callback_parent = [&](IPTestAdministrator& testAdmin) {
+            SleepMs(maxInitTime);
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+
+            ::unlink(clientPath.c_str());
+            UDPSender sender(
+                ::Thunder::Core::NodeId(clientPath.c_str()),
+                ::Thunder::Core::NodeId(serverPath.c_str()),
+                message);
+            ASSERT_EQ(sender.Open(maxWaitTimeMs), ::Thunder::Core::ERROR_NONE);
+            sender.Trigger();
+
+            ASSERT_EQ(testAdmin.Wait(initHandshakeValue), ::Thunder::Core::ERROR_NONE);
+            sender.Close(maxWaitTimeMs);
+        };
+
+        IPTestAdministrator testAdmin(callback_parent, callback_child,
+                                      initHandshakeValue, maxWaitTime);
+        ::Thunder::Core::Singleton::Dispose();
+    }
+
+} // Core
+} // Tests
+} // Thunder


### PR DESCRIPTION
## Coverity static analysis fixes — batch 1

This PR addresses a set of real bugs and false positives identified
during a systematic triage of ~599 Coverity findings against Thunder
master (HEAD b5b4746).

---

### Real bug fixes

**BAD_SHIFT — PluginServer.h**
`1 << bitNr` with a signed int literal is undefined behaviour when
`bitNr >= 31`. Changed to `1u << bitNr`.

**Random.cpp — typo and sign extension**
`lsb1 < 16` was a boolean comparison (yields 0 or 1) instead of the
intended left shift `lsb1 << 16`, corrupting uint32/uint64 output.
`uint16_t` values were also shifted in an int32 context before
assignment to uint64_t, causing sign extension when bit 15 is set.

**NodeId.cpp — uninitialised sockaddr_nl**
`sockaddr_nl.nl_pad` was left uninitialised. Fixed with `memset` before
field assignment.

**SocketPort.cpp — source-specific multicast uninitialised field**
A 10-year-old TODO: `ip_mreq_source.imr_interface` was never set on
Linux in the source-specific `Join()`/`Leave()` overloads. Zero-
initialised the struct and set `imr_interface` to `INADDR_ANY`.

**SocketPort.cpp — TOCTOU and domain socket cleanup**
`access()+remove()` replaced with unconditional `unlink()` in
`ConstructSocket()` and `Closed()`. Cleanup extended from `LISTEN`-only
to all binding socket types (`!= STREAM`). The now-redundant second
`unlink()` block removed. 

**SocketPort.cpp — double-open hardening**
Calling `Open()` on an already-open socket triggered an `ASSERT` abort
in debug builds and silently leaked the socket in release. Added an
`else if (m_State != 0)` guard that returns `ERROR_ILLEGAL_STATE`
without destroying the still-registered socket.

**DoorBell.cpp — TOCTOU and dangling pointer**
Same `access()+remove()` TOCTOU race.

**Singleton.h — broken double-checked locking (DCLP)**
The outer `if (g_TypedSingleton == nullptr)` read a plain pointer
without a lock or memory barrier. On weakly-ordered CPUs (ARM) a thread
can observe the non-null pointer before the constructor has finished.
Fixed by declaring `g_TypedSingleton` as `std::atomic<SINGLETON*>` with
acquire/release semantics. `Dispose()` uses `exchange(nullptr, acq_rel)`
to eliminate the double-free window.

**PluginServer.cpp — null dereference in Server::Close()**
`ClassType<Controller>()` result was dereferenced without a null check.
Added ASSERT and null guard.

---

### False positive annotations

- `PW.INCLUDE_RECURSION` — IPlugin.h / IShell.h mutual include is
  intentional and guarded by include guards
- `RESOURCE_LEAK` — Administrator.h ownership transfers via Thunder
  ref-counting
- `PW.CONVERSION_FUNCTION_NOT_USABLE` — Proxy.h intentional implicit
  conversions in the proxy pattern
- `ATOMICITY` — PluginServer.cpp lock-straddling around blocking
  `Deactivate()` is intentional
- `MISSING_LOCK` — ProxyPoolType diagnostic accessors and
  ResourceMonitor::Count() intentionally return momentary snapshots
- `DEADCODE` — PluginServer.cpp Hibernate() and Controller.cpp
  BuildInfo() branches controlled by `#ifdef`
- `INTEGER_OVERFLOW` — WebSerializer.cpp `sizeof(uint8_t[64])` is 64,
  well within uint16_t range

---

### Tests added

- `test_singleton.cpp` — extended with lifetime, DCLP stress, and
  concurrent construction tests
- `test_socketport.cpp` — new file, 29 tests covering state machine,
  TOCTOU fixes, socket options, TTL, Broadcast, multicast, TCP stream,
  UDP loopback, double-open, remote close, and data flow verification
  (65.1% line coverage of SocketPort.cpp)