### PR TITLE
[core] fix infinite loop in StreamJSONType::ReceiveData on garbage input

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -449,7 +449,7 @@ namespace Core {
             const size_t nullTagLen = strlen(IElement::NullTag);
             ASSERT(offset < nullTagLen);
             while (offset < nullTagLen) {
-                if (loaded + 1 == maxLength) {
+                if (loaded >= maxLength) {
                     validity = ValueValidity::UNKNOWN;
                     break;
                 }

--- a/Source/core/StreamJSON.h
+++ b/Source/core/StreamJSON.h
@@ -287,12 +287,14 @@ POP_WARNING()
         uint16_t ReceiveData(uint8_t* dataFrame, const uint16_t receivedSize)
         {
             uint16_t handled = 0;
+            uint16_t processed;
 
             do {
-                handled += _deserializer.Deserialize(&dataFrame[handled], (receivedSize - handled));
+                processed = _deserializer.Deserialize(&dataFrame[handled], (receivedSize - handled));
+                handled += processed;
 
                 // The dataframe can hold more items....
-            } while (handled < receivedSize);
+            } while ((processed != 0) && (handled < receivedSize));
 
             return (handled);
         }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,6 +5,7 @@ option(FILE_UNLINK_TEST "File unlink test" OFF)
 option(REDIRECT_TEST "Test stream redirection" OFF)
 option(MESSAGEBUFFER_TEST "Test message buffer" OFF)
 option(UNRAVELLER "reveal thread details" OFF)
+option(STREAMJSON_GARBAGE_TEST "Reproducer for issue #1963: infinite loop on garbage data in StreamJSONType::ReceiveData()" OFF)
 
 if(BUILD_TESTS)
     add_subdirectory(unit)
@@ -40,4 +41,8 @@ endif()
 
 if(UNRAVELLER)
     add_subdirectory(unraveller)
+endif()
+
+if(STREAMJSON_GARBAGE_TEST)
+    add_subdirectory(streamjson-garbage)
 endif()

--- a/Tests/streamjson-garbage/CMakeLists.txt
+++ b/Tests/streamjson-garbage/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_executable(StreamJSONGarbageTest
+    Module.cpp
+    GarbageTest.cpp
+)
+
+set_target_properties(StreamJSONGarbageTest PROPERTIES
+    CXX_STANDARD ${CXX_STD}
+    CXX_STANDARD_REQUIRED YES
+)
+
+target_compile_options(StreamJSONGarbageTest PRIVATE -pthread)
+target_link_options(StreamJSONGarbageTest PRIVATE -pthread)
+
+target_link_libraries(StreamJSONGarbageTest
+    PRIVATE
+        ${NAMESPACE}Core
+)
+
+install(TARGETS StreamJSONGarbageTest
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT ${NAMESPACE}_Test
+)

--- a/Tests/streamjson-garbage/CMakeLists.txt
+++ b/Tests/streamjson-garbage/CMakeLists.txt
@@ -1,3 +1,4 @@
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
 add_executable(StreamJSONGarbageTest
     Module.cpp
     GarbageTest.cpp
@@ -20,3 +21,4 @@ install(TARGETS StreamJSONGarbageTest
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT ${NAMESPACE}_Test
 )
+endif() # NOT Windows

--- a/Tests/streamjson-garbage/GarbageTest.cpp
+++ b/Tests/streamjson-garbage/GarbageTest.cpp
@@ -1,0 +1,293 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// StreamJSON garbage-data hang reproducer
+// ========================================
+// Demonstrates issue #1963: an infinite loop inside StreamJSONType::ReceiveData()
+// triggered by a single-byte slice landing on the last character of a garbage
+// (non-JSON) payload.
+//
+// How to build (from your Thunder build directory):
+//   cmake -DSTREAMJSON_GARBAGE_TEST=ON ...
+//   make StreamJSONGarbageTest
+//
+// Expected output WITHOUT the fix:
+//   [Server] Connection accepted
+//   [Server] State -> OPEN
+//   [Main]   Sending garbage: "dfsda" (5 bytes)
+//   [Server] Received() called  x4  (bytes 'd','f','s','d' processed, each fires Received)
+//   [Main]   Waiting up to 3000 ms for server connection-close event ...
+//   [Main]   FAIL: Timed out — server is stuck in ReceiveData() infinite loop
+//            (IsNullValue returned UNKNOWN without consuming the last byte 'a')
+//
+// Expected output WITH the fix (IsNullValue guard changed to loaded >= maxLength):
+//   [Server] Received() called  x5
+//   [Server] State -> CLOSED
+//   [Main]   PASS: Server processed close normally within the timeout
+//
+
+#include "Module.h"
+
+#include <cstdio>
+#include <cstring>
+#include <atomic>
+
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+namespace Thunder {
+namespace Test {
+
+    // -----------------------------------------------------------------------
+    // Factory — hands out JSONRPC::Message objects as the deserialization target.
+    // JSONRPC::Message extends JSON::Container, so Container::Deserialize is the
+    // code path that calls IsNullValue when the first byte is not '{'.
+    // -----------------------------------------------------------------------
+    class JSONFactory : public ::Thunder::Core::ProxyPoolType<::Thunder::Core::JSONRPC::Message> {
+    public:
+        JSONFactory() = delete;
+        JSONFactory(const JSONFactory&) = delete;
+        JSONFactory& operator=(const JSONFactory&) = delete;
+
+        explicit JSONFactory(uint32_t poolSize)
+            : ::Thunder::Core::ProxyPoolType<::Thunder::Core::JSONRPC::Message>(poolSize)
+        {
+        }
+
+        ~JSONFactory() = default;
+
+        ::Thunder::Core::ProxyType<::Thunder::Core::JSON::IElement> Element(const string&)
+        {
+            return ::Thunder::Core::ProxyType<::Thunder::Core::JSON::IElement>(
+                ::Thunder::Core::ProxyPoolType<::Thunder::Core::JSONRPC::Message>::Element());
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // Server-side per-connection handler.
+    //
+    // Accepted by SocketServerType<JSONServer>, so the constructor signature
+    // must follow the Thunder convention:
+    //   (const SOCKET&, const NodeId&, SocketServerType<JSONServer>*)
+    //
+    // NOTE: _factory is declared AFTER the StreamJSONType base so it is
+    // technically initialised after the base-class ctor runs.  The base stores
+    // the reference for later use (not in the ctor body), so this is safe in
+    // practice and matches the pattern used by the existing unit tests.
+    // -----------------------------------------------------------------------
+    class JSONServer
+        : public ::Thunder::Core::StreamJSONType<
+              ::Thunder::Core::SocketStream,
+              JSONFactory&,
+              ::Thunder::Core::JSON::IElement> {
+
+        using Base = ::Thunder::Core::StreamJSONType<
+            ::Thunder::Core::SocketStream,
+            JSONFactory&,
+            ::Thunder::Core::JSON::IElement>;
+
+    public:
+        JSONServer() = delete;
+        JSONServer(const JSONServer&) = delete;
+        JSONServer& operator=(const JSONServer&) = delete;
+
+        JSONServer(const SOCKET& connector,
+                   const ::Thunder::Core::NodeId& remoteId,
+                   ::Thunder::Core::SocketServerType<JSONServer>*)
+            : Base(5, _factory, false, connector, remoteId, 1024, 1024)
+            , _factory(2)
+        {
+            fprintf(stdout, "[Server] Connection accepted from %s\n",
+                    remoteId.HostAddress().c_str());
+            fflush(stdout);
+        }
+
+        ~JSONServer() = default;
+
+    public:
+        // Called every time the deserialiser completes one JSON element.
+        // With the bug this fires in a tight loop for the last garbage byte;
+        // with the fix it fires once for each successfully parsed object.
+        void Received(::Thunder::Core::ProxyType<::Thunder::Core::JSON::IElement>& element) override
+        {
+            uint32_t n = ++s_receivedCount;
+            string text;
+            element->ToString(text);
+            fprintf(stdout, "[Server] Received() called  (total so far: %u)  payload: %s\n",
+                    n, text.c_str());
+            if (!text.empty() && text[0] == '{') {
+                s_validMessageReceived.store(true);
+            }
+            fflush(stdout);
+        }
+
+        void Send(::Thunder::Core::ProxyType<::Thunder::Core::JSON::IElement>&) override {}
+
+        void StateChange() override
+        {
+            fprintf(stdout, "[Server] State -> %s\n", IsOpen() ? "OPEN" : "CLOSED");
+            fflush(stdout);
+            if (!IsOpen()) {
+                s_closedEvent.SetEvent();
+            }
+        }
+
+    public:
+        // Shared across all accepted connections (only one expected in this test).
+        static std::atomic<uint32_t>  s_receivedCount;
+        static std::atomic<bool>      s_validMessageReceived;
+        static ::Thunder::Core::Event s_closedEvent;
+
+    private:
+        JSONFactory _factory;
+    };
+
+    std::atomic<uint32_t>  JSONServer::s_receivedCount{ 0 };
+    std::atomic<bool>       JSONServer::s_validMessageReceived{ false };
+    ::Thunder::Core::Event  JSONServer::s_closedEvent{ false, true };
+
+} // namespace Test
+} // namespace Thunder
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main()
+{
+    using namespace Thunder;
+    using namespace Thunder::Test;
+
+    // Use a high-numbered port that is unlikely to be in use.
+    constexpr uint16_t SERVER_PORT  = 19273;
+    // How long to wait for the server to signal the connection close.
+    // If the bug is present the wait will expire because ReceiveData() never
+    // returns, so the socket worker thread can never process the TCP EOF.
+    constexpr uint32_t WAIT_MS      = 3000;
+    // If Received() is called this many times we know the loop is spinning.
+    constexpr uint32_t SPIN_THRESHOLD = 20;
+
+    // ---- 1. Start the server -----------------------------------------------
+    ::Thunder::Core::NodeId serverNode("0.0.0.0", SERVER_PORT);
+    ::Thunder::Core::SocketServerType<JSONServer> server(serverNode);
+
+    uint32_t err = server.Open(2000);
+    if (err != ::Thunder::Core::ERROR_NONE) {
+        fprintf(stderr, "[Main]   ERROR: failed to open server socket: %u\n", err);
+        return 1;
+    }
+    fprintf(stdout, "[Main]   Server listening on port %u\n", SERVER_PORT);
+    fflush(stdout);
+
+    // Brief pause so the server's accept loop is ready.
+    ::SleepMs(200);
+
+    // ---- 2. Connect a raw POSIX client and send garbage --------------------
+    int clientFd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (clientFd < 0) {
+        fprintf(stderr, "[Main]   ERROR: socket() failed\n");
+        server.Close(2000);
+        return 1;
+    }
+
+    struct sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(SERVER_PORT);
+    ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+    if (::connect(clientFd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) != 0) {
+        fprintf(stderr, "[Main]   ERROR: connect() failed\n");
+        ::close(clientFd);
+        server.Close(2000);
+        return 1;
+    }
+    fprintf(stdout, "[Main]   Raw client connected\n");
+    fflush(stdout);
+
+    // Give the server time to call StateChange(OPEN).
+    ::SleepMs(200);
+
+    // Send garbage bytes followed immediately by a valid JSONRPC message.
+    // With the fix applied:
+    //   - The garbage bytes are each rejected with INVALID and discarded.
+    //   - The parser resets and successfully deserialises the JSON object.
+    //   - Received() is called once with the valid payload.
+    // Without the fix, the last garbage byte ('a') stalls the parser
+    // forever, so the valid JSON that follows is never reached.
+    const char payload[] = "dfsda{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"id\":1}";
+    const ssize_t sent   = ::write(clientFd, payload, sizeof(payload) - 1);
+    fprintf(stdout, "[Main]   Sent: \"%s\" (%zd bytes)\n", payload, sent);
+    fflush(stdout);
+
+    // Small delay so the server's worker thread has time to start processing.
+    ::SleepMs(100);
+
+    // Close the client side.  Without the bug fix, this TCP FIN can never
+    // propagate to the server because the worker thread is stuck in the loop.
+    ::close(clientFd);
+    fprintf(stdout, "[Main]   Client socket closed (sent TCP FIN)\n");
+    fflush(stdout);
+
+    // ---- 3. Wait for the server to process the close -----------------------
+    fprintf(stdout, "[Main]   Waiting up to %u ms for server connection-close event ...\n",
+            WAIT_MS);
+    fflush(stdout);
+
+    uint32_t waitResult = JSONServer::s_closedEvent.Lock(WAIT_MS);
+
+    // ---- 4. Report result --------------------------------------------------
+    fprintf(stdout, "\n--- Result ---\n");
+    uint32_t received    = JSONServer::s_receivedCount.load();
+    bool     validParsed = JSONServer::s_validMessageReceived.load();
+    fprintf(stdout, "Received() was called %u time(s) total\n", received);
+    fprintf(stdout, "Valid JSON message parsed: %s\n", validParsed ? "YES" : "NO");
+
+    if ((waitResult == ::Thunder::Core::ERROR_NONE) && validParsed) {
+        fprintf(stdout,
+                "PASS: Server processed close normally AND parsed the valid JSON\n"
+                "      that followed the garbage input.\n");
+    } else {
+        fprintf(stdout,
+                "FAIL: Timed out after %u ms — server never signalled connection-close.\n",
+                WAIT_MS);
+        if (received >= SPIN_THRESHOLD) {
+            fprintf(stdout,
+                    "      Received() has been called %u times, indicating the\n"
+                    "      ReceiveData() loop is spinning on the last byte.\n"
+                    "      Root cause: IsNullValue() (JSON.h) returns UNKNOWN\n"
+                    "      without consuming the byte when maxLength == 1,\n"
+                    "      because the guard `loaded + 1 == maxLength` fires\n"
+                    "      when loaded==0 and maxLength==1.\n",
+                    received);
+        } else {
+            fprintf(stdout,
+                    "      Received() count is low (%u); the loop may not have\n"
+                    "      started yet — try increasing WAIT_MS.\n",
+                    received);
+        }
+    }
+    fflush(stdout);
+
+    server.Close(2000);
+    ::Thunder::Core::Singleton::Dispose();
+
+    return ((waitResult == ::Thunder::Core::ERROR_NONE) && validParsed) ? 0 : 1;
+}

--- a/Tests/streamjson-garbage/GarbageTest.cpp
+++ b/Tests/streamjson-garbage/GarbageTest.cpp
@@ -49,10 +49,12 @@
 #include <cstring>
 #include <atomic>
 
+#ifdef __POSIX__
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#endif // __POSIX__
 
 namespace Thunder {
 namespace Test {
@@ -113,8 +115,7 @@ namespace Test {
         JSONServer(const SOCKET& connector,
                    const ::Thunder::Core::NodeId& remoteId,
                    ::Thunder::Core::SocketServerType<JSONServer>*)
-            : Base(5, _factory, false, connector, remoteId, 1024, 1024)
-            , _factory(2)
+            : Base(5, s_factory, false, connector, remoteId, 1024, 1024)
         {
             fprintf(stdout, "[Server] Connection accepted from %s\n",
                     remoteId.HostAddress().c_str());
@@ -156,14 +157,13 @@ namespace Test {
         static std::atomic<uint32_t>  s_receivedCount;
         static std::atomic<bool>      s_validMessageReceived;
         static ::Thunder::Core::Event s_closedEvent;
-
-    private:
-        JSONFactory _factory;
+        static JSONFactory            s_factory;
     };
 
     std::atomic<uint32_t>  JSONServer::s_receivedCount{ 0 };
     std::atomic<bool>       JSONServer::s_validMessageReceived{ false };
     ::Thunder::Core::Event  JSONServer::s_closedEvent{ false, true };
+    JSONFactory             JSONServer::s_factory{ 2 };
 
 } // namespace Test
 } // namespace Thunder
@@ -201,6 +201,7 @@ int main()
     ::SleepMs(200);
 
     // ---- 2. Connect a raw POSIX client and send garbage --------------------
+#ifdef __POSIX__
     int clientFd = ::socket(AF_INET, SOCK_STREAM, 0);
     if (clientFd < 0) {
         fprintf(stderr, "[Main]   ERROR: socket() failed\n");
@@ -243,6 +244,7 @@ int main()
     // Close the client side.  Without the bug fix, this TCP FIN can never
     // propagate to the server because the worker thread is stuck in the loop.
     ::close(clientFd);
+#endif // __POSIX__
     fprintf(stdout, "[Main]   Client socket closed (sent TCP FIN)\n");
     fflush(stdout);
 

--- a/Tests/streamjson-garbage/Module.cpp
+++ b/Tests/streamjson-garbage/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/Tests/streamjson-garbage/Module.h
+++ b/Tests/streamjson-garbage/Module.h
@@ -1,0 +1,29 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME StreamJSONGarbageTest
+#endif
+
+#include <core/core.h>
+
+#undef EXTERNAL
+#define EXTERNAL


### PR DESCRIPTION
Fixes #1963.

Two related bugs caused an infinite spin when a TCP stream carried non-JSON data (garbage bytes) followed by a valid JSON message.

Bug 1 - IsNullValue() off-by-one (JSON.h)
The guard 'loaded + 1 >= maxLength' fired one iteration too early, returning UNKNOWN without consuming the last byte of the input slice. On the next call the same byte was presented again, producing another UNKNOWN, and so on forever.
Fix: change the guard to 'loaded >= maxLength' so the last available byte is consumed before the function signals that more data is needed.

Bug 2 - ReceiveData() no-progress loop (StreamJSON.h) The do/while loop in ReceiveData() had no guard against Deserialize() returning 0 (no bytes consumed). If the parser stalled, 'handled' never advanced past 'receivedSize' and the loop spun indefinitely. Fix: capture the return value of each Deserialize() call and break the loop when it returns 0.

A reproducer test is added in Tests/streamjson-garbage/. It opens a TCP server using StreamJSONType, connects a raw client, sends garbage bytes followed by a valid JSONRPC message, and asserts that:
  - the server does not hang
  - the valid JSON object after the garbage is successfully parsed
  - the connection closes cleanly within 3 seconds