### PR TITLE
Webrequest: Incomplete case handling & mapping

### DIFF
--- a/Source/Thunder/PluginServer.h
+++ b/Source/Thunder/PluginServer.h
@@ -5289,9 +5289,16 @@ namespace PluginHost {
                     }
                     break;
                 }
-                case Request::INCOMPLETE: 
-                // nothing to do for now, jira ticket created...
-                break;
+                case Request::INCOMPLETE: {
+                    SYSLOG(Logging::Error, (_T("Routing did not complete for request path [%s]"), request->Path.c_str()));
+
+                    Core::ProxyType<Web::Response> response(IFactories::Instance().Response());
+                    response->ErrorCode = Web::STATUS_INTERNAL_SERVER_ERROR;
+                    response->Message = _T("Request routing did not complete.");
+
+                    Submit(response);
+                    break;
+                }
                 default: {
                     // I think we handled every possible situation
                     ASSERT(false);

--- a/Source/common/Service.cpp
+++ b/Source/common/Service.cpp
@@ -48,7 +48,7 @@ namespace PluginHost {
         if (service.IsValid() == true) {
             _state = COMPLETE | (type & 0xF0);
             _service = service;
-        } else if (errorCode == Core::ERROR_BAD_REQUEST) {
+        } else if ((errorCode == Core::ERROR_BAD_REQUEST) || (errorCode == Core::ERROR_NOT_EXIST)) {
             _state = OBLIVIOUS | (type & 0xF0);
         } else if (errorCode == Core::ERROR_INVALID_SIGNATURE) {
             _state = INVALID_VERSION | (type & 0xF0);


### PR DESCRIPTION
Before this change:
If you GET a service with a callsign that doesn't exist, the callsign look up returns ERROR_NOT_EXIST which had no mapping. Which meant that routing state remained INCOMPLETE, and since the final switch did nothing, it would eventually time out

Now:
Now, it is mapped to OBLIVIOUS (404)
Currently, its now not possible to get to INCOMPLETE after routing (before routing, this is the initial state). If any future code is not mapped, you will now receive a return code & message instead of a silent timeout...