### PR TITLE
Add JSON::ArrayType Insert and Remove functions with tests and API documentation updates

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3345,55 +3345,48 @@ namespace Core {
             {
                 ASSERT(index <= Length());
 
-                if (index == Length()) {
-                    _data.push_back(ELEMENT());
-                    return (_data.back());
-                }
-                else {
-                    uint32_t skip = index;
-                    typename std::list<ELEMENT>::iterator locator = _data.begin();
+                typename std::list<ELEMENT>::iterator locator = _data.begin();
+                uint32_t skip = index;
 
-                    while (skip != 0) {
-                        locator++;
-                        skip--;
-                    }
-
-                    ASSERT(locator != _data.end());
-                    return (*(_data.insert(locator, ELEMENT())));
+                while (skip != 0) {
+                    ++locator;
+                    --skip;
                 }
+
+                locator = _data.insert(locator, ELEMENT());
+
+                return (*locator);
+
             }
 
             inline ELEMENT& Insert(const uint32_t index, const ELEMENT& element)
             {
                 ASSERT(index <= Length());
 
-                if (index == Length()) {
-                    _data.push_back(element);
-                    return (_data.back());
-                } else {
-                    uint32_t skip = index;
-                    typename std::list<ELEMENT>::iterator locator = _data.begin();
+                typename std::list<ELEMENT>::iterator locator = _data.begin();
+                uint32_t skip = index;
 
-                    while (skip != 0) {
-                        locator++;
-                        skip--;
-                    }
-
-                    ASSERT(locator != _data.end());
-                    return (*(_data.insert(locator, element)));
+                while (skip != 0) {
+                    ++locator;
+                    --skip;
                 }
+
+                locator = _data.insert(locator, element);
+
+                return (*locator);
+
             }
 
             inline ELEMENT* Remove(const uint32_t index)
             {
                 ASSERT(index < Length());
 
-                uint32_t skip = index;
                 typename std::list<ELEMENT>::iterator locator = _data.begin();
+                uint32_t skip = index;
 
                 while (skip != 0) {
-                    locator++;
-                    skip--;
+                    ++locator;
+                    --skip;
                 }
 
                 ASSERT(locator != _data.end());

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3377,6 +3377,23 @@ namespace Core {
 
             }
 
+            inline ELEMENT& Insert(const uint32_t index, ELEMENT&& element)
+            {
+                ASSERT(index <= Length());
+
+                typename std::list<ELEMENT>::iterator locator = _data.begin();
+                uint32_t skip = index;
+
+                while (skip != 0) {
+                    ++locator;
+                    --skip;
+                }
+
+                locator = _data.insert(locator, std::move(element));
+
+                return (*locator);
+            }
+
             inline ELEMENT* Remove(const uint32_t index)
             {
                 ASSERT(index < Length());

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3341,6 +3341,43 @@ namespace Core {
                 return (_data.back());
             }
 
+            void Insert(uint32_t index, const ELEMENT& element)
+            {
+                ASSERT(index <= Length());
+
+                if (index == Length()) {
+                    Add(element);
+                }
+                else {
+                    uint32_t skip = index;
+                    typename std::list<ELEMENT>::iterator locator = _data.begin();
+
+                    while (skip != 0) {
+                        locator++;
+                        skip--;
+                    }
+
+                    ASSERT(locator != _data.end());
+                    _data.insert(locator, element);
+                }
+            }
+
+            void Remove(uint32_t index)
+            {
+                ASSERT(index < Length());
+
+                uint32_t skip = index;
+                typename std::list<ELEMENT>::iterator locator = _data.begin();
+
+                while (skip != 0) {
+                    locator++;
+                    skip--;
+                }
+
+                ASSERT(locator != _data.end());
+                _data.erase(locator);
+            }
+
             ELEMENT& operator[](const uint32_t index)
             {
                 uint32_t skip = index;

--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -3341,12 +3341,13 @@ namespace Core {
                 return (_data.back());
             }
 
-            void Insert(uint32_t index, const ELEMENT& element)
+            inline ELEMENT& Insert(const uint32_t index)
             {
                 ASSERT(index <= Length());
 
                 if (index == Length()) {
-                    Add(element);
+                    _data.push_back(ELEMENT());
+                    return (_data.back());
                 }
                 else {
                     uint32_t skip = index;
@@ -3358,11 +3359,32 @@ namespace Core {
                     }
 
                     ASSERT(locator != _data.end());
-                    _data.insert(locator, element);
+                    return (*(_data.insert(locator, ELEMENT())));
                 }
             }
 
-            void Remove(uint32_t index)
+            inline ELEMENT& Insert(const uint32_t index, const ELEMENT& element)
+            {
+                ASSERT(index <= Length());
+
+                if (index == Length()) {
+                    _data.push_back(element);
+                    return (_data.back());
+                } else {
+                    uint32_t skip = index;
+                    typename std::list<ELEMENT>::iterator locator = _data.begin();
+
+                    while (skip != 0) {
+                        locator++;
+                        skip--;
+                    }
+
+                    ASSERT(locator != _data.end());
+                    return (*(_data.insert(locator, element)));
+                }
+            }
+
+            inline ELEMENT* Remove(const uint32_t index)
             {
                 ASSERT(index < Length());
 
@@ -3375,7 +3397,9 @@ namespace Core {
                 }
 
                 ASSERT(locator != _data.end());
-                _data.erase(locator);
+                typename std::list<ELEMENT>::iterator next = _data.erase(locator);
+
+                return ((next != _data.end()) ? &(*next) : nullptr);
             }
 
             ELEMENT& operator[](const uint32_t index)

--- a/Tests/unit/core/CMakeLists.txt
+++ b/Tests/unit/core/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_iso639.cpp
    test_iterator.cpp
    test_json_from_object.cpp
+   test_jsonarray.cpp
    test_jsonobject.cpp
    test_jsonparser.cpp
    test_jsonrpc_handler.cpp
@@ -122,6 +123,7 @@ add_executable(${TEST_RUNNER_NAME}
    test_iso639.cpp
    test_iterator.cpp
    test_json_from_object.cpp
+   test_jsonarray.cpp
    test_jsonobject.cpp
    test_jsonparser.cpp
    test_jsonrpc_handler.cpp

--- a/Tests/unit/core/test_jsonarray.cpp
+++ b/Tests/unit/core/test_jsonarray.cpp
@@ -36,10 +36,13 @@ namespace Core {
     TEST(JSONARRAY, InsertAtHead)
     {
         JsonArray array;
+        ::Thunder::Core::JSON::String head;
 
         array.Add() = _T("middle");
         array.Add() = _T("tail");
-        array.Insert(0, ::Thunder::Core::JSON::String(_T("head")));
+        head = _T("head");
+
+        array.Insert(0, head);
 
         EXPECT_EQ(3u, array.Length());
         EXPECT_STREQ("head", array[0].Value().c_str());
@@ -50,10 +53,13 @@ namespace Core {
     TEST(JSONARRAY, InsertAtTail)
     {
         JsonArray array;
+        ::Thunder::Core::JSON::String three;
 
         array.Add() = _T("one");
         array.Add() = _T("two");
-        array.Insert(array.Length(), ::Thunder::Core::JSON::String(_T("three")));
+        three = _T("three");
+
+        array.Insert(array.Length(), three);
 
         EXPECT_EQ(3u, array.Length());
         EXPECT_STREQ("one", array[0].Value().c_str());
@@ -64,10 +70,13 @@ namespace Core {
     TEST(JSONARRAY, InsertMidArray)
     {
         JsonArray array;
+        ::Thunder::Core::JSON::String center;
 
         array.Add() = _T("left");
         array.Add() = _T("right");
-        array.Insert(1, ::Thunder::Core::JSON::String(_T("center")));
+        center = _T("center");
+
+        array.Insert(1, center);
 
         EXPECT_EQ(3u, array.Length());
         EXPECT_STREQ("left", array[0].Value().c_str());
@@ -140,8 +149,10 @@ namespace Core {
         array.Add() = _T("alpha");
         array.Add() = _T("gamma");
         beta = _T("beta");
+
         array.Insert(1, beta);
         array.Remove(0);
+
         array.Add() = _T("delta");
 
         array.ToString(serialized);
@@ -227,7 +238,7 @@ namespace Core {
         EXPECT_STREQ("C", array[2].Value().c_str());
     }
 
-    TEST(JSONARRAY, MoveThroughInsertAndDelete)
+    TEST(JSONARRAY, MoveThroughInsertAndRemove)
     {
         JsonArray array;
         std::string serialized;
@@ -238,7 +249,7 @@ namespace Core {
 
         ::Thunder::Core::JSON::String moved = array[0];
         array.Remove(0);
-        array.Insert(1,moved);
+        array.Insert(1, moved);
 
         array.ToString(serialized);
 

--- a/Tests/unit/core/test_jsonarray.cpp
+++ b/Tests/unit/core/test_jsonarray.cpp
@@ -118,6 +118,46 @@ namespace Core {
         EXPECT_EQ(R"(["A","B","C"])", serialized);
     }
 
+    TEST(JSONARRAY, InsertRvalueAtHead)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("B");
+        array.Add() = _T("C");
+
+        ::Thunder::Core::JSON::String element;
+        element = _T("A");
+        array.Insert(0, std::move(element));
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("A", array[0].Value().c_str());
+        EXPECT_STREQ("B", array[1].Value().c_str());
+        EXPECT_STREQ("C", array[2].Value().c_str());
+
+        array.ToString(serialized);
+        EXPECT_EQ(R"(["A","B","C"])", serialized);
+    }
+
+    TEST(JSONARRAY, InsertRvalueMidAndSerialize)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("first");
+        array.Add() = _T("third");
+
+        ::Thunder::Core::JSON::String element;
+        element = _T("second");
+        array.Insert(1, std::move(element));
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("second", array[1].Value().c_str());
+
+        array.ToString(serialized);
+        EXPECT_EQ(R"(["first","second","third"])", serialized);
+    }
+
     TEST(JSONARRAY, InsertEmptyAtTailAndSerialize)
     {
         JsonArray array;

--- a/Tests/unit/core/test_jsonarray.cpp
+++ b/Tests/unit/core/test_jsonarray.cpp
@@ -1,0 +1,251 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#ifndef MODULE_NAME
+#include "../Module.h"
+#endif
+
+#include <core/core.h>
+
+namespace Thunder {
+namespace Tests {
+namespace Core {
+
+    using JsonArray = ::Thunder::Core::JSON::ArrayType<::Thunder::Core::JSON::String>;
+
+    TEST(JSONARRAY, InsertAtHead)
+    {
+        JsonArray array;
+
+        array.Add() = _T("middle");
+        array.Add() = _T("tail");
+        array.Insert(0, ::Thunder::Core::JSON::String(_T("head")));
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("head", array[0].Value().c_str());
+        EXPECT_STREQ("middle", array[1].Value().c_str());
+        EXPECT_STREQ("tail", array[2].Value().c_str());
+    }
+
+    TEST(JSONARRAY, InsertAtTail)
+    {
+        JsonArray array;
+
+        array.Add() = _T("one");
+        array.Add() = _T("two");
+        array.Insert(array.Length(), ::Thunder::Core::JSON::String(_T("three")));
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("one", array[0].Value().c_str());
+        EXPECT_STREQ("two", array[1].Value().c_str());
+        EXPECT_STREQ("three", array[2].Value().c_str());
+    }
+
+    TEST(JSONARRAY, InsertMidArray)
+    {
+        JsonArray array;
+
+        array.Add() = _T("left");
+        array.Add() = _T("right");
+        array.Insert(1, ::Thunder::Core::JSON::String(_T("center")));
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("left", array[0].Value().c_str());
+        EXPECT_STREQ("center", array[1].Value().c_str());
+        EXPECT_STREQ("right", array[2].Value().c_str());
+    }
+
+    TEST(JSONARRAY, AppendAndCheckLength)
+    {
+        JsonArray array;
+
+        array.Add() = _T("A");
+        array.Add() = _T("B");
+        array.Add() = _T("C");
+
+        EXPECT_EQ(3u, array.Length());
+    }
+
+    TEST(JSONARRAY, RemoveAtHead)
+    {
+        JsonArray array;
+
+        array.Add() = _T("head");
+        array.Add() = _T("middle");
+        array.Add() = _T("tail");
+
+        array.Remove(0);
+
+        EXPECT_EQ(2u, array.Length());
+        EXPECT_STREQ("middle", array[0].Value().c_str());
+        EXPECT_STREQ("tail", array[1].Value().c_str());
+    }
+
+    TEST(JSONARRAY, RemoveAtTail)
+    {
+        JsonArray array;
+
+        array.Add() = _T("head");
+        array.Add() = _T("middle");
+        array.Add() = _T("tail");
+
+        array.Remove(array.Length() - 1);
+
+        EXPECT_EQ(2u, array.Length());
+        EXPECT_STREQ("head", array[0].Value().c_str());
+        EXPECT_STREQ("middle", array[1].Value().c_str());
+    }
+
+    TEST(JSONARRAY, RemoveMidArray)
+    {
+        JsonArray array;
+
+        array.Add() = _T("left");
+        array.Add() = _T("center");
+        array.Add() = _T("right");
+
+        array.Remove(1);
+
+        EXPECT_EQ(2u, array.Length());
+        EXPECT_STREQ("left", array[0].Value().c_str());
+        EXPECT_STREQ("right", array[1].Value().c_str());
+    }
+
+    TEST(JSONARRAY, SerializeAfterMixedMutations)
+    {
+        JsonArray array;
+        std::string serialized;
+        ::Thunder::Core::JSON::String beta;
+
+        array.Add() = _T("alpha");
+        array.Add() = _T("gamma");
+        beta = _T("beta");
+        array.Insert(1, beta);
+        array.Remove(0);
+        array.Add() = _T("delta");
+
+        array.ToString(serialized);
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_EQ(R"(["beta","gamma","delta"])", serialized);
+    }
+
+    TEST(JSONARRAY, RemoveAllElements)
+    {
+        JsonArray array;
+
+        array.Add() = _T("first");
+        array.Add() = _T("second");
+        array.Add() = _T("third");
+
+        array.Remove(0);
+        array.Remove(0);
+        array.Remove(0);
+
+        EXPECT_EQ(0u, array.Length());
+        EXPECT_FALSE(array.IsSet());
+    }
+
+    TEST(JSONARRAY, ClearAfterRemove)
+    {
+        JsonArray array;
+
+        array.Add() = _T("first");
+        array.Add() = _T("second");
+        array.Add() = _T("third");
+
+        array.Remove(1);
+        array.Clear();
+
+        EXPECT_EQ(0u, array.Length());
+        EXPECT_FALSE(array.IsSet());
+    }
+
+    TEST(JSONARRAY, SerializeAfterRemove)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("A");
+        array.Add() = _T("B");
+        array.Add() = _T("C");
+
+        array.Remove(1);
+        array.ToString(serialized);
+
+        EXPECT_EQ(2u, array.Length());
+        EXPECT_EQ(R"(["A","C"])", serialized);
+    }
+
+    TEST(JSONARRAY, AddAfterRemove)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("A");
+        array.Add() = _T("B");
+        array.Add() = _T("C");
+
+        array.Remove(1);
+        array.Add() = _T("D");
+        array.ToString(serialized);
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_EQ(R"(["A","C","D"])", serialized);
+    }
+
+    TEST(JSONARRAY, AddOperatorIndexAndGetRegression)
+    {
+        JsonArray array;
+
+        array.Add() = _T("A");
+        array.Add() = _T("B");
+        array.Add() = _T("C");
+
+        EXPECT_STREQ("A", array[0].Value().c_str());
+        EXPECT_STREQ("B", array.Get(1).Value().c_str());
+        EXPECT_STREQ("C", array[2].Value().c_str());
+    }
+
+    TEST(JSONARRAY, MoveThroughInsertAndDelete)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("first");
+        array.Add() = _T("second");
+        array.Add() = _T("third");
+
+        ::Thunder::Core::JSON::String moved = array[0];
+        array.Remove(0);
+        array.Insert(1,moved);
+
+        array.ToString(serialized);
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_EQ(R"(["second","first","third"])", serialized);
+    }
+
+} // Core
+} // Tests
+} // Thunder

--- a/Tests/unit/core/test_jsonarray.cpp
+++ b/Tests/unit/core/test_jsonarray.cpp
@@ -33,6 +33,24 @@ namespace Core {
 
     using JsonArray = ::Thunder::Core::JSON::ArrayType<::Thunder::Core::JSON::String>;
 
+    TEST(JSONARRAY, InsertEmptyAtHead)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("middle");
+        array.Add() = _T("tail");
+        array.Insert(0) = _T("head");
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("head", array[0].Value().c_str());
+        EXPECT_STREQ("middle", array[1].Value().c_str());
+        EXPECT_STREQ("tail", array[2].Value().c_str());
+
+        array.ToString(serialized);
+        EXPECT_EQ(R"(["head","middle","tail"])", serialized);
+    }
+
     TEST(JSONARRAY, InsertAtHead)
     {
         JsonArray array;
@@ -82,6 +100,38 @@ namespace Core {
         EXPECT_STREQ("left", array[0].Value().c_str());
         EXPECT_STREQ("center", array[1].Value().c_str());
         EXPECT_STREQ("right", array[2].Value().c_str());
+    }
+
+    TEST(JSONARRAY, InsertEmptyMidAndSerialize)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("A");
+        array.Add() = _T("C");
+        array.Insert(1) = _T("B");
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("B", array[1].Value().c_str());
+
+        array.ToString(serialized);
+        EXPECT_EQ(R"(["A","B","C"])", serialized);
+    }
+
+    TEST(JSONARRAY, InsertEmptyAtTailAndSerialize)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("X");
+        array.Add() = _T("Y");
+        array.Insert(array.Length()) = _T("Z");
+
+        EXPECT_EQ(3u, array.Length());
+        EXPECT_STREQ("Z", array[2].Value().c_str());
+
+        array.ToString(serialized);
+        EXPECT_EQ(R"(["X","Y","Z"])", serialized);
     }
 
     TEST(JSONARRAY, AppendAndCheckLength)
@@ -159,6 +209,29 @@ namespace Core {
 
         EXPECT_EQ(3u, array.Length());
         EXPECT_EQ(R"(["beta","gamma","delta"])", serialized);
+    }
+
+    TEST(JSONARRAY, RemoveReturnsNextElement)
+    {
+        JsonArray array;
+        std::string serialized;
+
+        array.Add() = _T("A");
+        array.Add() = _T("B");
+        array.Add() = _T("C");
+
+        ::Thunder::Core::JSON::String* next = array.Remove(0);
+        ASSERT_NE(nullptr, next);
+        EXPECT_STREQ("B", next->Value().c_str());
+
+        next = array.Remove(1);
+        EXPECT_EQ(nullptr, next);
+
+        EXPECT_EQ(1u, array.Length());
+        EXPECT_STREQ("B", array[0].Value().c_str());
+
+        array.ToString(serialized);
+        EXPECT_EQ(R"(["B"])", serialized);
     }
 
     TEST(JSONARRAY, RemoveAllElements)

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -96,8 +96,68 @@ The following JSON data type representations are available:
 * `Core::JSON::Float`
 * `Core::JSON::Double`
 * `Core::JSON::ArrayType<T>` - An array containing objects of type `T`, where T is either a primative JSON type (e.g. Core::JSON::String) or a Core::JSON::Container object
-* `Core::JSON::EnumType<T>` - A string that will be converted to a C++ enum
+    * `Add()` appends in $O(1)$.
+    * `Insert(index, element)` inserts a copy before `index` and `Remove(index)` erases the element at `index`; both are $O(n)$ because the backing store is a `std::list`.
+    * For `Insert()`/`Remove()`, the list first needs a linear walk from `begin()` to `index` (cost: $O(n)$). The final `insert`/`erase` operation at that located iterator is $O(1)$, but the total operation is still $O(n)$.
+    * For large arrays, avoid repeatedly calling `Insert()`/`Remove()` inside tight loops. Repeated index-based mutations can lead to quadratic behavior over time.
+    * If you are only appending, prefer `Add()` (or `Insert(Length(), element)`), because append does not need index traversal and remains $O(1)$.
+    * Out-of-range access for `operator[]`, `Insert()`, and `Remove()` follows the same debug-assert / release-undefined contract.
+    * These mutation helpers are not thread-safe; callers must hold any required lock.
+    * Serialisation includes only elements whose `IsSet()` is true. For wrapper types where constructor-based values may remain unset (for example `Core::JSON::String`, `Core::JSON::NumberType<>`, `Core::JSON::Float`/`Core::JSON::Double`, and `Core::JSON::Boolean`), assign through `operator=` (or otherwise ensure `IsSet()` is true) before calling `Insert()`.
 
+#### ArrayType mutation examples
+
+`Insert(index, element)` inserts *before* `index`.
+
+```cpp
+Thunder::Core::JSON::ArrayType<Core::JSON::String> values;
+Thunder::Core::JSON::String a;
+Thunder::Core::JSON::String c;
+Thunder::Core::JSON::String e;
+
+a = _T("A");
+c = _T("C");
+e = _T("E");
+values.Add() = _T("B");
+values.Add() = _T("D");
+
+// Insert at front (index == 0):
+values.Insert(0, a);
+// values == ["A", "B", "D"]
+
+// Insert in middle:
+values.Insert(2, c);
+// values == ["A", "B", "C", "D"]
+
+// Insert at end (index == Length()):
+values.Insert(values.Length(), e);
+// values == ["A", "B", "C", "D", "E"]
+```, "E"]
+```
+
+`Remove(index)` erases the element at `index`; later elements shift down.
+
+```cpp
+Thunder::Core::JSON::ArrayType<Core::JSON::String> values;
+values.Add() = _T("A");
+values.Add() = _T("B");
+values.Add() = _T("C");
+values.Add() = _T("D");
+values.Add() = _T("E");
+
+// Remove from front:
+values.Remove(0);
+// values == ["B", "C", "D", "E"]
+
+// Remove from middle:
+values.Remove(1);
+// values == ["B", "D", "E"]
+
+// Remove from end:
+values.Remove(values.Length() - 1);
+// values == ["B", "D"]
+```
+* `Core::JSON::EnumType<T>` - A string that will be converted to a C++ enum
 #### Enums
 
 Thunder supports deserialising JSON strings directly to a C++ enum. This is useful when you need to restrict the possible values of a string to a known set.

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -95,22 +95,24 @@ The following JSON data type representations are available:
         * `Core::JSON::OctSInt32` - represent a base-8 integer of width uint32_t
 * `Core::JSON::Float`
 * `Core::JSON::Double`
-* `Core::JSON::ArrayType<T>` - An array containing objects of type `T`, where T is either a primative JSON type (e.g. Core::JSON::String) or a Core::JSON::Container object
-    * `Add()` appends in $O(1)$.
-    * `Insert(index, element)` inserts a copy before `index` and `Remove(index)` erases the element at `index`; both are $O(n)$ because the backing store is a `std::list`.
-    * For `Insert()`/`Remove()`, the list first needs a linear walk from `begin()` to `index` (cost: $O(n)$). The final `insert`/`erase` operation at that located iterator is $O(1)$, but the total operation is still $O(n)$.
-    * For large arrays, avoid repeatedly calling `Insert()`/`Remove()` inside tight loops. Repeated index-based mutations can lead to quadratic behavior over time.
-    * If you are only appending, prefer `Add()` (or `Insert(Length(), element)`), because append does not need index traversal and remains $O(1)$.
+* `Core::JSON::ArrayType<T>` - An array containing objects of type `T`, where T is either a primative JSON type (e.g. Core::JSON::String) or a Core::JSON::Container object.
+    * Complexity summary:
+        * `Add()` (append): $O(1)$
+        * `Insert(index, element)`: worst-case $O(n)$ (linear walk to `index`; insertion at located iterator is constant)
+        * `Insert(Length(), element)`: equivalent to append in the current implementation
+        * `Remove(index)`: $O(n)$ overall (linear walk to `index`; erase at located iterator is constant)
+    * For large arrays, avoid repeated index-based mutation (`Insert()`/`Remove()`) in tight loops; cumulative cost can become quadratic.
+    * `Insert(Length(), element)` is functionally equivalent to append; use `Add()` when append intent should be explicit.
     * Out-of-range access for `operator[]`, `Insert()`, and `Remove()` follows the same debug-assert / release-undefined contract.
     * These mutation helpers are not thread-safe; callers must hold any required lock.
-    * Serialisation includes only elements whose `IsSet()` is true. For wrapper types where constructor-based values may remain unset (for example `Core::JSON::String`, `Core::JSON::NumberType<>`, `Core::JSON::Float`/`Core::JSON::Double`, and `Core::JSON::Boolean`), assign through `operator=` (or otherwise ensure `IsSet()` is true) before calling `Insert()`.
+    * `Length()` reports stored element count. Serialisation includes only elements whose `IsSet()` is true. For wrapper types where constructor-based values may remain unset (for example `Core::JSON::String`, `Core::JSON::NumberType<>`, `Core::JSON::Float`/`Core::JSON::Double`, and `Core::JSON::Boolean`), assign through `operator=` (or otherwise ensure `IsSet()` is true) before calling `Insert()`.
 
 #### ArrayType mutation examples
 
 `Insert(index, element)` inserts *before* `index`.
 
 ```cpp
-Thunder::Core::JSON::ArrayType<Core::JSON::String> values;
+Thunder::Core::JSON::ArrayType<Thunder::Core::JSON::String> values;
 Thunder::Core::JSON::String a;
 Thunder::Core::JSON::String c;
 Thunder::Core::JSON::String e;
@@ -137,7 +139,7 @@ values.Insert(values.Length(), e);
 `Remove(index)` erases the element at `index`; later elements shift down.
 
 ```cpp
-Thunder::Core::JSON::ArrayType<Core::JSON::String> values;
+Thunder::Core::JSON::ArrayType<Thunder::Core::JSON::String> values;
 values.Add() = _T("A");
 values.Add() = _T("B");
 values.Add() = _T("C");

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -132,7 +132,6 @@ values.Insert(2, c);
 // Insert at end (index == Length()):
 values.Insert(values.Length(), e);
 // values == ["A", "B", "C", "D", "E"]
-```, "E"]
 ```
 
 `Remove(index)` erases the element at `index`; later elements shift down.
@@ -327,9 +326,9 @@ Populate a Container from another `IElement` (typed Container, VariantContainer,
 
 // Typed Container populated from a JsonObject
 JsonObject source;
-source["model"] = "ES1-B";
-source["firmware"] = "R5.0";
-source["extra"] = "ignored";  // not registered in DeviceInfo
+source["model"] = _T("ES1-B");
+source["firmware"] = _T("R5.0");
+source["extra"] = _T("ignored");  // not registered in DeviceInfo
 
 DeviceInfo device;
 if (device.FromObject(source)) {

--- a/docs/utils/json.md
+++ b/docs/utils/json.md
@@ -95,12 +95,13 @@ The following JSON data type representations are available:
         * `Core::JSON::OctSInt32` - represent a base-8 integer of width uint32_t
 * `Core::JSON::Float`
 * `Core::JSON::Double`
-* `Core::JSON::ArrayType<T>` - An array containing objects of type `T`, where T is either a primative JSON type (e.g. Core::JSON::String) or a Core::JSON::Container object.
+* `Core::JSON::ArrayType<T>` - An array containing objects of type `T`, where T is either a primitive JSON type (e.g. Core::JSON::String) or a Core::JSON::Container object.
     * Complexity summary:
         * `Add()` (append): $O(1)$
-        * `Insert(index, element)`: worst-case $O(n)$ (linear walk to `index`; insertion at located iterator is constant)
-        * `Insert(Length(), element)`: equivalent to append in the current implementation
-        * `Remove(index)`: $O(n)$ overall (linear walk to `index`; erase at located iterator is constant)
+        * `Insert(index)`: worst-case $O(n)$; inserts a default-constructed element before `index` and returns a reference to it
+        * `Insert(index, element)`: worst-case $O(n)$; inserts `element` before `index` and returns a reference to the inserted copy
+        * `Insert(Length(), ...)`: equivalent to append in the current implementation
+        * `Remove(index)`: $O(n)$ overall; erases the element at `index` and returns a pointer to the next element (or `nullptr` if the tail was removed)
     * For large arrays, avoid repeated index-based mutation (`Insert()`/`Remove()`) in tight loops; cumulative cost can become quadratic.
     * `Insert(Length(), element)` is functionally equivalent to append; use `Add()` when append intent should be explicit.
     * Out-of-range access for `operator[]`, `Insert()`, and `Remove()` follows the same debug-assert / release-undefined contract.
@@ -109,7 +110,7 @@ The following JSON data type representations are available:
 
 #### ArrayType mutation examples
 
-`Insert(index, element)` inserts *before* `index`.
+`Insert(index)` and `Insert(index, element)` insert *before* `index` and return a reference to the inserted element.
 
 ```cpp
 Thunder::Core::JSON::ArrayType<Thunder::Core::JSON::String> values;
@@ -136,7 +137,7 @@ values.Insert(values.Length(), e);
 // values == ["A", "B", "C", "D", "E"]
 ```
 
-`Remove(index)` erases the element at `index`; later elements shift down.
+`Remove(index)` erases the element at `index`, returns a pointer to the next element (or `nullptr` when the tail is removed), and shifts later elements down.
 
 ```cpp
 Thunder::Core::JSON::ArrayType<Thunder::Core::JSON::String> values;


### PR DESCRIPTION
This PR adds index-based mutation support to JSON::ArrayType by introducing Insert(index, element) and Remove(index) while preserving existing Add(), operator[], Get(), Length(), and Clear() behavior.

- Unit tests for insert/remove at head, middle, and tail, plus mixed mutation and serialization scenarios.
- Documentation updates in json.md covering:
- behavior and complexity (Insert/Remove are (O(n)), append remains (O(1)))
- index bounds and thread-safety expectations
- examples for front/middle/end insert and remove
- clarification that serialization includes only elements with IsSet() == true, with guidance for wrapper-type insertion.