### PR TITLE
[COM][RDKEMW-16318] Fix use-after-free SIGSEGV in UnknownProxy Release

### DIFF
--- a/Source/com/Administrator.cpp
+++ b/Source/com/Administrator.cpp
@@ -105,13 +105,13 @@ namespace RPC {
         proxy->Complete(response);
     }
 
-    bool Administrator::UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy)
+    bool Administrator::UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy, uintptr_t channelId)
     {
         bool removed = false;
 
         _adminLock.Lock();
 
-        ChannelMap::iterator index(_channelProxyMap.find(proxy.LinkId()));
+        ChannelMap::iterator index(_channelProxyMap.find(channelId));
 
         if (index != _channelProxyMap.end()) {
             Proxies::iterator entry(index->second.begin());
@@ -124,20 +124,17 @@ namespace RPC {
                 if (index->second.size() == 0) {
                     _channelProxyMap.erase(index);
                 }
-                else {
-                    // If it is not found, check the dangling map
-                    Proxies::iterator index = std::find(_danglingProxies.begin(), _danglingProxies.end(), &proxy);
-
-                    if (index != _danglingProxies.end()) {
-                        _danglingProxies.erase(index);
-                    }
-                    else {
-                        TRACE_L1("Could not find the Proxy entry to be unregistered from a channel perspective.");
-		    }
-		}
             }
         } else {
-            TRACE_L1("Could not find the Proxy entry to be unregistered from a channel perspective.");
+            // Channel has already been deleted (channelId == 0 or DeleteChannel already ran);
+            // search the dangling list for the proxy by pointer.
+            Proxies::iterator dangling = std::find(_danglingProxies.begin(), _danglingProxies.end(), &proxy);
+            if (dangling != _danglingProxies.end()) {
+                _danglingProxies.erase(dangling);
+                removed = true;
+            } else {
+                TRACE_L1("Could not find the Proxy entry to be unregistered from a channel perspective.");
+            }
         }
 
         _adminLock.Unlock();

--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -292,7 +292,7 @@ namespace RPC {
 
             _adminLock.Unlock();
         }
-        bool UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy);
+        bool UnregisterUnknownProxy(const ProxyStub::UnknownProxy& proxy, uintptr_t channelId);
 
    private:
         // ----------------------------------------------------------------------------------------------------

--- a/Source/com/IUnknown.h
+++ b/Source/com/IUnknown.h
@@ -160,6 +160,8 @@ namespace ProxyStub {
             ASSERT(_refCount > 0);
             _adminLock.Lock();
             if (_channel.IsValid() == true) {
+                _refCount++;    // Take a reference on behalf of the _danglingProxies entry so the proxy is not
+                                // destroyed while still tracked; balanced by UnregisterUnknownProxy() -> Release().
                 _channel.Release();
                 succeeded = true;
             }
@@ -209,42 +211,51 @@ namespace ProxyStub {
  
             if (_refCount > 1 ) {  // note this proxy is also held in the administrator list for non happy day scenario's so we should already release with refcount one, the UnregisterProxy will remove it from the list
                 _adminLock.Unlock();
-            } 
-            else if( _refCount == 0 ) {
-                _adminLock.Unlock();
-                result = Core::ERROR_DESTRUCTION_SUCCEEDED;
-                ASSERT(_channel.IsValid() == false);
+                if (_channel.IsValid() == false) {
+                    // Channel is gone (Invalidate() was called) but other references still exist.
+                    // Signal the caller so it does not interpret ERROR_NONE as a live connection.
+                    result = Core::ERROR_CONNECTION_CLOSED;
+                }
             }
             else {
-                if ((_channel.IsValid() == true) && ((_mode & (CACHING_RELEASE|CACHING_ADDREF)) == 0)) {
+                ASSERT(_refCount == 1);
+                uintptr_t channelId = 0;
 
-                    // We have reached "0", signal the other side..
-                    Core::ProxyType<RPC::InvokeMessage> message(RPC::Administrator::Instance().Message());
+                if (_channel.IsValid() == true) {
+                    if ((_mode & (CACHING_RELEASE|CACHING_ADDREF)) == 0) {
 
-                    message->Parameters().Set(_implementation, _interfaceId, 1);
+                        // We have reached "0", signal the other side..
+                        Core::ProxyType<RPC::InvokeMessage> message(RPC::Administrator::Instance().Message());
 
-                    // Pass on the number of reference we need to lower, since it is indicated by the amount of times this proxy had to be created
-                    message->Parameters().Writer().Number<uint32_t>(_remoteReferences);
+                        message->Parameters().Set(_implementation, _interfaceId, 1);
 
-                    // Just try the destruction for few Seconds...
-                    result = _channel->Invoke(message, RPC::CommunicationTimeOut);
+                        // Pass on the number of reference we need to lower, since it is indicated by the amount of times this proxy had to be created
+                        message->Parameters().Writer().Number<uint32_t>(_remoteReferences);
 
-                    if (result != Core::ERROR_NONE) {
-                        TRACE_L1("Could not remote release the Proxy.");
-                        result |= COM_ERROR;
+                        // Just try the destruction for few Seconds...
+                        result = _channel->Invoke(message, RPC::CommunicationTimeOut);
+
+                        if (result != Core::ERROR_NONE) {
+                            TRACE_L1("Could not remote release the Proxy.");
+                            result |= COM_ERROR;
+                        }
+                        else {
+                            // Pass the remote release return value through
+                            result = message->Response().Reader().Number<uint32_t>();
+                        }
                     }
-                    else {
-                        // Pass the remote release return value through
-                        result = message->Response().Reader().Number<uint32_t>();
-                    }
+
+                    // Capture channelId before releasing _channel so UnregisterUnknownProxy can locate
+                    // this proxy in _channelProxyMap or _danglingProxies regardless of race with
+                    // DeleteChannel / Invalidate().
+                    channelId = _channel->LinkId();
+                    _channel.Release();
                 }
 
                 _adminLock.Unlock();
 
                 // Remove our selves from the Administration, we are done..
-                if (RPC::Administrator::Instance().UnregisterUnknownProxy(*this) == true ) {
-                    ASSERT(_refCount == 1);
-                    _refCount = 0;
+                if (RPC::Administrator::Instance().UnregisterUnknownProxy(*this, channelId) == true) {
                     result = Core::ERROR_DESTRUCTION_SUCCEEDED;
                 }
             }


### PR DESCRIPTION


Problem
-------
A SIGSEGV crash occurred in PluginInitializerService::PluginStarter:: NotifyInitiator() on a COM-RPC proxy (IActivationCallback) that had already been freed.

The race condition is:
1. DeleteChannel() (socket I/O thread) calls Invalidate() on a proxy that still has refCount==1.
2. Invalidate() calls _channel.Release() which decrements the internal ProxyType refCount.  Because no extra reference was taken first, the ProxyType destructor fires immediately, dropping the proxy's own refCount to 0 — the proxy is deleted while still registered in _danglingProxies.
3. Later, when a worker thread calls Release() → UnregisterUnknownProxy() it finds a recycled address in _danglingProxies, deletes a now-live proxy and corrupts heap state → SIGSEGV.

A second independent bug: UnregisterUnknownProxy() looked up the proxy in _channelProxyMap using proxy.LinkId(), but by the time Release() runs _channel may already be cleared (by a concurrent Invalidate()), so LinkId() returns 0 and the lookup always fails.  The proxy was also never looked up in _danglingProxies from the outer-else path.

Fix
---
IUnknown.h – Invalidate():
  Increment _refCount before releasing _channel so the proxy stays alive
  until UnregisterUnknownProxy() balances the count via its own Release().

IUnknown.h – Release():
  * Capture channelId = _channel->LinkId() before calling _channel.Release() so the ID is available for the UnregisterUnknownProxy() call even when DeleteChannel/Invalidate has already cleared _channel.
  * Remove the now-dead '_refCount == 0' path (unreachable since Invalidate now prevents the spurious zero).
  * Propagate ERROR_CONNECTION_CLOSED when refCount > 1 and channel is gone, so callers know the connection is dead.

Administrator.cpp / Administrator.h – UnregisterUnknownProxy():
  * Accept an explicit 'uintptr_t channelId' parameter rather than calling proxy.LinkId() (which may return 0 after _channel is cleared).
  * When the channel is not found in _channelProxyMap (DeleteChannel already ran), search _danglingProxies by pointer — the correct location for a proxy whose channel has been torn down.
  * Remove the misplaced dangling-search in the found-in-channelMap branch (a proxy cannot be in both lists simultaneously).