### PR TITLE
Use RawString in Variant

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -1752,6 +1752,13 @@ namespace Core {
                 if ((_flagsAndCounters & (SetBit | QuoteFoundBit | QuotedSerializeBit)) == (SetBit | QuoteFoundBit)) {
                     return (Core::ToQuotedString('\"', _value));
                 }
+                else {
+                    return (RawString());
+                }
+            }
+
+            inline const string RawString() const
+            {
                 return (((_flagsAndCounters & (SetBit | NullBit)) == SetBit) ? Core::ToString(_value.c_str()) : Core::ToString(_default.c_str()));
             }
 
@@ -2112,9 +2119,13 @@ namespace Core {
                     offset += static_cast<uint32_t>(_value.length()) ;
                 } else {
                     offset = 0;
-                    _flagsAndCounters |= (_value == IElement::NullTag ? NullBit|SetBit : SetBit);
+                    flagsAndCounters |= SetBit;
 
                     if ((_flagsAndCounters & QuoteFoundBit) == 0) {
+                        if (_value == IElement::NullTag) {
+                            _flagsAndCounters |= NullBit;
+                        }
+
                         // Right-trim the non-string value, it's always left-trimmed already
                         _value.erase(std::find_if(_value.rbegin(), _value.rend(), [](const unsigned char ch) { return (!std::isspace(static_cast<uint8_t>(ch))); }).base(), _value.end());
                     }
@@ -4293,7 +4304,7 @@ namespace Core {
                 : JSON::String(false)
                 , _type(type::EMPTY)
             {
-                String::operator=("null");
+                String::operator=(_T("null"));
             }
 
             Variant(const int32_t value)
@@ -4404,7 +4415,7 @@ namespace Core {
             {
                 bool result = false;
                 if (_type == type::BOOLEAN) {
-                    result = (Value() == "true");
+                    result = (String() == _T("true"));
                 }
                 return result;
             }
@@ -4413,7 +4424,7 @@ namespace Core {
             {
                 int64_t result = 0;
                 if (_type == type::NUMBER) {
-                    result = Core::NumberType<int64_t>(Value().c_str(), static_cast<uint32_t>(Value().length()));
+                    result = Core::NumberType<int64_t>(String().c_str(), static_cast<uint32_t>(String().length()));
                 } else if (_type == type::FLOAT) {
                     result = static_cast<int64_t>(Float());
                 } else if (_type == type::DOUBLE) {
@@ -4429,7 +4440,7 @@ namespace Core {
                     result = static_cast<float>(Number());
                 } else if (_type == type::FLOAT) {
                     JSON::Float value;
-                    if (value.FromString(Value())) {
+                    if (value.FromString(String())) {
                         result = value.Value();
                     }
                 } else if (_type == type::DOUBLE) {
@@ -4447,7 +4458,7 @@ namespace Core {
                     result = static_cast<double>(Float());
                 } else if (_type == type::DOUBLE) {
                     JSON::Double value;
-                    if (value.FromString(Value())) {
+                    if (value.FromString(String())) {
                         result = value.Value();
                     }
                 }
@@ -4456,14 +4467,14 @@ namespace Core {
 
             const string String() const
             {
-                return Value();
+                return RawString();
             }
 
             ArrayType<Variant> Array() const
             {
                 ArrayType<Variant> result;
 
-                result.FromString(Value());
+                result.FromString(String());
 
                 return result;
             }
@@ -4996,7 +5007,7 @@ namespace Core {
         inline VariantContainer Variant::Object() const
         {
             VariantContainer result;
-            result.FromString(Value());
+            result.FromString(String());
             return (result);
         }
 
@@ -5046,14 +5057,14 @@ namespace Core {
             case type::BOOLEAN: {
                 Core::OptionalType<JSON::Error> error;
                 JSON::Boolean stacked;
-                stacked.FromString(Value(), error);
+                stacked.FromString(String(), error);
                 result = (error.IsSet() == false);
                 break;
             }
             case type::NUMBER: {
                 Core::OptionalType<JSON::Error> error;
                 JSON::DecUInt64 stacked;
-                stacked.FromString(Value(), error);
+                stacked.FromString(String(), error);
                 result = (error.IsSet() == false);
                 break;
             }
@@ -5061,14 +5072,14 @@ namespace Core {
             case type::FLOAT: {
                 Core::OptionalType<JSON::Error> error;
                 JSON::Double stacked;
-                stacked.FromString(Value(), error);
+                stacked.FromString(String(), error);
                 result = (error.IsSet() == false);
                 break;
             }
             case type::ARRAY: {
                 Core::OptionalType<JSON::Error> error;
                 Core::JSON::ArrayType<JSON::Variant> stacked;
-                stacked.FromString(Value(), error);
+                stacked.FromString(String(), error);
                 result = (error.IsSet() == false);
                 Core::JSON::ArrayType<JSON::Variant>::ConstIterator index = static_cast<const Core::JSON::ArrayType<JSON::Variant>&>(stacked).Elements();
                 if ((result == true) && (index.Next() == true) && index.Current().IsValid()) {
@@ -5083,7 +5094,7 @@ namespace Core {
             case type::OBJECT: {
                 Core::OptionalType<JSON::Error> error;
                 VariantContainer stacked;
-                stacked.FromString(Value(), error);
+                stacked.FromString(String(), error);
                 result = ((error.IsSet() == false) && (stacked.IsValid() == true));
                 break;
             }
@@ -5100,7 +5111,7 @@ namespace Core {
             // If we are complete, try to guess what it was that we received...
             if (offset == 0) {
                 if (IsQuoted() == false) {
-                    const string base = JSON::String::Value();
+                    const string base = JSON::String::RawString();
                     if (IsNull() == true) {
                         _type = type::EMPTY;
                     }

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -2119,7 +2119,7 @@ namespace Core {
                     offset += static_cast<uint32_t>(_value.length()) ;
                 } else {
                     offset = 0;
-                    flagsAndCounters |= SetBit;
+                    _flagsAndCounters |= SetBit;
 
                     if ((_flagsAndCounters & QuoteFoundBit) == 0) {
                         if (_value == IElement::NullTag) {

--- a/Tests/unit/core/test_jsonobject.cpp
+++ b/Tests/unit/core/test_jsonobject.cpp
@@ -202,7 +202,171 @@ namespace Core {
         EXPECT_TRUE(stringRefCreated.Content() == ::Thunder::Core::JSON::Variant::type::EMPTY);
     }
 
+    TEST(JSONOBJECT, ParsedStringVariantKeepsStringSemantics)
+    {
+        const std::string keyValues = R"({"string":"scribble"})";
 
+        JsonObject container;
+
+        ASSERT_TRUE(container.FromString(keyValues));
+        ASSERT_TRUE(container.HasLabel("string"));
+
+        const ::Thunder::Core::JSON::Variant parsed = container.Get("string");
+        const ::Thunder::Core::JSON::Variant constructed{ "scribble" };
+
+        EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_EQ(parsed.String(), std::string("scribble"));
+        EXPECT_EQ(parsed.Value(), std::string("scribble"));
+        EXPECT_TRUE(parsed == constructed);
+
+        std::string serialized;
+        EXPECT_TRUE(::Thunder::Core::JSON::IElement::ToString(parsed, serialized));
+        EXPECT_EQ(serialized, std::string("\"scribble\""));
+    }
+
+    // Tests for JSON.h fix: SetQuoted(quoted) preserves quoted state after Variant deserialization.
+    // Without the fix, string variants parsed from JSON lose their quoted state and re-serialize
+    // without surrounding quotes, breaking round-trip correctness.
+
+    TEST(JSONOBJECT, ParsedStringVariantRoundTrip)
+    {
+        // Verify that a string variant parsed from JSON and then re-serialized produces
+        // valid JSON with surrounding quotes (round-trip correctness).
+        const std::string original = R"({"key":"hello world"})";
+
+        JsonObject container;
+        ASSERT_TRUE(container.FromString(original));
+
+        std::string roundTripped;
+        ASSERT_TRUE(container.ToString(roundTripped));
+
+        // The re-serialized JSON must still contain the key with quoted value.
+        EXPECT_NE(roundTripped.find("\"hello world\""), std::string::npos);
+    }
+
+    TEST(JSONOBJECT, ParsedStringVariantLooksLikeNumber)
+    {
+        // A quoted value that looks like a number must remain a STRING type, not NUMBER.
+        // SetQuoted(quoted) ensures the type resolves to STRING when the token was quoted.
+        const std::string keyValues = R"({"val":"42"})";
+
+        JsonObject container;
+        ASSERT_TRUE(container.FromString(keyValues));
+
+        const ::Thunder::Core::JSON::Variant parsed = container.Get("val");
+
+        EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_EQ(parsed.String(), std::string("42"));
+
+        std::string serialized;
+        EXPECT_TRUE(::Thunder::Core::JSON::IElement::ToString(parsed, serialized));
+        // Must be serialized with quotes, not as a bare number.
+        EXPECT_EQ(serialized, std::string("\"42\""));
+    }
+
+    TEST(JSONOBJECT, ParsedStringVariantLooksLikeBoolean)
+    {
+        // A quoted "true" must remain a STRING, not BOOLEAN.
+        const std::string keyValues = R"({"flag":"true"})";
+
+        JsonObject container;
+        ASSERT_TRUE(container.FromString(keyValues));
+
+        const ::Thunder::Core::JSON::Variant parsed = container.Get("flag");
+
+        EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_EQ(parsed.String(), std::string("true"));
+
+        std::string serialized;
+        EXPECT_TRUE(::Thunder::Core::JSON::IElement::ToString(parsed, serialized));
+        EXPECT_EQ(serialized, std::string("\"true\""));
+    }
+
+    TEST(JSONOBJECT, ParsedStringVariantLooksLikeNull)
+    {
+        // A quoted "null" must remain a STRING, not EMPTY/null.
+        const std::string keyValues = R"({"nothing":"null"})";
+
+        JsonObject container;
+        ASSERT_TRUE(container.FromString(keyValues));
+
+        const ::Thunder::Core::JSON::Variant parsed = container.Get("nothing");
+
+        EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_EQ(parsed.String(), std::string("null"));
+
+        std::string serialized;
+        EXPECT_TRUE(::Thunder::Core::JSON::IElement::ToString(parsed, serialized));
+        EXPECT_EQ(serialized, std::string("\"null\""));
+    }
+
+    TEST(JSONOBJECT, MultipleStringVariantsAllPreserveQuotedState)
+    {
+        // All string fields in a JSON object must retain their string type and
+        // serialize with quotes after the fix.
+        const std::string keyValues = R"({"a":"alpha","b":"beta","c":"gamma"})";
+
+        JsonObject container;
+        ASSERT_TRUE(container.FromString(keyValues));
+
+        const std::vector<std::pair<std::string, std::string>> expected = {
+            {"a", "alpha"}, {"b", "beta"}, {"c", "gamma"}
+        };
+
+        for (const auto& kv : expected) {
+            const ::Thunder::Core::JSON::Variant parsed = container.Get(kv.first.c_str());
+
+            EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING)
+                << "Field '" << kv.first << "' should be STRING";
+            EXPECT_EQ(parsed.String(), kv.second)
+                << "Field '" << kv.first << "' has wrong value";
+
+            std::string serialized;
+            EXPECT_TRUE(::Thunder::Core::JSON::IElement::ToString(parsed, serialized));
+            EXPECT_EQ(serialized, "\"" + kv.second + "\"")
+                << "Field '" << kv.first << "' should serialize with quotes";
+        }
+    }
+
+    TEST(JSONOBJECT, ParsedStringVariantEqualityWithConstructed)
+    {
+        // A Variant parsed from JSON {"key":"value"} must compare equal to
+        // a Variant constructed directly with the same string.
+        const std::string keyValues = R"({"key":"Thunder"})";
+
+        JsonObject container;
+        ASSERT_TRUE(container.FromString(keyValues));
+
+        const ::Thunder::Core::JSON::Variant parsed    = container.Get("key");
+        const ::Thunder::Core::JSON::Variant constructed{ "Thunder" };
+
+        EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_EQ(parsed.Content(), constructed.Content());
+        EXPECT_TRUE(parsed == constructed);
+    }
+
+    TEST(JSONOBJECT, VariantReuseQuotedThenUnquoted)
+    {
+        // Regression test: reusing the same Variant for a second FromString() call must
+        // not carry over the quoted/serialize flag from the first parse.  Without the fix,
+        // parsing an unquoted number after a quoted string left IsQuoted()==true, causing
+        // the number to be misclassified as STRING.
+        ::Thunder::Core::JSON::Variant variant;
+
+        // First parse: quoted string — variant must be STRING.
+        ASSERT_TRUE(variant.FromString("\"hello\""));
+        EXPECT_EQ(variant.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
+        EXPECT_EQ(variant.String(), std::string("hello"));
+
+        // Second parse on the same instance: unquoted integer — variant must be NUMBER.
+        ASSERT_TRUE(variant.FromString("42"));
+        EXPECT_EQ(variant.Content(), ::Thunder::Core::JSON::Variant::type::NUMBER);
+        EXPECT_EQ(variant.Number(), static_cast<int64_t>(42));
+
+        // Third parse on the same instance: unquoted boolean — must be BOOLEAN, not STRING.
+        ASSERT_TRUE(variant.FromString("true"));
+        EXPECT_EQ(variant.Content(), ::Thunder::Core::JSON::Variant::type::BOOLEAN);
+    }
 } // Core
 } // Tests
 } // Thunder

--- a/Tests/unit/core/test_jsonobject.cpp
+++ b/Tests/unit/core/test_jsonobject.cpp
@@ -216,7 +216,6 @@ namespace Core {
 
         EXPECT_EQ(parsed.Content(), ::Thunder::Core::JSON::Variant::type::STRING);
         EXPECT_EQ(parsed.String(), std::string("scribble"));
-        EXPECT_EQ(parsed.Value(), std::string("scribble"));
         EXPECT_TRUE(parsed == constructed);
 
         std::string serialized;

--- a/Tests/unit/core/test_jsonobject.cpp
+++ b/Tests/unit/core/test_jsonobject.cpp
@@ -223,10 +223,6 @@ namespace Core {
         EXPECT_EQ(serialized, std::string("\"scribble\""));
     }
 
-    // Tests for JSON.h fix: SetQuoted(quoted) preserves quoted state after Variant deserialization.
-    // Without the fix, string variants parsed from JSON lose their quoted state and re-serialize
-    // without surrounding quotes, breaking round-trip correctness.
-
     TEST(JSONOBJECT, ParsedStringVariantRoundTrip)
     {
         // Verify that a string variant parsed from JSON and then re-serialized produces


### PR DESCRIPTION
String::Value() conditionally adds quotes to the string, the new RawString() is always unquoted.

Also fix quoted "null" string deserialized to null element.