### PR TITLE
[CMake] Add CXX_STANDARD propagation via the CompileSettings interface target

### DIFF
--- a/Source/extensions/localtracer/CMakeLists.txt
+++ b/Source/extensions/localtracer/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(${MODULE_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}>)
 
-target_compile_features(${MODULE_NAME} INTERFACE cxx_std_11)
+target_compile_features(${MODULE_NAME} INTERFACE cxx_std_${CXX_STD})
 
 install(TARGETS ${MODULE_NAME} EXPORT ${MODULE_NAME}Targets)
 

--- a/cmake/common/CompileSettings.cmake
+++ b/cmake/common/CompileSettings.cmake
@@ -29,12 +29,6 @@ add_library(CompileSettings::CompileSettings ALIAS CompileSettings)
 #
 # Global options
 #
-if(CXX_STD)
-    set_target_properties(CompileSettings PROPERTIES
-        INTERFACE_COMPILE_FEATURES "cxx_std_${CXX_STD}")
-else()
-    message(FATAL_ERROR "CXX_STD is not set")
-endif()
 
 target_include_directories(CompileSettings INTERFACE
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Source>)

--- a/cmake/common/CompileSettings.cmake
+++ b/cmake/common/CompileSettings.cmake
@@ -29,12 +29,14 @@ add_library(CompileSettings::CompileSettings ALIAS CompileSettings)
 #
 # Global options
 #
-if(NOT CXX_STD)
-    set(CXX_STD 11)
+if(CXX_STD)
+    set_target_properties(CompileSettings PROPERTIES
+        INTERFACE_COMPILE_FEATURES "cxx_std_${CXX_STD}")
+else()
+    message(FATAL_ERROR "CXX_STD is not set")
 endif()
 
-set_target_properties(CompileSettings PROPERTIES
-    INTERFACE_COMPILE_FEATURES "cxx_std_${CXX_STD}")
+
 
 target_include_directories(CompileSettings INTERFACE
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Source>)

--- a/cmake/common/CompileSettings.cmake
+++ b/cmake/common/CompileSettings.cmake
@@ -29,6 +29,13 @@ add_library(CompileSettings::CompileSettings ALIAS CompileSettings)
 #
 # Global options
 #
+if(NOT CXX_STD)
+    set(CXX_STD 11)
+endif()
+
+set_target_properties(CompileSettings PROPERTIES
+    INTERFACE_COMPILE_FEATURES "cxx_std_${CXX_STD}")
+
 target_include_directories(CompileSettings INTERFACE
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Source>)
 

--- a/cmake/common/CompileSettings.cmake
+++ b/cmake/common/CompileSettings.cmake
@@ -36,8 +36,6 @@ else()
     message(FATAL_ERROR "CXX_STD is not set")
 endif()
 
-
-
 target_include_directories(CompileSettings INTERFACE
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Source>)
 


### PR DESCRIPTION
This is to make sure the macOS build (and any other build for that matter) properly uses C++17 instead of 11