### PR TITLE
Add FromObject Unit Tests for Typed and Variant Containers

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3880,6 +3880,13 @@ namespace Core {
                 }
             }
 
+            bool FromObject(const IElement& source)
+            {
+                string json;
+                source.ToString(json);
+                return FromString(json);
+            }
+
             // IElement iface:
             uint16_t Serialize(char stream[], const uint16_t maxLength, uint32_t& offset) const override
             {

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3880,11 +3880,17 @@ namespace Core {
                 }
             }
 
-            bool FromObject(const IElement& source)
+            bool FromObject(const IElement& source, Core::OptionalType<Error>& error)
             {
                 string json;
                 source.ToString(json);
-                return FromString(json);
+                return FromString(json, error);
+            }
+
+            bool FromObject(const IElement& source)
+            {
+                Core::OptionalType<Error> error;
+                return FromObject(source, error);
             }
 
             // IElement iface:

--- a/Tests/unit/core/CMakeLists.txt
+++ b/Tests/unit/core/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_ipcclient.cpp
    test_iso639.cpp
    test_iterator.cpp
+   test_json_from_object.cpp
    test_jsonobject.cpp
    test_jsonparser.cpp
    test_jsonrpc_handler.cpp
@@ -120,6 +121,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_hex2strserialization.cpp
    test_iso639.cpp
    test_iterator.cpp
+   test_json_from_object.cpp
    test_jsonobject.cpp
    test_jsonparser.cpp
    test_jsonrpc_handler.cpp

--- a/Tests/unit/core/test_json_from_object.cpp
+++ b/Tests/unit/core/test_json_from_object.cpp
@@ -1,0 +1,388 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#ifndef MODULE_NAME
+#include "../Module.h"
+#endif
+
+#include <core/core.h>
+
+namespace Thunder {
+namespace Tests {
+namespace Core {
+
+    struct DeviceInfo : public ::Thunder::Core::JSON::Container {
+        DeviceInfo()
+            : ::Thunder::Core::JSON::Container()
+            , model()
+            , firmware()
+        {
+            Add(_T("model"), &model);
+            Add(_T("firmware"), &firmware);
+        }
+
+        ::Thunder::Core::JSON::String model;
+        ::Thunder::Core::JSON::String firmware;
+    };
+
+    struct NestedDevice : public ::Thunder::Core::JSON::Container {
+        NestedDevice()
+            : ::Thunder::Core::JSON::Container()
+            , model()
+            , region()
+        {
+            Add(_T("model"), &model);
+            Add(_T("region"), &region);
+        }
+
+        ::Thunder::Core::JSON::String model;
+        ::Thunder::Core::JSON::String region;
+    };
+
+    struct DeviceResponse : public ::Thunder::Core::JSON::Container {
+        DeviceResponse()
+            : ::Thunder::Core::JSON::Container()
+            , status()
+            , device()
+        {
+            Add(_T("status"), &status);
+            Add(_T("device"), &device);
+        }
+
+        ::Thunder::Core::JSON::String status;
+        NestedDevice device;
+    };
+
+    struct ThreeFields : public ::Thunder::Core::JSON::Container {
+        ThreeFields()
+            : ::Thunder::Core::JSON::Container()
+            , a()
+            , b()
+            , c()
+        {
+            Add(_T("a"), &a);
+            Add(_T("b"), &b);
+            Add(_T("c"), &c);
+        }
+
+        ::Thunder::Core::JSON::String a;
+        ::Thunder::Core::JSON::String b;
+        ::Thunder::Core::JSON::String c;
+    };
+
+    // 4.1: VariantContainer ← VariantContainer (replace semantics)
+    TEST(JSONFromObject, VariantContainer_FromObject_VariantContainer_Replace)
+    {
+        JsonObject source;
+        source.Set(_T("a"), JsonValue(1));
+        source.Set(_T("b"), JsonValue(2));
+
+        JsonObject target;
+        target.Set(_T("b"), JsonValue(99));
+        target.Set(_T("c"), JsonValue(3));
+
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_EQ(target.Get(_T("a")).Number(), 1);
+        EXPECT_EQ(target.Get(_T("b")).Number(), 2);
+
+        EXPECT_FALSE(target.HasLabel(_T("c")));
+    }
+
+    // 4.2: Typed Container — only registered slots updated
+    TEST(JSONFromObject, TypedContainer_OnlyRegisteredSlotsUpdated)
+    {
+        JsonObject source;
+        source.Set(_T("model"), JsonValue(string("ES1-A")));
+        source.Set(_T("firmware"), JsonValue(string("R4.4.7")));
+        source.Set(_T("extra"), JsonValue(string("ignored")));
+
+        DeviceInfo target;
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_STREQ(target.firmware.Value().c_str(), "R4.4.7");
+
+        EXPECT_FALSE(target.HasLabel(_T("extra")));
+    }
+
+    // 4.3: Typed Container — absent source keys leave target fields unset
+    TEST(JSONFromObject, TypedContainer_AbsentSourceKeysAreUnset)
+    {
+        DeviceInfo source;
+        source.model = _T("ES1-A");
+
+        DeviceInfo target;
+        target.model = _T("old-model");
+        target.firmware = _T("old-firmware");
+
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_FALSE(target.firmware.IsSet());
+    }
+
+    // 4.4: Deep recursive update — nested typed Container
+    TEST(JSONFromObject, TypedContainer_DeepRecursiveNested)
+    {
+        DeviceResponse source;
+        source.status = _T("ok");
+        source.device.model = _T("ES1-B");
+
+        DeviceResponse target;
+        target.status = _T("old");
+        target.device.model = _T("old-model");
+        target.device.region = _T("EU");
+
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_STREQ(target.status.Value().c_str(), "ok");
+        EXPECT_STREQ(target.device.model.Value().c_str(), "ES1-B");
+
+        EXPECT_FALSE(target.device.region.IsSet());
+    }
+
+    // 4.5: Cross-type: typed Container ← VariantContainer
+    TEST(JSONFromObject, TypedContainer_FromObject_VariantContainer)
+    {
+        JsonObject source;
+        source.Set(_T("model"), JsonValue(string("ES1-B")));
+        source.Set(_T("firmware"), JsonValue(string("R5.0")));
+
+        DeviceInfo target;
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+        EXPECT_STREQ(target.model.Value().c_str(), "ES1-B");
+        EXPECT_STREQ(target.firmware.Value().c_str(), "R5.0");
+    }
+
+    // 4.6: Cross-type: VariantContainer ← typed Container
+    TEST(JSONFromObject, VariantContainer_FromObject_TypedContainer)
+    {
+        DeviceInfo source;
+        source.model = _T("ES1-A");
+        source.firmware = _T("R4.4.7");
+
+        JsonObject target;
+        target.Set(_T("old_key"), JsonValue(string("will-be-gone")));
+
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_STREQ(target.Get(_T("model")).String().c_str(), "ES1-A");
+        EXPECT_STREQ(target.Get(_T("firmware")).String().c_str(), "R4.4.7");
+
+        EXPECT_FALSE(target.HasLabel(_T("old_key")));
+    }
+
+    // 4.7: Typed Container ← Typed Container (same type)
+    TEST(JSONFromObject, TypedContainer_FromObject_TypedContainer)
+    {
+        DeviceInfo source;
+        source.model = _T("ES1-A");
+        source.firmware = _T("R4.4.7");
+
+        DeviceInfo target;
+        target.model = _T("old");
+
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_STREQ(target.firmware.Value().c_str(), "R4.4.7");
+    }
+
+    // 4.8: Null fields from source are imported
+    TEST(JSONFromObject, TypedContainer_NullFieldsImported)
+    {
+        DeviceInfo source;
+        source.model = _T("ES1-A");
+        source.firmware.Null(true);
+
+        DeviceInfo target;
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_TRUE(target.firmware.IsNull());
+        EXPECT_TRUE(target.firmware.IsSet());
+    }
+
+    // 4.9: Returns false for invalid source (scalar as source)
+    TEST(JSONFromObject, ReturnsFalse_ScalarSource)
+    {
+        ::Thunder::Core::JSON::String scalar;
+        scalar = _T("just a string");
+
+        DeviceInfo target;
+        target.model = _T("will-be-cleared");
+
+        bool result = target.FromObject(scalar);
+
+        EXPECT_FALSE(result);
+    }
+
+    // 4.10: Empty source — default-constructed typed Container serialises to "{}".
+    TEST(JSONFromObject, EmptySource_ReturnsFalse)
+    {
+        DeviceInfo source;
+
+        DeviceInfo target;
+        target.model = _T("old-model");
+        target.firmware = _T("old-firmware");
+
+        bool result = target.FromObject(source);
+
+        EXPECT_FALSE(result);
+
+        EXPECT_FALSE(target.model.IsSet());
+        EXPECT_FALSE(target.firmware.IsSet());
+    }
+
+    // 4.11: Unset fields in source are discarded (not imported)
+    TEST(JSONFromObject, UnsetFieldsDiscarded)
+    {
+        ThreeFields source;
+        source.a = _T("hello");
+
+        ThreeFields target;
+        target.a = _T("old-a");
+        target.b = _T("old-b");
+        target.c = _T("old-c");
+
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+
+        EXPECT_STREQ(target.a.Value().c_str(), "hello");
+        EXPECT_FALSE(target.b.IsSet());
+        EXPECT_FALSE(target.c.IsSet());
+    }
+
+    // 4.12: VariantContainer chaining — last FromObject wins (clear-first)
+    TEST(JSONFromObject, VariantContainer_Chaining_LastWins)
+    {
+        JsonObject source1;
+        source1.Set(_T("x"), JsonValue(1));
+
+        JsonObject source2;
+        source2.Set(_T("y"), JsonValue(2));
+
+        JsonObject source3;
+        source3.Set(_T("z"), JsonValue(3));
+
+        JsonObject target;
+        target.FromObject(source1);
+        target.FromObject(source2);
+        target.FromObject(source3);
+
+        EXPECT_FALSE(target.HasLabel(_T("x")));
+        EXPECT_FALSE(target.HasLabel(_T("y")));
+
+        EXPECT_TRUE(target.HasLabel(_T("z")));
+        EXPECT_EQ(target.Get(_T("z")).Number(), 3);
+    }
+
+    // 4.13: ArrayType as source returns false
+    TEST(JSONFromObject, ReturnsFalse_ArraySource)
+    {
+        ::Thunder::Core::JSON::ArrayType<::Thunder::Core::JSON::String> arr;
+        arr.Add() = _T("item1");
+        arr.Add() = _T("item2");
+
+        DeviceInfo target;
+        target.model = _T("will-be-cleared");
+
+        bool result = target.FromObject(arr);
+
+        EXPECT_FALSE(result);
+    }
+
+    // 4.14: Self import works because FromObject serializes before deserializing
+    TEST(JSONFromObject, TypedContainer_FromObject_SelfPreservesValues)
+    {
+        DeviceInfo target;
+        target.model = _T("ES1-A");
+        target.firmware = _T("R4.4.7");
+
+        bool result = target.FromObject(target);
+
+        EXPECT_TRUE(result);
+        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_STREQ(target.firmware.Value().c_str(), "R4.4.7");
+    }
+
+    // 4.15: Cross-type: VariantContainer <- typed Container with nested object
+    TEST(JSONFromObject, VariantContainer_FromObject_TypedContainerNested)
+    {
+        DeviceResponse source;
+        source.status = _T("ok");
+        source.device.model = _T("ES1-B");
+        source.device.region = _T("EU");
+
+        JsonObject target;
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+        EXPECT_STREQ(target.Get(_T("status")).String().c_str(), "ok");
+        EXPECT_EQ(target.Get(_T("device")).Content(), JsonValue::type::OBJECT);
+
+        JsonObject nested;
+        nested.FromString(target.Get(_T("device")).String());
+        EXPECT_STREQ(nested.Get(_T("model")).String().c_str(), "ES1-B");
+        EXPECT_STREQ(nested.Get(_T("region")).String().c_str(), "EU");
+    }
+
+    // 4.16: Cross-type: typed Container <- VariantContainer with nested object
+    TEST(JSONFromObject, TypedContainer_FromObject_VariantContainerNested)
+    {
+        JsonObject source;
+        source.Set(_T("status"), JsonValue(string("ok")));
+
+        JsonObject nested;
+        nested.Set(_T("model"), JsonValue(string("ES1-C")));
+        nested.Set(_T("region"), JsonValue(string("US")));
+        source.Set(_T("device"), JsonValue(nested));
+
+        DeviceResponse target;
+        bool result = target.FromObject(source);
+
+        EXPECT_TRUE(result);
+        EXPECT_STREQ(target.status.Value().c_str(), "ok");
+        EXPECT_STREQ(target.device.model.Value().c_str(), "ES1-C");
+        EXPECT_STREQ(target.device.region.Value().c_str(), "US");
+    }
+
+
+} // Core
+} // Tests
+} // Thunder

--- a/Tests/unit/core/test_json_from_object.cpp
+++ b/Tests/unit/core/test_json_from_object.cpp
@@ -301,9 +301,9 @@ namespace Core {
         source3.Set(_T("z"), JsonValue(3));
 
         JsonObject target;
-        target.FromObject(source1);
-        target.FromObject(source2);
-        target.FromObject(source3);
+        EXPECT_TRUE(target.FromObject(source1));
+        EXPECT_TRUE(target.FromObject(source2));
+        EXPECT_TRUE(target.FromObject(source3));
 
         EXPECT_FALSE(target.HasLabel(_T("x")));
         EXPECT_FALSE(target.HasLabel(_T("y")));
@@ -357,7 +357,7 @@ namespace Core {
         EXPECT_EQ(target.Get(_T("device")).Content(), JsonValue::type::OBJECT);
 
         JsonObject nested;
-        nested.FromString(target.Get(_T("device")).String());
+        ASSERT_TRUE(nested.FromString(target.Get(_T("device")).String()));
         EXPECT_STREQ(nested.Get(_T("model")).String().c_str(), "ES1-B");
         EXPECT_STREQ(nested.Get(_T("region")).String().c_str(), "EU");
     }

--- a/Tests/unit/core/test_json_from_object.cpp
+++ b/Tests/unit/core/test_json_from_object.cpp
@@ -113,17 +113,17 @@ namespace Core {
     TEST(JSONFromObject, TypedContainer_OnlyRegisteredSlotsUpdated)
     {
         JsonObject source;
-        source.Set(_T("model"), JsonValue(string("ES1-A")));
-        source.Set(_T("firmware"), JsonValue(string("R4.4.7")));
-        source.Set(_T("extra"), JsonValue(string("ignored")));
+        source.Set(_T("model"), JsonValue(_T("ES1-A")));
+        source.Set(_T("firmware"), JsonValue(_T("R4.4.7")));
+        source.Set(_T("extra"), JsonValue(_T("ignored")));
 
         DeviceInfo target;
         bool result = target.FromObject(source);
 
         EXPECT_TRUE(result);
 
-        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
-        EXPECT_STREQ(target.firmware.Value().c_str(), "R4.4.7");
+        EXPECT_STREQ(target.model.Value().c_str(), _T("ES1-A"));
+        EXPECT_STREQ(target.firmware.Value().c_str(), _T("R4.4.7"));
 
         EXPECT_FALSE(target.HasLabel(_T("extra")));
     }
@@ -142,7 +142,7 @@ namespace Core {
 
         EXPECT_TRUE(result);
 
-        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_STREQ(target.model.Value().c_str(), _T("ES1-A"));
         EXPECT_FALSE(target.firmware.IsSet());
     }
 
@@ -162,8 +162,8 @@ namespace Core {
 
         EXPECT_TRUE(result);
 
-        EXPECT_STREQ(target.status.Value().c_str(), "ok");
-        EXPECT_STREQ(target.device.model.Value().c_str(), "ES1-B");
+        EXPECT_STREQ(target.status.Value().c_str(), _T("ok"));
+        EXPECT_STREQ(target.device.model.Value().c_str(), _T("ES1-B"));
 
         EXPECT_FALSE(target.device.region.IsSet());
     }
@@ -172,15 +172,15 @@ namespace Core {
     TEST(JSONFromObject, TypedContainer_FromObject_VariantContainer)
     {
         JsonObject source;
-        source.Set(_T("model"), JsonValue(string("ES1-B")));
-        source.Set(_T("firmware"), JsonValue(string("R5.0")));
+        source.Set(_T("model"), JsonValue(_T("ES1-B")));
+        source.Set(_T("firmware"), JsonValue(_T("R5.0")));
 
         DeviceInfo target;
         bool result = target.FromObject(source);
 
         EXPECT_TRUE(result);
-        EXPECT_STREQ(target.model.Value().c_str(), "ES1-B");
-        EXPECT_STREQ(target.firmware.Value().c_str(), "R5.0");
+        EXPECT_STREQ(target.model.Value().c_str(), _T("ES1-B"));
+        EXPECT_STREQ(target.firmware.Value().c_str(), _T("R5.0"));
     }
 
     // 4.6: Cross-type: VariantContainer ← typed Container
@@ -191,14 +191,14 @@ namespace Core {
         source.firmware = _T("R4.4.7");
 
         JsonObject target;
-        target.Set(_T("old_key"), JsonValue(string("will-be-gone")));
+        target.Set(_T("old_key"), JsonValue(_T("will-be-gone")));
 
         bool result = target.FromObject(source);
 
         EXPECT_TRUE(result);
 
-        EXPECT_STREQ(target.Get(_T("model")).String().c_str(), "ES1-A");
-        EXPECT_STREQ(target.Get(_T("firmware")).String().c_str(), "R4.4.7");
+        EXPECT_STREQ(target.Get(_T("model")).String().c_str(), _T("ES1-A"));
+        EXPECT_STREQ(target.Get(_T("firmware")).String().c_str(), _T("R4.4.7"));
 
         EXPECT_FALSE(target.HasLabel(_T("old_key")));
     }
@@ -217,8 +217,8 @@ namespace Core {
 
         EXPECT_TRUE(result);
 
-        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
-        EXPECT_STREQ(target.firmware.Value().c_str(), "R4.4.7");
+        EXPECT_STREQ(target.model.Value().c_str(), _T("ES1-A"));
+        EXPECT_STREQ(target.firmware.Value().c_str(), _T("R4.4.7"));
     }
 
     // 4.8: Null fields from source are imported
@@ -232,7 +232,7 @@ namespace Core {
         bool result = target.FromObject(source);
 
         EXPECT_TRUE(result);
-        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
+        EXPECT_STREQ(target.model.Value().c_str(), _T("ES1-A"));
         EXPECT_TRUE(target.firmware.IsNull());
         EXPECT_TRUE(target.firmware.IsSet());
     }
@@ -283,7 +283,7 @@ namespace Core {
 
         EXPECT_TRUE(result);
 
-        EXPECT_STREQ(target.a.Value().c_str(), "hello");
+        EXPECT_STREQ(target.a.Value().c_str(), _T("hello"));
         EXPECT_FALSE(target.b.IsSet());
         EXPECT_FALSE(target.c.IsSet());
     }
@@ -337,8 +337,8 @@ namespace Core {
         bool result = target.FromObject(target);
 
         EXPECT_TRUE(result);
-        EXPECT_STREQ(target.model.Value().c_str(), "ES1-A");
-        EXPECT_STREQ(target.firmware.Value().c_str(), "R4.4.7");
+        EXPECT_STREQ(target.model.Value().c_str(), _T("ES1-A"));
+        EXPECT_STREQ(target.firmware.Value().c_str(), _T("R4.4.7"));
     }
 
     // 4.15: Cross-type: VariantContainer <- typed Container with nested object
@@ -353,33 +353,33 @@ namespace Core {
         bool result = target.FromObject(source);
 
         EXPECT_TRUE(result);
-        EXPECT_STREQ(target.Get(_T("status")).String().c_str(), "ok");
+        EXPECT_STREQ(target.Get(_T("status")).String().c_str(), _T("ok"));
         EXPECT_EQ(target.Get(_T("device")).Content(), JsonValue::type::OBJECT);
 
         JsonObject nested;
         ASSERT_TRUE(nested.FromString(target.Get(_T("device")).String()));
-        EXPECT_STREQ(nested.Get(_T("model")).String().c_str(), "ES1-B");
-        EXPECT_STREQ(nested.Get(_T("region")).String().c_str(), "EU");
+        EXPECT_STREQ(nested.Get(_T("model")).String().c_str(), _T("ES1-B"));
+        EXPECT_STREQ(nested.Get(_T("region")).String().c_str(), _T("EU"));
     }
 
     // 4.16: Cross-type: typed Container <- VariantContainer with nested object
     TEST(JSONFromObject, TypedContainer_FromObject_VariantContainerNested)
     {
         JsonObject source;
-        source.Set(_T("status"), JsonValue(string("ok")));
+        source.Set(_T("status"), JsonValue(_T("ok")));
 
         JsonObject nested;
-        nested.Set(_T("model"), JsonValue(string("ES1-C")));
-        nested.Set(_T("region"), JsonValue(string("US")));
+        nested.Set(_T("model"), JsonValue(_T("ES1-C")));
+        nested.Set(_T("region"), JsonValue(_T("US")));
         source.Set(_T("device"), JsonValue(nested));
 
         DeviceResponse target;
         bool result = target.FromObject(source);
 
         EXPECT_TRUE(result);
-        EXPECT_STREQ(target.status.Value().c_str(), "ok");
-        EXPECT_STREQ(target.device.model.Value().c_str(), "ES1-C");
-        EXPECT_STREQ(target.device.region.Value().c_str(), "US");
+        EXPECT_STREQ(target.status.Value().c_str(), _T("ok"));
+        EXPECT_STREQ(target.device.model.Value().c_str(), _T("ES1-C"));
+        EXPECT_STREQ(target.device.region.Value().c_str(), _T("US"));
     }
 
 

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -249,7 +249,7 @@ if (error.IsSet()) {
 
 #### From Object
 
-Populate a Container from another `IElement` (typed Container, VariantContainer, etc.) without manually serialising to an intermediate string.
+Populate a Container from another `IElement` (typed Container, VariantContainer, etc.) without manually calling `ToString()`/`FromString()` yourself (internally it serialises to a temporary string).
 
 `FromObject()` is not thread-safe. If the source or destination object can be accessed from multiple threads, hold the required lock before calling it.
 
@@ -285,7 +285,7 @@ if (target.FromObject(source)) {
 
 On a typed Container, only pre-registered fields are updated and unknown keys in source are silently skipped. On a VariantContainer, all keys from source are imported and previous content is discarded.
 
-Returns `false` if the source does not serialise to a valid JSON object (e.g. a scalar or array). Only fields with `IsSet() == true` in the source are transferred.
+ Returns `false` if the source serialises to a JSON value that cannot be deserialised into the destination container (e.g. a scalar or array; for typed containers, an empty object `{}` is also rejected). Only fields with `IsSet() == true` in the source are transferred.
 
 ### Serialise
 

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -247,6 +247,46 @@ if (error.IsSet()) {
 
 
 
+#### From Object
+
+Populate a Container from another `IElement` (typed Container, VariantContainer, etc.) without manually serialising to an intermediate string.
+
+`FromObject()` is not thread-safe. If the source or destination object can be accessed from multiple threads, hold the required lock before calling it.
+
+```c++
+// Typed Container populated from a JsonObject
+JsonObject source;
+source["model"] = "ES1-B";
+source["firmware"] = "R5.0";
+source["extra"] = "ignored";  // not registered in DeviceInfo
+
+DeviceInfo device;
+if (device.FromObject(source)) {
+    printf("Model: %s\n", device.Model.Value().c_str());
+    printf("Firmware: %s\n", device.Firmware.Value().c_str());
+    // "extra" was silently skipped — device has no slot for it
+}
+```
+
+```c++
+// JsonObject populated from a typed Container
+DeviceInfo source;
+source.Model = "ES1-A";
+source.Firmware = "R4.4.7";
+
+JsonObject target;
+target["old_key"] = "will-be-gone";
+
+if (target.FromObject(source)) {
+    // target now has "model" and "firmware" only — "old_key" was cleared
+    printf("Model: %s\n", target["model"].String().c_str());
+}
+```
+
+On a typed Container, only pre-registered fields are updated and unknown keys in source are silently skipped. On a VariantContainer, all keys from source are imported and previous content is discarded.
+
+Returns `false` if the source does not serialise to a valid JSON object (e.g. a scalar or array). Only fields with `IsSet() == true` in the source are transferred.
+
 ### Serialise
 
 #### To File

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -254,6 +254,17 @@ Populate a Container from another `IElement` (typed Container, VariantContainer,
 `FromObject()` is not thread-safe. If the source or destination object can be accessed from multiple threads, hold the required lock before calling it.
 
 ```c++
+ // Example typed container used below
+ struct DeviceInfo : public Core::JSON::Container {
+     DeviceInfo()
+     {
+         Add(_T("model"), &Model);
+         Add(_T("firmware"), &Firmware);
+     }
+     Core::JSON::String Model;
+     Core::JSON::String Firmware;
+ };
+
 // Typed Container populated from a JsonObject
 JsonObject source;
 source["model"] = "ES1-B";


### PR DESCRIPTION
Adds `Container::FromObject(const IElement& source)` to JSON.h which populates a JSON Container from the serialized representation of another IElement.

Added few unit tests and updated the docs.