### PR TITLE
[R4_4] Add lock to Core::SystemInfo::(Get/Set)Environment backport

### DIFF
--- a/Source/core/SystemInfo.cpp
+++ b/Source/core/SystemInfo.cpp
@@ -69,6 +69,7 @@ namespace WPEFramework {
 namespace Core {
 
     /* static */ SystemInfo SystemInfo::_systemInfo;
+    static CriticalSection _lock;
 
     static string ConstructUniqueId(
         const TCHAR DeviceId[],
@@ -370,6 +371,7 @@ namespace Core {
     /* static */ bool SystemInfo::GetEnvironment(const string& name, string& value)
     {
 #ifdef __LINUX__
+        SafeSyncType<CriticalSection> scopedLock(_lock);
         TCHAR* text = ::getenv(name.c_str());
 
         if (text != nullptr) {
@@ -381,17 +383,24 @@ namespace Core {
         return (text != nullptr);
 #else
         TCHAR buffer[1024];
-        DWORD bytes = GetEnvironmentVariable(name.c_str(), buffer, sizeof(buffer));
+        const DWORD capacity = sizeof(buffer) / sizeof(buffer[0]);
 
-        value = string(buffer, bytes);
+        DWORD characters = ::GetEnvironmentVariable(name.c_str(), buffer, capacity);
 
-        return (bytes > 0);
+        ASSERT(characters < capacity);
+        if (characters > 0) {
+            value.assign(buffer, characters);
+        } else {
+            value.clear();
+        }
+        return (characters > 0);
 #endif
     }
 
     /* static */ bool SystemInfo::SetEnvironment(const string& name, const TCHAR* value, const bool forced)
     {
         bool result = false;
+        SafeSyncType<CriticalSection> scopedLock(_lock);
 #ifdef __LINUX__
         if ((forced == true) || (::getenv(name.c_str()) == nullptr)) {
             if (value != nullptr) {


### PR DESCRIPTION
* add lock to get set environment

* spacing

* ifdef linux

* lock for windows too

* windows assert

* forgot #endif

* characters

* lock for linux

(cherry picked from commit 213a68ef431d6eccbe8417e32083a1602aeb797d)