### PR TITLE
[CMake] Prevent plugin libraries from being retained after dlclose

### DIFF
--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -159,6 +159,13 @@ set(PUBLIC_HEADERS
 
 target_compile_options (${TARGET} PRIVATE -Wno-psabi)
 
+# GNU unique symbols make glibc retain a DSO after dlclose(). Header-defined
+# static template members can be instantiated by plugin DSOs, so this option
+# must propagate to every Core consumer that can be unloaded.
+target_compile_options(${TARGET} INTERFACE
+    $<$<CXX_COMPILER_ID:GNU>:-fno-gnu-unique>
+    )
+
 # non-buildable interface target to carry the definitions
 # All build flags that are applicable to the whole system should be set here in the 
 # core since the core is included everywhere so if they are set here, they are 


### PR DESCRIPTION
This is a fix for an issue first observed in [this](https://jira.rdkcentral.com/jira/browse/METROL-1073) Jira ticket.

GCC emits `STB_GNU_UNIQUE` symbols for some header-defined static template members. On glibc, this causes plugin .so to remain mapped after dlclose().

Propagate `-fno-gnu-unique` from the Core target to unloadable consumers, allowing deactivated plugin libraries to be fully unmapped. This applies generically to all affected static template members, not only warning-reporting code mentioned in the ticket.