### PR TITLE
Stop CallsignAccess from pinning plugin libraries

### DIFF
--- a/Source/core/CallsignTLS.h
+++ b/Source/core/CallsignTLS.h
@@ -71,7 +71,7 @@ namespace Core {
         };
 
         template <const TCHAR** MODULENAME>
-        struct CallsignAccess {
+        struct EXTERNAL_HIDDEN CallsignAccess {
             static const TCHAR* Callsign() {
                 if (_moduleName.empty()) {
                     _moduleName = (string(_T("???  (Module:")) + *MODULENAME + _T(')'));


### PR DESCRIPTION
Plugin libraries were never unloaded when Thunder was built with warning reporting or exception catching enabled. Libraries are dlopen'ed at startup to read their metadata, so even a configuration with every plugin set to Deactivated left all of them mapped.

CallsignTLS::CallsignAccess<&Plugin_X>::_moduleName is a static data member of a template defined in a header, so it has vague linkage, and GCC emits such an object with default visibility as STB_GNU_UNIQUE. glibc marks the DSO owning a unique symbol NODELETE, after which dlclose() silently does nothing. A breakpoint on do_lookup_unique() confirms this is the only symbol acquiring NODELETE on a plugin.

The member was already marked EXTERNAL_HIDDEN at its definition, but that has no effect: CallsignTLS is marked EXTERNAL, which applies default visibility to the whole class and takes precedence over an attribute on the out of class definition of a nested member. Placing EXTERNAL_HIDDEN on the nested template itself does take effect.

/proc/<pid>/maps goes from 12 plugin mappings to 0.